### PR TITLE
feat: add configurable LLM prompt context character limits

### DIFF
--- a/docs/llm-analyzer.md
+++ b/docs/llm-analyzer.md
@@ -45,6 +45,11 @@ export SKILL_SCANNER_LLM_API_KEY=your_key
 export SKILL_SCANNER_LLM_MODEL=claude-3-5-sonnet-20241022
 skill-scanner scan /path/to/skill --use-llm
 
+# Increase LLM prompt context limits (defaults: 1500 script / 2000 referenced)
+skill-scanner scan /path/to/skill --use-llm \
+  --llm-script-char-limit 6000 \
+  --llm-referenced-char-limit 8000
+
 # Use OpenAI
 skill-scanner scan /path/to/skill --use-llm --llm-provider openai
 
@@ -62,7 +67,9 @@ from skill_scanner.core.loader import load_skill
 # Initialize analyzer
 analyzer = LLMAnalyzer(
     model="claude-3-5-sonnet-20241022",
-    api_key="your_key"
+    api_key="your_key",
+    script_file_char_limit=6000,
+    referenced_file_char_limit=8000,
 )
 
 # Scan skill

--- a/skill_scanner/api/api_server.py
+++ b/skill_scanner/api/api_server.py
@@ -82,6 +82,12 @@ class ScanRequest(BaseModel):
     skill_directory: str = Field(..., description="Path to skill directory")
     use_llm: bool = Field(False, description="Enable LLM analyzer")
     llm_provider: str | None = Field("anthropic", description="LLM provider (anthropic or openai)")
+    llm_script_char_limit: int = Field(
+        1500, ge=1, description="Max chars from each script file to include in LLM prompt context"
+    )
+    llm_referenced_char_limit: int = Field(
+        2000, ge=1, description="Max chars from each referenced file to include in LLM prompt context"
+    )
     use_behavioral: bool = Field(False, description="Enable behavioral analyzer (dataflow analysis)")
     use_aidefense: bool = Field(False, description="Enable Cisco AI Defense analyzer")
     aidefense_api_key: str | None = Field(None, description="AI Defense API key (or use AI_DEFENSE_API_KEY env var)")
@@ -118,6 +124,12 @@ class BatchScanRequest(BaseModel):
     recursive: bool = False
     use_llm: bool = False
     llm_provider: str | None = "anthropic"
+    llm_script_char_limit: int = Field(
+        1500, ge=1, description="Max chars from each script file to include in LLM prompt context"
+    )
+    llm_referenced_char_limit: int = Field(
+        2000, ge=1, description="Max chars from each referenced file to include in LLM prompt context"
+    )
     use_behavioral: bool = False
     use_aidefense: bool = False
     aidefense_api_key: str | None = None
@@ -199,10 +211,18 @@ async def scan_skill(request: ScanRequest):
             provider_str = request.llm_provider or "anthropic"
             if llm_model:
                 # Use explicit model from environment
-                llm_analyzer = LLMAnalyzer(model=llm_model)
+                llm_analyzer = LLMAnalyzer(
+                    model=llm_model,
+                    script_file_char_limit=request.llm_script_char_limit,
+                    referenced_file_char_limit=request.llm_referenced_char_limit,
+                )
             else:
                 # Use provider default model
-                llm_analyzer = LLMAnalyzer(provider=provider_str)
+                llm_analyzer = LLMAnalyzer(
+                    provider=provider_str,
+                    script_file_char_limit=request.llm_script_char_limit,
+                    referenced_file_char_limit=request.llm_referenced_char_limit,
+                )
             analyzers.append(llm_analyzer)
 
         if request.use_aidefense and AIDEFENSE_AVAILABLE:
@@ -287,6 +307,12 @@ async def scan_uploaded_skill(
     file: UploadFile = File(..., description="ZIP file containing skill package"),
     use_llm: bool = Query(False, description="Enable LLM analyzer"),
     llm_provider: str = Query("anthropic", description="LLM provider"),
+    llm_script_char_limit: int = Query(
+        1500, ge=1, description="Max chars from each script file to include in LLM prompt context"
+    ),
+    llm_referenced_char_limit: int = Query(
+        2000, ge=1, description="Max chars from each referenced file to include in LLM prompt context"
+    ),
     use_behavioral: bool = Query(False, description="Enable behavioral analyzer"),
     use_aidefense: bool = Query(False, description="Enable AI Defense analyzer"),
     aidefense_api_key: str | None = Query(None, description="AI Defense API key"),
@@ -298,6 +324,8 @@ async def scan_uploaded_skill(
         file: ZIP file containing skill package
         use_llm: Enable LLM analyzer
         llm_provider: LLM provider to use
+        llm_script_char_limit: Max chars from each script file for LLM prompt context
+        llm_referenced_char_limit: Max chars from each referenced file for LLM prompt context
         use_behavioral: Enable behavioral analyzer
         use_aidefense: Enable AI Defense analyzer
         aidefense_api_key: AI Defense API key
@@ -338,6 +366,8 @@ async def scan_uploaded_skill(
             skill_directory=str(skill_dir),
             use_llm=use_llm,
             llm_provider=llm_provider,
+            llm_script_char_limit=llm_script_char_limit,
+            llm_referenced_char_limit=llm_referenced_char_limit,
             use_behavioral=use_behavioral,
             use_aidefense=use_aidefense,
             aidefense_api_key=aidefense_api_key,
@@ -385,6 +415,8 @@ async def scan_batch(request: BatchScanRequest, background_tasks: BackgroundTask
         request.recursive,
         request.use_llm,
         request.llm_provider,
+        request.llm_script_char_limit,
+        request.llm_referenced_char_limit,
         request.use_behavioral,
         request.use_aidefense,
         request.aidefense_api_key,
@@ -434,6 +466,8 @@ def run_batch_scan(
     recursive: bool,
     use_llm: bool,
     llm_provider: str | None,
+    llm_script_char_limit: int = 1500,
+    llm_referenced_char_limit: int = 2000,
     use_behavioral: bool = False,
     use_aidefense: bool = False,
     aidefense_api_key: str | None = None,
@@ -448,6 +482,8 @@ def run_batch_scan(
         recursive: Search recursively
         use_llm: Use LLM analyzer
         llm_provider: LLM provider
+        llm_script_char_limit: Max chars from each script file for LLM prompt context
+        llm_referenced_char_limit: Max chars from each referenced file for LLM prompt context
         use_behavioral: Use behavioral analyzer
         use_aidefense: Use AI Defense analyzer
         aidefense_api_key: AI Defense API key
@@ -475,10 +511,18 @@ def run_batch_scan(
                 provider_str = llm_provider or "anthropic"
                 if llm_model:
                     # Use explicit model from environment
-                    llm_analyzer = LLMAnalyzer(model=llm_model)
+                    llm_analyzer = LLMAnalyzer(
+                        model=llm_model,
+                        script_file_char_limit=llm_script_char_limit,
+                        referenced_file_char_limit=llm_referenced_char_limit,
+                    )
                 else:
                     # Use provider default model
-                    llm_analyzer = LLMAnalyzer(provider=provider_str)
+                    llm_analyzer = LLMAnalyzer(
+                        provider=provider_str,
+                        script_file_char_limit=llm_script_char_limit,
+                        referenced_file_char_limit=llm_referenced_char_limit,
+                    )
                 analyzers.append(llm_analyzer)
             except Exception:
                 pass  # Continue without LLM analyzer

--- a/skill_scanner/cli/cli.py
+++ b/skill_scanner/cli/cli.py
@@ -54,6 +54,14 @@ from ..core.reporters.markdown_reporter import MarkdownReporter
 from ..core.reporters.table_reporter import TableReporter
 
 
+def positive_int(value: str) -> int:
+    """Argparse validator for positive integer values."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("Value must be >= 1")
+    return parsed
+
+
 def scan_command(args):
     """Handle the scan command for a single skill."""
     skill_dir = Path(args.skill_directory)
@@ -113,6 +121,8 @@ def scan_command(args):
                     api_key=api_key,
                     base_url=base_url,
                     api_version=api_version,
+                    script_file_char_limit=args.llm_script_char_limit,
+                    referenced_file_char_limit=args.llm_referenced_char_limit,
                 )
                 analyzers.append(llm_analyzer)
                 status_print(f"Using LLM analyzer with model: {model}")
@@ -330,6 +340,8 @@ def scan_all_command(args):
                 api_key=api_key,
                 base_url=base_url,
                 api_version=api_version,
+                script_file_char_limit=args.llm_script_char_limit,
+                referenced_file_char_limit=args.llm_referenced_char_limit,
             )
             analyzers.append(llm_analyzer)
             status_print(f"Using LLM analyzer with model: {model}")
@@ -741,6 +753,18 @@ Examples:
         "--llm-provider", choices=["anthropic", "openai"], default="anthropic", help="LLM provider (default: anthropic)"
     )
     scan_parser.add_argument(
+        "--llm-script-char-limit",
+        type=positive_int,
+        default=1500,
+        help="Max chars from each script file to include in LLM prompt context (default: 1500)",
+    )
+    scan_parser.add_argument(
+        "--llm-referenced-char-limit",
+        type=positive_int,
+        default=2000,
+        help="Max chars from each referenced file to include in LLM prompt context (default: 2000)",
+    )
+    scan_parser.add_argument(
         "--use-trigger",
         action="store_true",
         help="Enable trigger specificity analysis (detects overly generic descriptions)",
@@ -809,6 +833,18 @@ Examples:
     scan_all_parser.add_argument("--aidefense-api-url", help="AI Defense API URL (optional, defaults to US region)")
     scan_all_parser.add_argument(
         "--llm-provider", choices=["anthropic", "openai"], default="anthropic", help="LLM provider (default: anthropic)"
+    )
+    scan_all_parser.add_argument(
+        "--llm-script-char-limit",
+        type=positive_int,
+        default=1500,
+        help="Max chars from each script file to include in LLM prompt context (default: 1500)",
+    )
+    scan_all_parser.add_argument(
+        "--llm-referenced-char-limit",
+        type=positive_int,
+        default=2000,
+        help="Max chars from each referenced file to include in LLM prompt context (default: 2000)",
     )
     scan_all_parser.add_argument(
         "--use-trigger",

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -244,6 +244,8 @@ class TestScanEndpoint:
             "use_behavioral": True,
             "use_llm": False,
             "llm_provider": "anthropic",
+            "llm_script_char_limit": 2500,
+            "llm_referenced_char_limit": 3500,
             "use_aidefense": False,
         }
 
@@ -265,6 +267,8 @@ class TestBatchScanEndpoint:
             "skills_directory": str(test_skills_dir),
             "recursive": False,
             "use_llm": False,
+            "llm_script_char_limit": 2500,
+            "llm_referenced_char_limit": 3500,
         }
 
         response = client.post("/scan-batch", json=request_data)

--- a/tests/test_cli_custom_rules.py
+++ b/tests/test_cli_custom_rules.py
@@ -116,6 +116,40 @@ class TestYaraMode:
         assert "invalid" in stderr.lower() or "choice" in stderr.lower()
 
 
+class TestLlmPromptContextLimits:
+    """Tests for LLM prompt context size CLI options."""
+
+    def test_scan_accepts_llm_char_limit_options(self, safe_skill_dir):
+        """Test scan command accepts LLM char limit options."""
+        stdout, stderr, code = run_cli(
+            [
+                "scan",
+                str(safe_skill_dir),
+                "--format",
+                "json",
+                "--llm-script-char-limit",
+                "2500",
+                "--llm-referenced-char-limit",
+                "3500",
+            ]
+        )
+        assert code == 0, f"CLI failed: {stderr}"
+        _ = json.loads(stdout)
+
+    def test_scan_rejects_non_positive_llm_char_limit(self, safe_skill_dir):
+        """Test scan command rejects invalid non-positive LLM char limit options."""
+        _, stderr, code = run_cli(
+            [
+                "scan",
+                str(safe_skill_dir),
+                "--llm-script-char-limit",
+                "0",
+            ]
+        )
+        assert code != 0
+        assert "must be >= 1" in stderr
+
+
 # =============================================================================
 # Disable Rule Tests
 # =============================================================================
@@ -236,6 +270,24 @@ class TestScanAllCustomOptions:
             ["scan-all", str(test_dir), "--format", "json", "--disable-rule", "MANIFEST_MISSING_LICENSE"]
         )
         assert code == 0, f"CLI failed: {stderr}"
+
+    def test_scan_all_accepts_llm_char_limit_options(self):
+        """Test scan-all accepts LLM char limit options."""
+        test_dir = Path(__file__).parent.parent / "evals" / "test_skills" / "safe"
+        stdout, stderr, code = run_cli(
+            [
+                "scan-all",
+                str(test_dir),
+                "--format",
+                "json",
+                "--llm-script-char-limit",
+                "2500",
+                "--llm-referenced-char-limit",
+                "3500",
+            ]
+        )
+        assert code == 0, f"CLI failed: {stderr}"
+        _ = json.loads(stdout)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
This PR adds configurable LLM prompt context limits so users can control how much script and referenced-file content is included in LLM analysis prompts.

## Changes
- Add configurable limits to `LLMAnalyzer` and `PromptBuilder`:
  - `script_file_char_limit` (default: `1500`)
  - `referenced_file_char_limit` (default: `2000`)
- Validate both limits are positive integers.
- Wire new options through CLI:
  - `scan --llm-script-char-limit --llm-referenced-char-limit`
  - `scan-all --llm-script-char-limit --llm-referenced-char-limit`
- Wire new options through API request models and execution paths:
  - single scan
  - upload scan
  - batch scan
- Update docs with CLI and Python usage examples.
- Add/expand tests for:
  - analyzer validation and truncation behavior
  - CLI option acceptance and validation
  - API payload support

## Testing
- `pytest tests/test_llm_analyzer.py tests/test_cli_custom_rules.py tests/test_api_endpoints.py`
- `pytest tests/test_api_server_config.py`
- `python evals/benchmark_runner.py`

All pass locally.
