### PR TITLE
fix: normalize nullable union types in Google schema sanitizer

### DIFF
--- a/tests/test_llm_request_handler.py
+++ b/tests/test_llm_request_handler.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for _sanitize_schema_for_google in LLMRequestHandler.
+
+Verifies that the sanitizer correctly converts JSON Schema constructs
+that are incompatible with the Google GenAI SDK's structured output format.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from skill_scanner.core.analyzers.llm_request_handler import LLMRequestHandler
+
+
+@pytest.fixture
+def handler() -> LLMRequestHandler:
+    """Build an LLMRequestHandler with a mock provider config.
+
+    Uses MagicMock to avoid ProviderConfig side effects (Gemini SDK
+    detection, API key resolution) that are irrelevant to schema
+    sanitization tests.
+    """
+    return LLMRequestHandler(provider_config=MagicMock())
+
+
+class TestSanitizeSchemaForGoogle:
+    """Tests for _sanitize_schema_for_google."""
+
+    def test_converts_nullable_union_type(self, handler: LLMRequestHandler) -> None:
+        schema = {"type": ["string", "null"], "description": "optional"}
+        result = handler._sanitize_schema_for_google(schema)
+        assert result == {"type": "STRING", "nullable": True, "description": "optional"}
+
+    def test_normalizes_scalar_type_case(self, handler: LLMRequestHandler) -> None:
+        schema = {"type": "string", "description": "required"}
+        result = handler._sanitize_schema_for_google(schema)
+        assert result == {"type": "STRING", "description": "required"}
+
+    def test_strips_additional_properties(self, handler: LLMRequestHandler) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "inner": {"type": "object", "additionalProperties": False, "properties": {}},
+            },
+            "additionalProperties": False,
+        }
+        result = handler._sanitize_schema_for_google(schema)
+        assert "additionalProperties" not in result
+        assert "additionalProperties" not in result["properties"]["inner"]
+
+    def test_handles_nested_array_items(self, handler: LLMRequestHandler) -> None:
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "evidence": {"type": ["string", "null"]},
+                },
+            },
+        }
+        result = handler._sanitize_schema_for_google(schema)
+        assert result["items"]["properties"]["evidence"] == {
+            "type": "STRING",
+            "nullable": True,
+        }
+
+    @pytest.mark.parametrize(
+        "json_type,expected",
+        [
+            ("string", "STRING"),
+            ("number", "NUMBER"),
+            ("integer", "INTEGER"),
+            ("boolean", "BOOLEAN"),
+            ("array", "ARRAY"),
+            ("object", "OBJECT"),
+        ],
+    )
+    def test_all_json_types_uppercased(self, handler: LLMRequestHandler, json_type: str, expected: str) -> None:
+        result = handler._sanitize_schema_for_google({"type": json_type})
+        assert result["type"] == expected
+
+    def test_null_only_union_raises(self, handler: LLMRequestHandler) -> None:
+        with pytest.raises(NotImplementedError, match="null-only types"):
+            handler._sanitize_schema_for_google({"type": ["null"]})
+
+    def test_scalar_null_type_raises(self, handler: LLMRequestHandler) -> None:
+        with pytest.raises(NotImplementedError, match="null-only types"):
+            handler._sanitize_schema_for_google({"type": "null"})
+
+    def test_multi_type_union_raises(self, handler: LLMRequestHandler) -> None:
+        with pytest.raises(NotImplementedError, match="multi-type unions"):
+            handler._sanitize_schema_for_google({"type": ["string", "number"]})
+
+    def test_multi_type_nullable_union_raises(self, handler: LLMRequestHandler) -> None:
+        with pytest.raises(NotImplementedError, match="multi-type unions"):
+            handler._sanitize_schema_for_google({"type": ["string", "number", "null"]})
+
+    def test_shipped_response_schema(self, handler: LLMRequestHandler) -> None:
+        """Verify sanitization of the actual llm_response_schema.json shipped with the package."""
+        schema_path = (
+            Path(__file__).resolve().parents[1] / "skill_scanner" / "data" / "prompts" / "llm_response_schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        result = handler._sanitize_schema_for_google(schema)
+
+        finding_props = result["properties"]["findings"]["items"]["properties"]
+
+        for field in ("aisubtech", "location", "evidence", "remediation"):
+            assert finding_props[field]["type"] == "STRING", f"{field} type not normalized"
+            assert finding_props[field]["nullable"] is True, f"{field} not marked nullable"
+
+        assert finding_props["severity"]["type"] == "STRING"
+        assert "nullable" not in finding_props["severity"]
+
+        assert "additionalProperties" not in result
+        assert "additionalProperties" not in result["properties"]["findings"]["items"]


### PR DESCRIPTION
## Description

`_sanitize_schema_for_google()` strips `additionalProperties` but passes through JSON Schema union types like `["string", "null"]` unchanged. The Google GenAI SDK rejects array values in the `type` field — it expects a single type enum value (e.g. `"STRING"`) plus `nullable: true`.

The shipped `llm_response_schema.json` uses `["string", "null"]` for four nullable finding fields (`aisubtech`, `location`, `evidence`, `remediation`). When the SDK validates these, it raises a `ValidationError`, which `analyze_async()` catches and swallows (#38), causing the LLM analyzer to silently return zero threat findings.

This PR extends the sanitizer to convert nullable union types, normalize scalar type casing, and raise `NotImplementedError` for type patterns that cannot be represented in the Gemini schema format (null-only types, multi-type unions).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #37

## Changes Made

- **`skill_scanner/core/analyzers/llm_request_handler.py`**:
  - Extend `_sanitize_schema_for_google()` to convert `["X", "null"]` to `{"type": "X_UPPER", "nullable": true}` and normalize scalar type strings to uppercase via `.upper()`
  - Raise `NotImplementedError` for null-only types (`"null"`, `["null"]`) and multi-type unions (`["string", "number"]`) that cannot be mapped to a single Gemini type

- **`tests/test_llm_request_handler.py`** (new):
  - Dedicated test class with `MagicMock`-based fixture (avoids `ProviderConfig` side effects)
  - Tests: nullable union conversion, scalar type uppercasing, `additionalProperties` stripping, nested array items, all 6 non-null JSON Schema types, null-only type rejection (scalar and union), multi-type union rejection (with and without null), and end-to-end validation against the shipped `llm_response_schema.json`

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing

```bash
PYTHONPATH=. python -c "
from skill_scanner.core.analyzers.llm_request_handler import LLMRequestHandler
from unittest.mock import MagicMock
import json, pathlib

h = LLMRequestHandler(provider_config=MagicMock())
schema = json.loads(
    pathlib.Path('skill_scanner/data/prompts/llm_response_schema.json').read_text()
)
result = h._sanitize_schema_for_google(schema)
fp = result['properties']['findings']['items']['properties']
for f in ('aisubtech', 'location', 'evidence', 'remediation'):
    assert fp[f]['type'] == 'STRING' and fp[f]['nullable'] is True
print('Schema sanitization OK')
"
```

**Results:**
- Expected: All four nullable fields converted to `{"type": "STRING", "nullable": true}`
- Actual: Matches expected — no `ValidationError` from the Google GenAI SDK

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Type hints added where applicable
- [x] Docstrings added/updated for public APIs
- [x] No hardcoded credentials or secrets
- [x] Error handling is comprehensive
- [x] Logging is appropriate

### Documentation
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] CHANGELOG updated
- [x] Code comments added for complex logic

### Security
- [x] No new security vulnerabilities introduced
- [x] Input validation added where needed
- [x] Follows security best practices from workspace rules
- [x] No eval/exec on user input without sanitization

### Testing
- [x] Tests pass: `uv run pre-commit run --all-files` (ruff lint + format pass; gitleaks hook failed to install due to local SSL error, not related to this change)
- [ ] Benchmark passes: `uv run python evals/runners/benchmark_runner.py`
- [x] No regressions in existing functionality
- [x] Edge cases covered

## Performance Impact

- [x] No significant performance regression
- [x] Resource usage is acceptable

## Additional Notes

_This PR was written with assistance from Cursor + Claude Opus 4.6 + GPT 5.3 Codex._
