### PR TITLE
[BUG] Fix crash on dict-valued compatibility field in StaticAnalyzer

### DIFF
--- a/skill_scanner/core/analyzers/static.py
+++ b/skill_scanner/core/analyzers/static.py
@@ -946,7 +946,7 @@ class StaticAnalyzer(BaseAnalyzer):
     def _manifest_declares_network(self, skill: Skill) -> bool:
         """Check if manifest declares network usage."""
         if skill.manifest.compatibility:
-            compatibility_lower = skill.manifest.compatibility.lower()
+            compatibility_lower = str(skill.manifest.compatibility).lower()
             return "network" in compatibility_lower or "internet" in compatibility_lower
         return False
 

--- a/skill_scanner/data/packs/core/python/consistency_checks.py
+++ b/skill_scanner/data/packs/core/python/consistency_checks.py
@@ -47,7 +47,7 @@ def skill_uses_network(skill: Skill) -> bool:
 def manifest_declares_network(skill: Skill) -> bool:
     """Check if manifest declares network usage."""
     if skill.manifest.compatibility:
-        compatibility_lower = skill.manifest.compatibility.lower()
+        compatibility_lower = str(skill.manifest.compatibility).lower()
         return "network" in compatibility_lower or "internet" in compatibility_lower
     return False
 


### PR DESCRIPTION
## Summary

`StaticAnalyzer._manifest_declares_network()` (and the standalone `manifest_declares_network()` in `consistency_checks.py`) call `.lower()` on `skill.manifest.compatibility` assuming it is always a string. Skills that declare `compatibility` as a YAML mapping crash the entire scan with:

```
AttributeError: 'dict' object has no attribute 'lower'
```

**Repro**: Any skill with a dict-typed compatibility field, e.g.:

```yaml
compatibility:
  python-version: "3.8+"
  platforms: [linux, macos, windows]
```

The guard `if skill.manifest.compatibility:` passes (dicts are truthy), then `.lower()` blows up.

## Fix

Wrap the value with `str()` before calling `.lower()` — consistent with `strict_structure.py` line 349 which already does `str(metadata["compatibility"])` for validation.

## Changes

- `skill_scanner/core/analyzers/static.py` — `str()` wrap in `_manifest_declares_network`
- `skill_scanner/data/packs/core/python/consistency_checks.py` — same fix in standalone function
- `tests/static_analysis/test_static_analyzer.py` — regression test with dict compatibility

## Test plan

- [x] New regression test `test_dict_compatibility_does_not_crash` passes
- [x] Full `tests/static_analysis/` suite passes (9/9)
- [x] Verified against a real skill (`benchflow-ai/senior-data-engineer`) that previously crashed — now scans successfully

Relates to #31

Made with [Cursor](https://cursor.com)