### PR TITLE
feat(cli): render markdown in terminal when --format markdown and std…

### DIFF
--- a/skill_scanner/cli/cli.py
+++ b/skill_scanner/cli/cli.py
@@ -289,9 +289,7 @@ def _write_output(args: argparse.Namespace, output: str) -> None:
     """Write *output* to a file or stdout, and emit any additional formats."""
     formats = _get_formats(args)
     primary_fmt = formats[0] if formats else "summary"
-    render_md = (
-        sys.stdout.isatty() and not getattr(args, "no_render_markdown", False)
-    )
+    render_md = sys.stdout.isatty() and not getattr(args, "no_render_markdown", False)
 
     # Primary format: write to --output file or stdout
     if args.output:


### PR DESCRIPTION
## Issue

When users run `skill-scanner scan ... --format markdown` and send output to the terminal (no `-o` file), they see **raw markdown** which is hard to read. The format is meant to be human-readable, but in the terminal it isn’t without rendering.

This PR **renders markdown in the terminal** when stdout is a TTY: headings, bold, lists, and code blocks display in a readable way. Piped output and file writes stay **raw markdown** so scripts and redirects (e.g. `> report.md`) still get valid markdown. A **`--no-render-markdown`** flag lets users force raw output in the terminal when needed (e.g. copy-paste or scripting).

## Summary

- **Terminal (TTY):** Markdown is rendered with Rich so `--format markdown` is easy to read.
- **Piped/redirected or `-o file`:** Output stays raw markdown for automation and files.
- **`--no-render-markdown`:** Optional flag to print raw markdown even when stdout is a TTY.

Uses the existing `rich` dependency; no new dependencies.

## Testing

- `skill-scanner scan evals/skills/prompt-injection/jailbreak-override --format markdown --detailed` in a real terminal → rendered output.
- `skill-scanner scan ... --format markdown | cat` → raw markdown.
- `skill-scanner scan ... --format markdown -o report.md` → file contains raw markdown.
- `skill-scanner scan ... --format markdown --no-render-markdown` → raw markdown in terminal.