### PR TITLE
fix: add explicit UTF-8 encoding to all file I/O to prevent UnicodeDecodeError

### DIFF
--- a/evals/runners/benchmark_runner.py
+++ b/evals/runners/benchmark_runner.py
@@ -127,7 +127,7 @@ class SkillBenchmarkRunner:
     def _evaluate_skill(self, skill_path: Path, expected_file: Path):
         """Evaluate a single skill."""
         # Load expected results
-        with open(expected_file) as f:
+        with open(expected_file, encoding="utf-8") as f:
             expected = json.load(f)
 
         skill_name = expected.get("skill_name", skill_path.name)
@@ -324,7 +324,7 @@ def main():
     # Save JSON if requested
     if args.output:
         output_data = {"benchmark": asdict(result), "individual_results": runner.results}
-        with open(args.output, "w") as f:
+        with open(args.output, "w", encoding="utf-8") as f:
             json.dump(output_data, f, indent=2)
         print(f"Results saved to: {args.output}")
 

--- a/evals/runners/eval_runner.py
+++ b/evals/runners/eval_runner.py
@@ -521,7 +521,7 @@ def main():
                     k: v for k, v in comparison_results["with_meta"].items() if k != "eval_results_with_scan"
                 },
             }
-            with open(args.output, "w") as f:
+            with open(args.output, "w", encoding="utf-8") as f:
                 json.dump(output_data, f, indent=2)
             print(f"\nResults saved to: {args.output}")
 
@@ -576,7 +576,7 @@ def main():
     if args.output:
         # Remove non-serializable data
         output_results = {k: v for k, v in results.items() if k != "eval_results_with_scan"}
-        with open(args.output, "w") as f:
+        with open(args.output, "w", encoding="utf-8") as f:
             json.dump(output_results, f, indent=2)
         print(f"\nResults saved to: {args.output}")
 

--- a/evals/runners/policy_benchmark.py
+++ b/evals/runners/policy_benchmark.py
@@ -119,7 +119,7 @@ def run_eval_benchmark(scanner: SkillScanner, eval_dir: Path) -> dict:
         if not (skill_dir / "SKILL.md").exists():
             continue
 
-        with open(expected_file) as f:
+        with open(expected_file, encoding="utf-8") as f:
             expected = json.load(f)
 
         skill_name = expected.get("skill_name", skill_dir.name)

--- a/evals/runners/update_expected_findings.py
+++ b/evals/runners/update_expected_findings.py
@@ -58,7 +58,7 @@ def load_expected(skill_dir: Path):
     if not expected_file.exists():
         return None
 
-    with open(expected_file) as f:
+    with open(expected_file, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -182,7 +182,7 @@ def main():
                     )
 
                 # Save updated file
-                with open(expected_file, "w") as f:
+                with open(expected_file, "w", encoding="utf-8") as f:
                     json.dump(existing, f, indent=2)
                 print(f"  [OK] Updated {expected_file}")
                 updates_needed.append(skill_name)

--- a/scripts/fp_analysis_collect.py
+++ b/scripts/fp_analysis_collect.py
@@ -122,7 +122,7 @@ def main():
 
     out_path = Path(__file__).parent.parent / ".local_benchmark" / "fp_analysis_collect.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(out_path, "w") as f:
+    with open(out_path, "w", encoding="utf-8") as f:
         json.dump(out, f, indent=2)
 
     print(f"Wrote {out_path}")

--- a/scripts/update_brew_formula.py
+++ b/scripts/update_brew_formula.py
@@ -241,7 +241,7 @@ def render_formula(
 
 def read_local_version() -> str:
     """Read __version__ from skill_scanner/_version.py."""
-    text = VERSION_PATH.read_text()
+    text = VERSION_PATH.read_text(encoding="utf-8")
     match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', text)
     if not match:
         print(f"Could not parse version from {VERSION_PATH}", file=sys.stderr)

--- a/skill_scanner/config/config.py
+++ b/skill_scanner/config/config.py
@@ -142,7 +142,7 @@ class Config:
         """
         # Load .env file
         if config_file.exists():
-            with open(config_file) as f:
+            with open(config_file, encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:

--- a/skill_scanner/core/scan_policy.py
+++ b/skill_scanner/core/scan_policy.py
@@ -470,7 +470,7 @@ class ScanPolicy:
         if not path.exists():
             raise FileNotFoundError(f"Policy file not found: {path}")
 
-        with open(path) as fh:
+        with open(path, encoding="utf-8") as fh:
             raw: dict[str, Any] = yaml.safe_load(fh) or {}
 
         # If this IS the default file, just parse directly
@@ -488,7 +488,7 @@ class ScanPolicy:
     def to_yaml(self, path: str | Path) -> None:
         """Dump the full policy to a YAML file for editing."""
         data = self._to_dict()
-        with open(path, "w") as fh:
+        with open(path, "w", encoding="utf-8") as fh:
             fh.write("# Skill Scanner – Scan Policy\n")
             fh.write("# Customise this file to match your organisation's security bar.\n")
             fh.write("# Only include sections you want to override; omitted sections\n")
@@ -502,7 +502,7 @@ class ScanPolicy:
     @classmethod
     def _load_default_raw(cls) -> dict[str, Any]:
         if _DEFAULT_POLICY_PATH.exists():
-            with open(_DEFAULT_POLICY_PATH) as fh:
+            with open(_DEFAULT_POLICY_PATH, encoding="utf-8") as fh:
                 return yaml.safe_load(fh) or {}
         return {}
 

--- a/skill_scanner/hooks/pre_commit.py
+++ b/skill_scanner/hooks/pre_commit.py
@@ -92,7 +92,7 @@ def load_config(repo_root: Path) -> dict:
     for config_path in config_paths:
         if config_path.exists():
             try:
-                with open(config_path) as f:
+                with open(config_path, encoding="utf-8") as f:
                     user_config = json.load(f)
                     config.update(user_config)
                     break

--- a/tests/test_api_server_config.py
+++ b/tests/test_api_server_config.py
@@ -42,7 +42,7 @@ class TestModulePathsValid:
         Returns list of (line_number, module_path) tuples.
         """
         paths = []
-        content = filepath.read_text()
+        content = filepath.read_text(encoding="utf-8")
 
         # Parse the AST to find uvicorn.run calls
         try:
@@ -142,7 +142,7 @@ class TestModulePathFormat:
     def test_api_server_path_includes_api_subpackage(self):
         """Test that api_server.py delegates to the correct module path."""
         api_server_path = Path(__file__).parent.parent / "skill_scanner" / "api" / "api_server.py"
-        content = api_server_path.read_text()
+        content = api_server_path.read_text(encoding="utf-8")
 
         # api_server.py is a thin wrapper; it should reference the canonical
         # app location: skill_scanner.api.api:app (not skill_scanner.api_server:app)
@@ -157,7 +157,7 @@ class TestModulePathFormat:
     def test_api_cli_path_includes_api_subpackage(self):
         """Test that api_cli.py path includes 'api' subpackage."""
         api_cli_path = Path(__file__).parent.parent / "skill_scanner" / "api" / "api_cli.py"
-        content = api_cli_path.read_text()
+        content = api_cli_path.read_text(encoding="utf-8")
 
         # The path should be skill_scanner.api.api, not skill_scanner.api
         assert "skill_scanner.api.api" in content, "api_cli.py should use 'skill_scanner.api.api:app' path"
@@ -273,7 +273,7 @@ class TestModulePathConsistency:
         api_dir = Path(__file__).parent.parent / "skill_scanner" / "api"
 
         for py_file in api_dir.glob("*.py"):
-            content = py_file.read_text()
+            content = py_file.read_text(encoding="utf-8")
 
             # Check for old module references in uvicorn paths
             if "skillanalyzer" in content.lower():
@@ -287,7 +287,7 @@ class TestModulePathConsistency:
         api_dir = Path(__file__).parent.parent / "skill_scanner" / "api"
 
         for py_file in api_dir.glob("*.py"):
-            content = py_file.read_text()
+            content = py_file.read_text(encoding="utf-8")
 
             # Find uvicorn.run calls with string arguments
             uvicorn_pattern = r'uvicorn\.run\(["\']([^"\']+)["\']'

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -58,7 +58,7 @@ class TestLLMAnalyzerOperatorPrecedence:
     def test_llm_filter_external_check_parenthesized(self):
         """External check in is_internal_file_reading has proper parentheses."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "analyzers" / "llm_analyzer.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         # The is_internal_file_reading block has "or" conditions in parentheses
         assert "is_internal_file_reading" in text
         assert "(" in text and ")" in text
@@ -86,7 +86,7 @@ class TestDeterministicFindingIds:
     def test_scanner_uses_sha256_for_ids(self):
         """Scanner uses hashlib.sha256 for ID generation."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "scanner.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert "hashlib.sha256" in text
 
 
@@ -185,7 +185,7 @@ class TestLLMAnalyzerPathTraversal:
     def test_llm_analyzer_rejects_path_traversal(self):
         """LLM analyzer source includes path traversal rejection."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "analyzers" / "llm_analyzer.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert ".." in text
         assert "lstrip" in text or "replace" in text
 
@@ -201,7 +201,7 @@ class TestAPIKeysInHeaders:
     def test_api_keys_in_headers(self):
         """API router uses Header() for API keys."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "api" / "router.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert "Header(" in text
         assert "X-VirusTotal-Key" in text or "x-virustotal-key" in text.lower()
         assert "X-AIDefense-Key" in text or "x-aidefense-key" in text.lower()
@@ -218,7 +218,7 @@ class TestAPINoRawExceptionIn500:
     def test_api_no_raw_exception_in_500(self):
         """500 responses use generic message; exceptions logged."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "api" / "router.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert "Internal scan error" in text
         assert "logger.exception" in text
 
@@ -250,7 +250,7 @@ class TestBoundedCacheThreadSafety:
     def test_bounded_cache_thread_safety(self):
         """_BoundedCache uses threading.Lock."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "api" / "router.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert "threading" in text
         assert "Lock()" in text
 
@@ -266,7 +266,7 @@ class TestCrossSkillSyntheticResult:
     def test_cross_skill_findings_not_appended_to_first_result(self):
         """Cross-skill findings use add_cross_skill_findings, not results[0]."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "scanner.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert "add_cross_skill_findings" in text
 
     def test_report_has_cross_skill_findings_field(self):
@@ -312,7 +312,7 @@ class TestStaticAnalyzerLogsExceptions:
     def test_static_analyzer_logs_exceptions(self):
         """No bare 'except Exception: pass' - uses logger.debug or logger.warning."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "analyzers" / "static.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         # Match "except Exception..." followed by newline and line with only "pass"
         # (greedy .*? with DOTALL wrongly matches across distant "pass")
         bare_passes = re.findall(
@@ -333,7 +333,7 @@ class TestNoDeadCapabilityInflationSkip:
     def test_no_dead_capability_inflation_skip(self):
         """No dead skip for capability_inflation_generic."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "analyzers" / "static.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         if "capability_inflation_generic" in text:
             idx = text.find("capability_inflation_generic")
             before = text[max(0, idx - 150) : idx]
@@ -351,7 +351,7 @@ class TestAnalyzerFactoryNarrowCatches:
     def test_analyzer_factory_narrow_catches(self):
         """analyzer_factory uses narrowed exception catches, not bare except Exception."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "analyzer_factory.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert "except (ImportError" in text
         lines = text.splitlines()
         broad_catches = [l.strip() for l in lines if "except Exception" in l and "ImportError" not in l]
@@ -369,7 +369,7 @@ class TestLoaderUsesStdlibModules:
     def test_loader_uses_stdlib_modules(self):
         """Loader uses stdlib_module_names for import filtering."""
         source = Path(__file__).resolve().parent.parent / "skill_scanner" / "core" / "loader.py"
-        text = source.read_text()
+        text = source.read_text(encoding="utf-8")
         assert "stdlib_module_names" in text
 
 

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -302,7 +302,7 @@ class TestMultipleFormats:
         _write_output(args, primary_output)
 
         assert Path(sarif_path).exists()
-        sarif_content = json.loads(Path(sarif_path).read_text())
+        sarif_content = json.loads(Path(sarif_path).read_text(encoding="utf-8"))
         assert sarif_content.get("$schema") or sarif_content.get("version")
 
     def test_cli_accepts_multiple_format_flags(self):

--- a/tests/test_meta_analyzer.py
+++ b/tests/test_meta_analyzer.py
@@ -416,7 +416,7 @@ class TestAITechTaxonomy:
         if not prompt_path.exists():
             pytest.skip("Prompt file not found")
 
-        prompt_content = prompt_path.read_text()
+        prompt_content = prompt_path.read_text(encoding="utf-8")
 
         # Check that key AITech codes are mentioned
         expected_codes = [

--- a/tests/test_rule_registry.py
+++ b/tests/test_rule_registry.py
@@ -51,7 +51,7 @@ _YARA_RULE_NAME_RE = re.compile(r"^rule\s+(\w+)", re.MULTILINE)
 
 def _load_pack_rule_ids() -> set[str]:
     """Load all rule IDs declared in the core pack.yaml."""
-    with open(_CORE_PACK_YAML) as fh:
+    with open(_CORE_PACK_YAML, encoding="utf-8") as fh:
         data = yaml.safe_load(fh)
     return set((data.get("rules") or {}).keys())
 
@@ -60,7 +60,7 @@ def _load_signature_rule_ids() -> set[str]:
     """Parse all YAML files in signatures/ and return all rule IDs."""
     ids: set[str] = set()
     for yaml_file in sorted(_CORE_SIGNATURES_DIR.glob("*.yaml")):
-        with open(yaml_file) as fh:
+        with open(yaml_file, encoding="utf-8") as fh:
             rules = yaml.safe_load(fh) or []
         ids.update(r["id"] for r in rules)
     return ids
@@ -70,7 +70,7 @@ def _load_yara_rule_names() -> set[str]:
     """Parse .yara files and return all YARA_ prefixed rule IDs."""
     names: set[str] = set()
     for yara_file in _CORE_YARA_DIR.glob("*.yara"):
-        text = yara_file.read_text()
+        text = yara_file.read_text(encoding="utf-8")
         for m in _YARA_RULE_NAME_RE.finditer(text):
             names.add(f"YARA_{m.group(1)}")
     return names
@@ -290,7 +290,7 @@ class TestPackCoverageAudit:
 
     def test_pack_entries_have_enabled_knob(self):
         """Every rule in pack.yaml must have at least an 'enabled' knob."""
-        with open(_CORE_PACK_YAML) as fh:
+        with open(_CORE_PACK_YAML, encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
         rules = data.get("rules") or {}
         for rule_id, rule_data in rules.items():
@@ -300,7 +300,7 @@ class TestPackCoverageAudit:
     def test_no_orphan_pack_entries_for_signatures(self):
         """pack.yaml signature entries should correspond to actual rules."""
         sig_ids = _load_signature_rule_ids()
-        with open(_CORE_PACK_YAML) as fh:
+        with open(_CORE_PACK_YAML, encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
         pack_sigs = {
             rid
@@ -315,7 +315,7 @@ class TestPackCoverageAudit:
     def test_no_orphan_pack_entries_for_yara(self):
         """pack.yaml YARA entries should correspond to actual .yara rules."""
         yara_ids = _load_yara_rule_names()
-        with open(_CORE_PACK_YAML) as fh:
+        with open(_CORE_PACK_YAML, encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
         pack_yara = {
             rid for rid, rd in (data.get("rules") or {}).items() if isinstance(rd, dict) and rd.get("source") == "yara"

--- a/tests/test_scan_policy.py
+++ b/tests/test_scan_policy.py
@@ -318,7 +318,7 @@ class TestPolicySectionAnalyzerIntegration:
                 path=skillmd,
                 relative_path="SKILL.md",
                 file_type="markdown",
-                content=skillmd.read_text(),
+                content=skillmd.read_text(encoding="utf-8"),
                 size_bytes=skillmd.stat().st_size,
             ),
         ]

--- a/tests/test_taxonomy_validation.py
+++ b/tests/test_taxonomy_validation.py
@@ -278,7 +278,7 @@ class TestLLMAnalyzerTaxonomy:
             return []
 
         results = []
-        content = filepath.read_text()
+        content = filepath.read_text(encoding="utf-8")
 
         for line_num, line in enumerate(content.splitlines(), start=1):
             # Find AITech codes
@@ -330,7 +330,7 @@ class TestLLMAnalyzerTaxonomy:
         if not schema_path.exists():
             pytest.skip("LLM response schema not found")
 
-        schema = json.loads(schema_path.read_text())
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
         invalid_codes = []
 
         # Navigate to aitech enum in schema


### PR DESCRIPTION
## Summary

- Fixes #57 — `UnicodeDecodeError: 'gbk' codec can't decode byte 0x93` on systems where the default locale encoding is not UTF-8 (e.g. GBK on Chinese Windows).
- Adds explicit `encoding="utf-8"` to all text-mode `open()` and `Path.read_text()` calls that were relying on the system default encoding.
- 16 files updated across production code (`skill_scanner/`), tests, eval runners, and scripts — all 1173 existing tests pass.

### Root cause

Python's `open()` and `Path.read_text()` default to `locale.getpreferredencoding()` when no encoding is specified. On Chinese Windows systems this is GBK, which cannot decode UTF-8 multi-byte sequences, causing the reported crash.

### Files changed

| Area | Files |
|------|-------|
| **Production** | `skill_scanner/core/scan_policy.py`, `skill_scanner/config/config.py`, `skill_scanner/hooks/pre_commit.py` |
| **Tests** | `test_rule_registry.py`, `test_bug_fixes.py`, `test_issue_fixes.py`, `test_taxonomy_validation.py`, `test_scan_policy.py`, `test_meta_analyzer.py`, `test_api_server_config.py` |
| **Eval runners** | `benchmark_runner.py`, `eval_runner.py`, `policy_benchmark.py`, `update_expected_findings.py` |
| **Scripts** | `update_brew_formula.py`, `fp_analysis_collect.py` |

## Test plan

- [x] All 1173 existing tests pass (`pytest tests/ -x -q` → 1173 passed, 3 skipped)
- [x] All pre-commit hooks pass (ruff, ruff format, addlicense, detect secrets, etc.)
- [ ] Verify on a Windows system with GBK locale that the scanner runs without `UnicodeDecodeError`