### PR TITLE
fix: make litellm and google providers optional extras

### DIFF
--- a/.github/workflows/scan-skills.yml
+++ b/.github/workflows/scan-skills.yml
@@ -103,7 +103,14 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Install skill-scanner
-        run: pip install cisco-ai-skill-scanner
+        env:
+          INPUT_USE_LLM: ${{ inputs.use_llm }}
+        run: |
+          EXTRAS=""
+          if [ "$INPUT_USE_LLM" = "true" ]; then
+            EXTRAS="[llm]"
+          fi
+          pip install "cisco-ai-skill-scanner${EXTRAS}"
 
       - name: Validate inputs
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,15 +67,18 @@ dependencies = [
     "oletools>=0.60.1",
     # Unicode homoglyph attack detection (confusables.txt backed)
     "confusable-homoglyphs>=3.3.0",
-    # LLM support (required)
+    # LLM direct clients (lightweight, used for provider detection)
     "anthropic>=0.40.0",
     "openai>=1.0.0",
+]
+
+[project.optional-dependencies]
+# LLM proxy + Google providers (required only when use_llm=true)
+llm = [
     "litellm>=1.77.0",
     "google-genai>=0.2.0",
     "google-generativeai>=0.8.0",
 ]
-
-[project.optional-dependencies]
 # AWS Bedrock support (requires boto3 for IAM credentials)
 bedrock = [
     "boto3>=1.28.57",
@@ -94,6 +97,9 @@ azure = [
 # supply-chain = ["guarddog>=2.0.0"]
 # All optional provider extras
 all = [
+    "litellm>=1.77.0",
+    "google-genai>=0.2.0",
+    "google-generativeai>=0.8.0",
     "boto3>=1.28.57",
     "google-cloud-aiplatform>=1.38.0",
     "azure-identity>=1.15.0",


### PR DESCRIPTION
## Problem

`litellm`, `google-genai`, and `google-generativeai` are listed as required dependencies, but they are only needed when `use_llm=true`. On some CI runner environments, `litellm` fails to install due to unresolvable transitive dependencies, breaking the base install for all users regardless of whether they use LLM analysis.

## Fix

Move `litellm`, `google-genai`, and `google-generativeai` to a new `[llm]` optional extra. `anthropic` and `openai` remain in core as they are used as lightweight direct clients.

The `scan-skills.yml` reusable workflow now installs `cisco-ai-skill-scanner[llm]` only when `use_llm: true`, keeping the base install fast and conflict-free.

The existing runtime guards (`importlib.util.find_spec` checks and `try/except ImportError` blocks) already handle the absence of these packages gracefully — no code changes required.

## Testing

Validated end-to-end on a CI run with `use_llm: false` (default): install succeeds, scan completes, SARIF output generated.

## Pull Request Checklist

- [x] All pre-commit hooks pass (`uv run pre-commit run --all-files`)
- [x] All unit tests pass (`uv run pytest tests/`)
- [ ] All benchmarks pass without significant regressions (`uv run python evals/runners/benchmark_runner.py`)
- [x] Tests added/updated for changes (no behavior changes; existing `ImportError` guards cover absence of optional deps)
- [x] Documentation updated if needed (no docs changes required)
- [x] Commit messages follow conventional format (e.g., `feat:`, `fix:`, `docs:`)