### PR TITLE
fix: make only Google LLM providers optional to fix github action

### DIFF
--- a/.github/workflows/scan-skills.yml
+++ b/.github/workflows/scan-skills.yml
@@ -103,7 +103,19 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Install skill-scanner
-        run: pip install cisco-ai-skill-scanner
+        env:
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
+        run: |
+          EXTRAS=""
+          case "$INPUT_LLM_MODEL" in
+            gemini/*|*gemini*)
+              EXTRAS="[google]"
+              ;;
+            vertex_ai/*|vertex/*|*vertex*)
+              EXTRAS="[vertex]"
+              ;;
+          esac
+          pip install "cisco-ai-skill-scanner${EXTRAS}"
 
       - name: Validate inputs
         env:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ pip install cisco-ai-skill-scanner
 # AWS Bedrock support
 pip install cisco-ai-skill-scanner[bedrock]
 
+# Google AI Studio / Gemini support
+pip install cisco-ai-skill-scanner[google]
+
 # Google Vertex AI support
 pip install cisco-ai-skill-scanner[vertex]
 

--- a/docs/reference/dependencies-and-llm-providers.md
+++ b/docs/reference/dependencies-and-llm-providers.md
@@ -48,8 +48,8 @@ All versions from [`pyproject.toml`](https://github.com/cisco-ai-defense/skill-s
 | `anthropic` | >= 0.40.0 | Anthropic Claude SDK |
 | `openai` | >= 1.0.0 | OpenAI SDK |
 | `litellm` | >= 1.77.0 | Multi-provider LLM routing |
-| `google-genai` | >= 0.2.0 | Google AI SDK |
-| `google-generativeai` | >= 0.8.0 | Google Generative AI SDK |
+| `google-genai` | optional via `[google]` | Google AI Studio / Gemini SDK |
+| `google-generativeai` | optional via `[google]` | Legacy Google Generative AI SDK compatibility |
 
 ## Optional Provider Extras
 
@@ -58,6 +58,9 @@ Install only what you need:
 ```bash
 # AWS Bedrock
 pip install "cisco-ai-skill-scanner[bedrock]"
+
+# Google AI Studio / Gemini
+pip install "cisco-ai-skill-scanner[google]"
 
 # Google Vertex AI
 pip install "cisco-ai-skill-scanner[vertex]"
@@ -71,6 +74,7 @@ pip install "cisco-ai-skill-scanner[all]"
 
 | Extra | Package | Version | Purpose |
 |-------|---------|---------|---------|
+| `google` | `google-genai`, `google-generativeai` | varies | Google AI Studio / Gemini SDK support |
 | `bedrock` | `boto3` | >= 1.28.57 | AWS Bedrock IAM credential support |
 | `vertex` | `google-cloud-aiplatform` | >= 1.38.0 | Google Vertex AI support |
 | `azure` | `azure-identity` | >= 1.15.0 | Azure managed identity auth |
@@ -88,7 +92,7 @@ Set `SKILL_SCANNER_LLM_MODEL` using the provider prefix convention:
 | OpenAI | `openai/gpt-4o` | |
 | AWS Bedrock | `bedrock/anthropic.claude-sonnet-4-20250514-v1:0` | Requires `[bedrock]` extra or API key |
 | Google Vertex AI | `vertex_ai/gemini-2.5-pro` | Requires `[vertex]` extra |
-| Google AI Studio | `gemini/gemini-2.5-flash` | Via LiteLLM |
+| Google AI Studio | `gemini/gemini-2.5-flash` | Requires `[google]` extra |
 | Azure OpenAI | `azure/my-deployment-name` | Requires `[azure]` extra |
 | Ollama (local) | `ollama/llama3` | No API key needed |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,14 @@ dependencies = [
     "anthropic==0.76.0",
     "openai==2.15.0",
     "litellm==1.82.3",
-    "google-genai==1.60.0",
-    "google-generativeai==0.8.6",
 ]
 
 [project.optional-dependencies]
+# Google AI Studio / Gemini SDKs
+google = [
+    "google-genai==1.60.0",
+    "google-generativeai==0.8.6",
+]
 # AWS Bedrock support (requires boto3 for IAM credentials)
 bedrock = [
     "boto3==1.42.37",
@@ -94,6 +97,8 @@ azure = [
 # supply-chain = ["guarddog==2.0.0"]
 # All optional provider extras
 all = [
+    "google-genai==1.60.0",
+    "google-generativeai==0.8.6",
     "boto3==1.42.37",
     "google-cloud-aiplatform==1.135.0",
     "azure-identity==1.25.1",

--- a/uv.lock
+++ b/uv.lock
@@ -515,8 +515,6 @@ dependencies = [
     { name = "click" },
     { name = "confusable-homoglyphs" },
     { name = "fastapi" },
-    { name = "google-genai" },
-    { name = "google-generativeai" },
     { name = "httpx" },
     { name = "litellm" },
     { name = "magika" },
@@ -540,12 +538,18 @@ all = [
     { name = "azure-identity" },
     { name = "boto3" },
     { name = "google-cloud-aiplatform" },
+    { name = "google-genai" },
+    { name = "google-generativeai" },
 ]
 azure = [
     { name = "azure-identity" },
 ]
 bedrock = [
     { name = "boto3" },
+]
+google = [
+    { name = "google-genai" },
+    { name = "google-generativeai" },
 ]
 vertex = [
     { name = "google-cloud-aiplatform" },
@@ -575,8 +579,10 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.125.0" },
     { name = "google-cloud-aiplatform", marker = "extra == 'all'", specifier = ">=1.38.0" },
     { name = "google-cloud-aiplatform", marker = "extra == 'vertex'", specifier = ">=1.38.0" },
-    { name = "google-genai", specifier = ">=0.2.0" },
-    { name = "google-generativeai", specifier = ">=0.8.0" },
+    { name = "google-genai", marker = "extra == 'all'", specifier = ">=0.2.0" },
+    { name = "google-genai", marker = "extra == 'google'", specifier = ">=0.2.0" },
+    { name = "google-generativeai", marker = "extra == 'all'", specifier = ">=0.8.0" },
+    { name = "google-generativeai", marker = "extra == 'google'", specifier = ">=0.8.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "litellm", specifier = "==1.80.16" },
     { name = "magika", specifier = ">=0.6.0" },
@@ -594,7 +600,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },
     { name = "yara-x", specifier = ">=1.12.0" },
 ]
-provides-extras = ["all", "azure", "bedrock", "vertex"]
+provides-extras = ["all", "azure", "bedrock", "google", "vertex"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Pull Request

## Description

  This PR fixes the reusable GitHub Actions workflow so CI can still use the normal LLM scanning path without requiring Google-specific dependencies on every install.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [x] Documentation update

  ## Related Issues

  Related to #N/A

  ## Changes Made

  - Added a dedicated `google` extra for Google AI Studio / Gemini SDK dependencies.
  - Updated the reusable GitHub Actions workflow to install `[google]` only for Gemini-like models and `[vertex]` only for Vertex-like models.
  - Updated docs and `uv.lock` to reflect the new dependency layout.

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] No hardcoded credentials or secrets
  - [x] No new security vulnerabilities introduced
  - [x] README/documentation updated where needed
  - [x] Tests pass locally
  - [x] No regressions found in existing functionality
  - [ ] Benchmark passes: uv run python evals/runners/benchmark_runner.py
  - [ ] CHANGELOG updated