### PR TITLE
chore(deps): update litellm to 1.82.3 and pin all dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,70 +46,69 @@ keywords = [
 ]
 
 dependencies = [
-    "PyYAML>=6.0.1",
-    "python-frontmatter>=1.0.0",
-    "click>=8.1.0",
-    "rich>=13.0.0",
-    "textual>=1.0.0",
-    "tabulate>=0.9.0",
-    "pydantic>=2.6.0",
-    "fastapi>=0.125.0",
-    "uvicorn[standard]>=0.29.0",
-    "python-multipart>=0.0.6",
-    "yara-x>=1.12.0",
-    "python-dotenv>=1.0.0",
-    "httpx>=0.28.1",
+    "PyYAML==6.0.3",
+    "python-frontmatter==1.1.0",
+    "click==8.3.1",
+    "rich==14.2.0",
+    "textual==7.5.0",
+    "tabulate==0.9.0",
+    "pydantic==2.12.5",
+    "fastapi==0.128.0",
+    "uvicorn[standard]==0.40.0",
+    "python-multipart==0.0.22",
+    "yara-x==1.13.0",
+    "python-dotenv==1.2.1",
+    "httpx==0.28.1",
     # AI-powered file type detection (200+ types, ~99% accuracy)
-    "magika>=0.6.0",
+    "magika==1.0.1",
     # Structural PDF analysis (detects JS, OpenAction, Launch, etc.)
-    "pdfid>=1.1.0",
+    "pdfid==1.1.3",
     # Office document macro/VBA detection (oleid + olevba)
-    "oletools>=0.60.1",
+    "oletools==0.60.2",
     # Unicode homoglyph attack detection (confusables.txt backed)
-    "confusable-homoglyphs>=3.3.0",
+    "confusable-homoglyphs==3.3.1",
     # LLM support (required)
-    "anthropic>=0.40.0",
-    "openai>=1.0.0",
-    # Pin below known-bad PyPI release 1.82.8 (BerriAI/litellm#24512); IOC spot-check on wheel, see PR body.
-    "litellm==1.80.16",
-    "google-genai>=0.2.0",
-    "google-generativeai>=0.8.0",
+    "anthropic==0.76.0",
+    "openai==2.15.0",
+    "litellm==1.82.3",
+    "google-genai==1.60.0",
+    "google-generativeai==0.8.6",
 ]
 
 [project.optional-dependencies]
 # AWS Bedrock support (requires boto3 for IAM credentials)
 bedrock = [
-    "boto3>=1.28.57",
+    "boto3==1.42.37",
 ]
 # Google Vertex AI support
 vertex = [
-    "google-cloud-aiplatform>=1.38.0",
+    "google-cloud-aiplatform==1.135.0",
 ]
 # Azure OpenAI support (for managed identity auth)
 azure = [
-    "azure-identity>=1.15.0",
+    "azure-identity==1.25.1",
 ]
 # Supply chain dependency scanning (requires network access)
 # NOTE: guarddog has a dependency conflict with pip-audit via tomli.
 # Install separately: pip install guarddog
-# supply-chain = ["guarddog>=2.0.0"]
+# supply-chain = ["guarddog==2.0.0"]
 # All optional provider extras
 all = [
-    "boto3>=1.28.57",
-    "google-cloud-aiplatform>=1.38.0",
-    "azure-identity>=1.15.0",
+    "boto3==1.42.37",
+    "google-cloud-aiplatform==1.135.0",
+    "azure-identity==1.25.1",
 ]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.4.1",
-    "pytest-cov>=6.2.1",
-    "pytest-asyncio>=1.0.0",
-    "ruff>=0.14.0",
-    "mypy>=1.8.0",
-    "pre-commit>=4.5.0",
-    "liccheck>=0.9.2",
-    "pip-audit>=2.10.0",
+    "pytest==9.0.2",
+    "pytest-cov==7.0.0",
+    "pytest-asyncio==1.3.0",
+    "ruff==0.14.12",
+    "mypy==1.19.1",
+    "pre-commit==4.5.1",
+    "liccheck==0.9.2",
+    "pip-audit==2.10.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Update litellm from 1.80.16 to 1.82.3
- Pin all dependency versions with exact (`==`) specifiers instead of minimum (`>=`) bounds for reproducible builds
- Applies to core dependencies, optional extras (bedrock, vertex, azure), and dev dependency group

## Test plan

- [ ] Verify `pip install .` resolves all pinned versions correctly
- [ ] Run `pytest` to confirm no regressions from dependency changes
- [ ] Verify litellm 1.82.3 works with existing LLM provider integrations