### PR TITLE
fix: include filename and line number in Python parser syntax error warnings (#69)

### DIFF
--- a/skill_scanner/core/static_analysis/context_extractor.py
+++ b/skill_scanner/core/static_analysis/context_extractor.py
@@ -262,7 +262,7 @@ class ContextExtractor:
             SkillScriptContext with extracted information
         """
         # Parse with AST parser
-        parser = PythonParser(source_code)
+        parser = PythonParser(source_code, source_file=str(file_path))
         if not parser.parse():
             # Return empty context if parsing fails
             return SkillScriptContext(file_path=str(file_path), functions=[], imports=[], dataflows=[])
@@ -394,7 +394,7 @@ class ContextExtractor:
             return contexts
 
         # Parse with AST parser
-        parser = PythonParser(source_code)
+        parser = PythonParser(source_code, source_file=str(file_path))
         if not parser.parse():
             return contexts
 

--- a/skill_scanner/core/static_analysis/parser/python_parser.py
+++ b/skill_scanner/core/static_analysis/parser/python_parser.py
@@ -124,14 +124,16 @@ class PythonParser:
         },
     }
 
-    def __init__(self, source_code: str):
+    def __init__(self, source_code: str, source_file: str = "<unknown>"):
         """
         Initialize parser with source code.
 
         Args:
             source_code: Python source code to parse
+            source_file: Optional filename for better error messages
         """
         self.source_code = source_code
+        self.source_file = source_file
         self.tree: ast.Module | None = None
         self.functions: list[FunctionInfo] = []
         self.imports: list[str] = []
@@ -147,14 +149,20 @@ class PythonParser:
             True if parsing succeeded, False otherwise
         """
         try:
-            self.tree = ast.parse(self.source_code)
+            self.tree = ast.parse(self.source_code, filename=self.source_file)
             self._extract_imports()
             self._extract_module_level_strings()
             self._extract_functions()
             self._extract_global_code()
             return True
         except SyntaxError as e:
-            logger.warning("Syntax error in source: %s", e)
+            logger.warning(
+                "Syntax error in %s (line %s): %s\n  %s",
+                e.filename or self.source_file,
+                e.lineno,
+                e.msg,
+                (e.text or "").rstrip(),
+            )
             return False
 
     def _extract_module_level_strings(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #69 — Python parser syntax error warnings omitted the file path and line context, making it difficult to identify which file triggered the error when scanning multi-file skills.

## Root Cause

`ast.parse()` was called without a `filename=` argument, so `SyntaxError.filename` was always `<unknown>`. The warning logged `str(e)` which produces the unhelpful message:

```
WARNING Syntax error in source: invalid syntax (<unknown>, line 240)
```

## Fix

Two changes:

1. **`PythonParser.__init__()`** gains an optional `source_file` parameter (default `"<unknown>"`).
2. **`ast.parse()`** now receives `filename=self.source_file`, so `SyntaxError.filename` is populated with the real path.
3. **`logger.warning()`** now logs `e.filename`, `e.lineno`, `e.msg`, and `e.text` separately for structured, grep-friendly output.
4. **`context_extractor.py`** passes `source_file=str(file_path)` at both call sites that have a real file path available.

## Before / After

**Before:**
```
WARNING  Syntax error in source: invalid syntax (<unknown>, line 240)
WARNING  Syntax error in source: invalid syntax (<unknown>, line 2)
```

**After:**
```
WARNING  Syntax error in skills/backdoor/process.py (line 240): invalid syntax
           some_bad_python_here =
WARNING  Syntax error in skills/obfuscation/encode.py (line 2): invalid syntax
           def broken(:
```

## Changes

- `skill_scanner/core/static_analysis/parser/python_parser.py` — `__init__` signature, `ast.parse` call, `except SyntaxError` block
- `skill_scanner/core/static_analysis/context_extractor.py` — two `PythonParser()` call sites updated to pass `source_file=str(file_path)`

The third `PythonParser` call site in `context_extractor.py` uses synthetic function source (not a real file path), so it correctly falls back to the `"<unknown>"` default.