### PR TITLE
Detect documented Anthropic and OpenAI project key prefixes

### DIFF
--- a/skill_scanner/data/packs/core/yara/credential_harvesting_generic.yara
+++ b/skill_scanner/data/packs/core/yara/credential_harvesting_generic.yara
@@ -30,10 +30,12 @@ rule credential_harvesting_generic{
         ////////////////////////////////////////////////
 
         // API credentials - real keys only (not Bearer YOUR_*)
-        // AKIA keys, ghp_ tokens, sk- keys with actual values (not placeholders)
+        // AKIA keys, ghp_ tokens, legacy sk- keys, and documented provider-specific sk- prefixes
         $api_credentials_aws = /\bAKIA[0-9A-Z]{16}\b/
         $api_credentials_github = /\bghp_[A-Za-z0-9]{36}\b/
-        $api_credentials_sk = /\bsk-[A-Za-z0-9]{48,}\b/
+        $api_credentials_sk_legacy = /\bsk-[A-Za-z0-9]{48,}\b/
+        $api_credentials_openai_project = /\bsk-proj-[A-Za-z0-9_-]{20,}\b/
+        $api_credentials_anthropic = /\bsk-ant-api\d{2}-[A-Za-z0-9_-]{20,}\b/
 
         // SSH keys, certificates and credential file content
         $key_certificate_content = /(-----BEGIN (RSA |OPENSSH |EC |DSA )?PRIVATE KEY-----)/
@@ -110,7 +112,9 @@ rule credential_harvesting_generic{
             // Real API credentials (high confidence specific patterns)
             $api_credentials_aws or
             $api_credentials_github or
-            $api_credentials_sk or
+            $api_credentials_sk_legacy or
+            $api_credentials_openai_project or
+            $api_credentials_anthropic or
 
             // Actual private key content
             $key_certificate_content or

--- a/tests/test_new_detections.py
+++ b/tests/test_new_detections.py
@@ -682,6 +682,48 @@ class TestSecretsRuleQuality:
         key_findings = [f for f in findings if f.rule_id == "SECRET_PRIVATE_KEY"]
         assert len(key_findings) >= 1
 
+    def test_bare_anthropic_key_detected_end_to_end(self, tmp_path):
+        """Bare documented Anthropic keys should trigger the YARA credential rule."""
+        skill = _quick_skill(
+            tmp_path,
+            {
+                "tool.py": 'key = "sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\n',
+            },
+        )
+        analyzer = StaticAnalyzer()
+        findings = analyzer.analyze(skill)
+
+        key_findings = [f for f in findings if f.rule_id == "YARA_credential_harvesting_generic"]
+        assert len(key_findings) >= 1
+
+    def test_bare_openai_project_key_detected_end_to_end(self, tmp_path):
+        """Bare documented OpenAI project keys should trigger the YARA credential rule."""
+        skill = _quick_skill(
+            tmp_path,
+            {
+                "tool.py": 'key = "sk-proj-8Dvo0_nGTvHe6fffWX8xb5HhX5s5MHBLPlfEbc22uxKkdLs8A"\n',
+            },
+        )
+        analyzer = StaticAnalyzer()
+        findings = analyzer.analyze(skill)
+
+        key_findings = [f for f in findings if f.rule_id == "YARA_credential_harvesting_generic"]
+        assert len(key_findings) >= 1
+
+    def test_long_hyphenated_slug_not_flagged_end_to_end(self, tmp_path):
+        """Long hyphenated slugs should not become YARA credential-harvesting findings."""
+        skill = _quick_skill(
+            tmp_path,
+            {
+                "tool.py": 'note = "sk-reference-slug-for-documentation-and-indexing-aaaaaaaaaaaaaaaaaa"\n',
+            },
+        )
+        analyzer = StaticAnalyzer()
+        findings = analyzer.analyze(skill)
+
+        key_findings = [f for f in findings if f.rule_id == "YARA_credential_harvesting_generic"]
+        assert len(key_findings) == 0
+
 
 class TestCommandInjectionEvalRuleQuality:
     """Regression tests for COMMAND_INJECTION_EVAL precision."""

--- a/tests/test_yara_true_positives.py
+++ b/tests/test_yara_true_positives.py
@@ -85,6 +85,20 @@ class TestUnicodeSteganographyTruePositives:
 class TestCredentialHarvestingTruePositives:
     """Ensure credential harvesting rule catches real threats."""
 
+    def test_detects_bare_anthropic_api_key(self, yara_scanner):
+        """Documented bare Anthropic keys should trigger credential harvesting."""
+        content = 'key = "sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'
+        matches = yara_scanner.scan_content(content, "config.py")
+        credential_matches = [m for m in matches if m["rule_name"] == "credential_harvesting_generic"]
+        assert len(credential_matches) > 0, "Should detect bare Anthropic API key"
+
+    def test_detects_bare_openai_project_key(self, yara_scanner):
+        """Documented bare OpenAI project keys should trigger credential harvesting."""
+        content = 'key = "sk-proj-8Dvo0_nGTvHe6fffWX8xb5HhX5s5MHBLPlfEbc22uxKkdLs8A"'
+        matches = yara_scanner.scan_content(content, "config.py")
+        credential_matches = [m for m in matches if m["rule_name"] == "credential_harvesting_generic"]
+        assert len(credential_matches) > 0, "Should detect bare OpenAI project key"
+
     def test_detects_real_api_key_pattern(self, yara_scanner):
         """Should detect actual API keys (not placeholders)."""
         content = 'OPENAI_API_KEY = "sk-proj-abc123xyz789verylongkey000000"'
@@ -271,6 +285,13 @@ class TestFalsePositiveRegression:
         matches = yara_scanner.scan_content(content, "dangerous.sh")
         system_matches = [m for m in matches if m["rule_name"] == "system_manipulation_generic"]
         assert len(system_matches) >= 1, "rm -rf ~/ should still trigger system_manipulation_generic"
+
+    def test_ignores_long_hyphenated_slug(self, yara_scanner):
+        """Long hyphenated slugs should not be mistaken for sk- credentials."""
+        content = 'note = "sk-reference-slug-for-documentation-and-indexing-aaaaaaaaaaaaaaaaaa"'
+        matches = yara_scanner.scan_content(content, "docs.py")
+        credential_matches = [m for m in matches if m["rule_name"] == "credential_harvesting_generic"]
+        assert len(credential_matches) == 0, "Long hyphenated slugs should not trigger credential harvesting"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

I realized the scanner's regex needs tightening to catch more API keys. This updates `credential_harvesting_generic` to detect documented hyphenated `sk-...` key families that were missed by the legacy generic pattern.

## Root cause

The previous rule only allowed alphanumeric characters after `sk-`:

```yara
# skill_scanner/data/packs/core/yara/credential_harvesting_generic.yara
$api_credentials_sk = /\bsk-[A-Za-z0-9]{48,}\b/
```

Official Anthropic documentation shows API key hints with the form `sk-ant-api03-...`, and OpenAI's official cookbook examples show project-scoped keys with the form `sk-proj-...`. Because those documented key families contain hyphens immediately after `sk-`, bare keys from those families were missed by the generic matcher.

## Changes

- keep legacy `sk-...` coverage
- add explicit detection for bare OpenAI project keys: `sk-proj-...`
- add explicit detection for bare Anthropic keys: `sk-ant-api..-...`
- add raw YARA regression tests for both bare-key cases
- add analyzer-level regression tests for both bare-key cases
- add a false-positive regression to avoid matching long hyphenated non-secret slugs

## Updated rule shape

```yara
# skill_scanner/data/packs/core/yara/credential_harvesting_generic.yara
$api_credentials_sk_legacy = /\bsk-[A-Za-z0-9]{48,}\b/
$api_credentials_openai_project = /\bsk-proj-[A-Za-z0-9_-]{20,}\b/
$api_credentials_anthropic = /\bsk-ant-api\d{2}-[A-Za-z0-9_-]{20,}\b/
```

## Why not broaden the generic rule?

A broad change to `[A-Za-z0-9\\-]{48,}` catches the missed key families, but it also overmatches long hyphenated non-secret slugs. This change keeps the legacy generic matcher and adds narrower provider-specific patterns instead.

## Validation

Ran:

```powershell
.\.venv\Scripts\pytest tests\test_yara_true_positives.py tests\test_yara_modes.py tests\test_policy_integration.py tests\static_analysis\test_static_analyzer.py tests\test_new_detections.py -q
```

Result:

```text
146 passed, 1 skipped
```

## References

- Anthropic API key docs: https://docs.anthropic.com/en/api/admin-api/apikeys/get-api-key
- Anthropic example usage: https://docs.anthropic.com/en/docs/build-with-claude/claude-for-sheets
- OpenAI cookbook example: https://cookbook.openai.com/examples/agents_sdk/evaluate_agents
