### PR TITLE
deps: pin litellm to 1.83.0 (post-supply-chain incident)

### DIFF
--- a/Formula/skill-scanner.rb
+++ b/Formula/skill-scanner.rb
@@ -227,8 +227,8 @@ class SkillScanner < Formula
   end
 
   resource "litellm" do
-    url "https://files.pythonhosted.org/packages/ac/cc/03bf7849c62587db0fb7c46f427d6a49290750752d3189a0bd95d4b78587/litellm-1.80.16.tar.gz"
-    sha256 "f96233649f99ab097f7d8a3ff9898680207b9eea7d2e23f438074a3dbcf50cca"
+    url "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz"
+    sha256 "860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a"
   end
 
   resource "markdown-it-py" do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ dependencies = [
     # LLM support (required)
     "anthropic==0.76.0",
     "openai==2.15.0",
-    "litellm==1.82.3",
+    # Pin to 1.83.0+ (avoid compromised PyPI lines in 1.80.16 / 1.82.3 / 1.82.8 — BerriAI/litellm#24512).
+    "litellm==1.83.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ requires-dist = [
     { name = "google-generativeai", marker = "extra == 'all'", specifier = "==0.8.6" },
     { name = "google-generativeai", marker = "extra == 'google'", specifier = "==0.8.6" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "litellm", specifier = "==1.82.3" },
+    { name = "litellm", specifier = "==1.83.0" },
     { name = "magika", specifier = "==1.0.1" },
     { name = "oletools", specifier = "==0.60.2" },
     { name = "openai", specifier = "==2.15.0" },
@@ -1941,7 +1941,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.82.3"
+version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1957,9 +1957,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/00/13993312e6d2fb29cd6d5ffceb293455ef747fe5675eaa9aa49b09184656/litellm-1.82.3.tar.gz", hash = "sha256:7215b95e7cc38a52b5ae778d67e8829dec86594c8b05d8431294e95c7d59937c", size = 17368754, upload-time = "2026-03-16T21:51:30.356Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/3a/590d58dee65a238f7f3d5c37f8f9f9021ecaf27fe379a393b4259324b56e/litellm-1.82.3-py3-none-any.whl", hash = "sha256:609901f6c5a5cf8c24386e4e3f50738bb8a9db719709fd76b208c8ee6d00f7a7", size = 15551034, upload-time = "2026-03-16T21:51:26.747Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace vulnerable-era pins with 1.83.0. Align Homebrew formula resource with pyproject/uv.lock.
