### PR TITLE
fix: issue where using --lenient could allow binary and non-UTF-8 content to be passed to loader in certain cases

### DIFF
--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -100,7 +100,7 @@ def _render_cli_reference() -> str:
         "| `--enable-meta` | off | Enable the meta (cross-correlation) analyzer |",
         "| `--fail-on-findings` | off | Exit non-zero if critical or high findings are reported; equivalent to `--fail-on-severity high` (CI gate) |",
         "| `--fail-on-severity LEVEL` | off | Exit non-zero if findings at or above LEVEL exist (critical, high, medium, low, info) |",
-        "| `--lenient` | off | Tolerate malformed skills: coerce bad fields, fill defaults, and continue instead of failing |",
+        "| `--lenient` | off | Tolerate malformed YAML / missing fields: coerce bad fields, fill defaults, and continue instead of failing. Binary and non-UTF-8 files always fail. |",
         "| `--detailed` | off | Include full evidence in output |",
         "| `--compact` | off | Minimize output (JSON: no pretty-print) |",
         "| `--verbose` | off | Verbose logging |",

--- a/skill_scanner/core/loader.py
+++ b/skill_scanner/core/loader.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import frontmatter
 
-from ..utils.file_utils import get_file_type
+from ..utils.file_utils import FileValidationError, get_file_type, read_text_strict
 from .exceptions import SkillLoadError
 from .models import Skill, SkillFile, SkillManifest
 
@@ -68,11 +68,12 @@ class SkillLoader:
 
         Args:
             skill_directory: Path to the skill directory
-            lenient: When True, tolerate missing/malformed fields and return
-                a best-effort Skill instead of raising ``SkillLoadError``.
-                When ``SKILL.md`` is absent and *lenient* is True, the loader
-                falls back to scanning ``.md`` files in the directory as
-                instruction bodies (supports non-Codex/Cursor formats such as
+            lenient: When True, tolerate missing/malformed YAML frontmatter and
+                fill default manifest fields instead of raising ``SkillLoadError``.
+                Files must still be valid UTF-8 text without NUL bytes; binary
+                or invalid encoding always fails. When ``SKILL.md`` is absent and
+                *lenient* is True, the loader falls back to scanning ``.md`` files
+                in the directory (supports non-Codex/Cursor formats such as
                 Claude Code ``.claude/commands/*.md``).
             skill_file: Optional custom metadata filename to use instead of
                 ``SKILL.md`` (e.g. ``"README.md"``).
@@ -152,37 +153,27 @@ class SkillLoader:
         # Use the first .md file as the primary path
         primary_md = md_files[0]
 
-        # Try to parse frontmatter from the primary file.
-        # _parse_skill_md validates UTF-8 and rejects binary content;
-        # let those errors propagate — a binary .md file should never
-        # silently become an empty skill, even in lenient mode.
-        try:
-            manifest, body = self._parse_skill_md(primary_md, lenient=True)
-        except SkillLoadError as e:
-            err_msg = str(e)
-            if "null bytes" in err_msg or "not valid UTF-8" in err_msg:
-                raise
-            # Frontmatter parsing failed but content is valid text — use raw
-            try:
-                body = primary_md.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
-                body = ""
-            manifest = SkillManifest(
-                name=skill_directory.name,
-                description="(no description)",
-            )
+        manifest, body = self._parse_skill_md(primary_md, lenient=True)
 
         # Append content from remaining .md files
         extra_bodies: list[str] = []
         for md_file in md_files[1:]:
-            try:
-                extra_bodies.append(md_file.read_text(encoding="utf-8"))
-            except (OSError, UnicodeDecodeError):
-                continue
+            extra_bodies.append(self._read_skill_text_file(md_file))
         if extra_bodies:
             body = body + "\n\n" + "\n\n".join(extra_bodies)
 
         return primary_md, manifest, body
+
+    def _read_skill_text_file(self, path: Path) -> str:
+        """Read a skill metadata or markdown file as strict UTF-8 text.
+
+        Delegates to :func:`~skill_scanner.utils.file_utils.read_text_strict`
+        and converts failures to :class:`SkillLoadError`.
+        """
+        try:
+            return read_text_strict(path, max_size_bytes=self.max_file_size_bytes)
+        except FileValidationError as e:
+            raise SkillLoadError(str(e)) from e
 
     def _parse_skill_md(self, skill_md_path: Path, *, lenient: bool = False) -> tuple[SkillManifest, str]:
         """
@@ -199,23 +190,7 @@ class SkillLoader:
         Raises:
             SkillLoadError: If parsing fails (strict mode only)
         """
-        try:
-            raw = skill_md_path.read_bytes()
-        except OSError as e:
-            raise SkillLoadError(f"Failed to read {skill_md_path.name}: {e}")
-
-        if b"\x00" in raw:
-            raise SkillLoadError(
-                f"{skill_md_path.name} contains null bytes (binary content); "
-                f"skill metadata files must be valid UTF-8 text"
-            )
-
-        try:
-            content = raw.decode("utf-8")
-        except UnicodeDecodeError as e:
-            raise SkillLoadError(
-                f"{skill_md_path.name} is not valid UTF-8: {e}; skill metadata files must be valid UTF-8 text"
-            )
+        content = self._read_skill_text_file(skill_md_path)
 
         # Parse with python-frontmatter
         try:

--- a/skill_scanner/core/loader.py
+++ b/skill_scanner/core/loader.py
@@ -214,8 +214,7 @@ class SkillLoader:
             content = raw.decode("utf-8")
         except UnicodeDecodeError as e:
             raise SkillLoadError(
-                f"{skill_md_path.name} is not valid UTF-8: {e}; "
-                f"skill metadata files must be valid UTF-8 text"
+                f"{skill_md_path.name} is not valid UTF-8: {e}; skill metadata files must be valid UTF-8 text"
             )
 
         # Parse with python-frontmatter

--- a/skill_scanner/core/loader.py
+++ b/skill_scanner/core/loader.py
@@ -152,11 +152,17 @@ class SkillLoader:
         # Use the first .md file as the primary path
         primary_md = md_files[0]
 
-        # Try to parse frontmatter from the primary file
+        # Try to parse frontmatter from the primary file.
+        # _parse_skill_md validates UTF-8 and rejects binary content;
+        # let those errors propagate — a binary .md file should never
+        # silently become an empty skill, even in lenient mode.
         try:
             manifest, body = self._parse_skill_md(primary_md, lenient=True)
-        except SkillLoadError:
-            # If even lenient parsing fails, use raw content
+        except SkillLoadError as e:
+            err_msg = str(e)
+            if "null bytes" in err_msg or "not valid UTF-8" in err_msg:
+                raise
+            # Frontmatter parsing failed but content is valid text — use raw
             try:
                 body = primary_md.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
@@ -194,10 +200,23 @@ class SkillLoader:
             SkillLoadError: If parsing fails (strict mode only)
         """
         try:
-            with open(skill_md_path, encoding="utf-8") as f:
-                content = f.read()
-        except (OSError, UnicodeDecodeError) as e:
-            raise SkillLoadError(f"Failed to read SKILL.md: {e}")
+            raw = skill_md_path.read_bytes()
+        except OSError as e:
+            raise SkillLoadError(f"Failed to read {skill_md_path.name}: {e}")
+
+        if b"\x00" in raw:
+            raise SkillLoadError(
+                f"{skill_md_path.name} contains null bytes (binary content); "
+                f"skill metadata files must be valid UTF-8 text"
+            )
+
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise SkillLoadError(
+                f"{skill_md_path.name} is not valid UTF-8: {e}; "
+                f"skill metadata files must be valid UTF-8 text"
+            )
 
         # Parse with python-frontmatter
         try:

--- a/skill_scanner/core/strict_structure.py
+++ b/skill_scanner/core/strict_structure.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import frontmatter
 
+from ..utils.file_utils import FileValidationError, read_text_strict
 from .exceptions import SkillValidationError
 
 
@@ -252,13 +253,14 @@ class SkillValidator:
     def _validate_frontmatter(self, skill_md_path: Path, root: Path, result: ValidationResult) -> None:
         """Parse SKILL.md frontmatter and validate fields."""
         try:
-            content = skill_md_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+            content = read_text_strict(skill_md_path)
+        except FileValidationError as exc:
             result.errors.append(
                 ValidationError(
                     code=ValidationErrorCode.FRONTMATTER_PARSE_ERROR,
                     message="Failed to read SKILL.md",
                     file_path="SKILL.md",
+                    detail=str(exc),
                 )
             )
             return

--- a/skill_scanner/utils/file_utils.py
+++ b/skill_scanner/utils/file_utils.py
@@ -21,6 +21,35 @@ File utility functions.
 from pathlib import Path
 
 
+class FileValidationError(Exception):
+    """Raised by :func:`read_text_strict` when a file is not valid UTF-8 text."""
+
+
+def read_text_strict(
+    path: Path,
+    *,
+    max_size_bytes: int | None = None,
+) -> str:
+    """Read *path* as strict UTF-8 text, rejecting binary content.
+
+    Raises :class:`FileValidationError` when the file is too large, contains
+    NUL bytes, or is not valid UTF-8.  The ``utf-8-sig`` codec is used so that
+    a leading BOM is silently stripped.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError as e:
+        raise FileValidationError(f"Failed to read {path.name}: {e}") from e
+    if max_size_bytes is not None and len(raw) > max_size_bytes:
+        raise FileValidationError(f"{path.name} exceeds maximum size ({max_size_bytes} bytes): {path}")
+    if b"\x00" in raw:
+        raise FileValidationError(f"{path.name} contains null bytes (binary content is not allowed): {path}")
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError as e:
+        raise FileValidationError(f"{path.name} is not valid UTF-8: {path} ({e})") from e
+
+
 def read_file_safe(file_path: Path, max_size_mb: int = 10) -> str | None:
     """
     Safely read a file with size limit.

--- a/tests/test_lenient_no_skillmd.py
+++ b/tests/test_lenient_no_skillmd.py
@@ -128,6 +128,25 @@ class TestLoaderLenientFallback:
 
         assert skill.name == "real-skill"
 
+    def test_lenient_fallback_binary_primary_md_raises(self, loader, tmp_path):
+        """Lenient synthesis must not load binary primary .md as an empty skill."""
+        skill_dir = tmp_path / "bin-md"
+        skill_dir.mkdir()
+        (skill_dir / "note.md").write_bytes(b"\xff\xfe")
+
+        with pytest.raises(SkillLoadError, match="not valid UTF-8"):
+            loader.load_skill(skill_dir, lenient=True)
+
+    def test_lenient_fallback_binary_secondary_md_raises(self, loader, tmp_path):
+        """All concatenated .md files must be valid UTF-8 text."""
+        skill_dir = tmp_path / "mixed-md"
+        skill_dir.mkdir()
+        (skill_dir / "a.md").write_text("# OK\n", encoding="utf-8")
+        (skill_dir / "b.md").write_bytes(b"\x00")
+
+        with pytest.raises(SkillLoadError, match="null bytes"):
+            loader.load_skill(skill_dir, lenient=True)
+
     def test_lenient_claude_code_commands_dir(self, loader, tmp_path):
         """Simulate Claude Code .claude/commands/*.md directory structure."""
         cmd_dir = tmp_path / ".claude" / "commands" / "deploy"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -239,6 +239,47 @@ def test_codex_skills_directory_structure(loader, tmp_path):
     assert file_types["assets/template.txt"] == "other"
 
 
+def test_binary_skill_md_raises_error(loader, tmp_path):
+    """A SKILL.md that is actually a binary file must hard-fail."""
+    skill_dir = tmp_path / "binary-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+    with pytest.raises(SkillLoadError, match="null bytes"):
+        loader.load_skill(skill_dir)
+
+
+def test_non_utf8_skill_md_raises_error(loader, tmp_path):
+    """A SKILL.md encoded in Latin-1 (not UTF-8) must hard-fail."""
+    skill_dir = tmp_path / "latin1-skill"
+    skill_dir.mkdir()
+    latin1_content = "---\nname: café\ndescription: résumé\n---\n# Héllo\n".encode("latin-1")
+    (skill_dir / "SKILL.md").write_bytes(latin1_content)
+
+    with pytest.raises(SkillLoadError, match="not valid UTF-8"):
+        loader.load_skill(skill_dir)
+
+
+def test_binary_skill_md_raises_in_lenient_mode(loader, tmp_path):
+    """Lenient mode must NOT swallow binary SKILL.md — the error must propagate."""
+    skill_dir = tmp_path / "lenient-binary"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+    with pytest.raises(SkillLoadError, match="null bytes"):
+        loader.load_skill(skill_dir, lenient=True)
+
+
+def test_lenient_fallback_binary_md_raises(loader, tmp_path):
+    """Lenient fallback (no SKILL.md, .md files present) must fail on binary .md."""
+    skill_dir = tmp_path / "lenient-binary-fallback"
+    skill_dir.mkdir()
+    (skill_dir / "README.md").write_bytes(b"\x00\x01\x02\x03binary junk")
+
+    with pytest.raises(SkillLoadError, match="null bytes"):
+        loader.load_skill(skill_dir, lenient=True)
+
+
 def test_referenced_files_no_false_the_py_from_english_prose(loader):
     """English 'from the …' / 'import the …' must not imply a local the.py."""
     body = "Read from the documentation for details.\n\nYou may import the module later.\n"

--- a/tests/test_robustness_features.py
+++ b/tests/test_robustness_features.py
@@ -188,6 +188,35 @@ class TestLenientLoader:
         with pytest.raises(SkillLoadError, match="No SKILL.md and no .md files found"):
             loader.load_skill(empty_dir, lenient=True)
 
+    def test_invalid_utf8_skill_md_strict_raises(self, tmp_path):
+        skill_dir = tmp_path / "bad-enc"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(b"\xff\xfe\xfd")
+
+        loader = SkillLoader()
+        with pytest.raises(SkillLoadError, match="not valid UTF-8"):
+            loader.load_skill(skill_dir)
+
+    def test_invalid_utf8_skill_md_lenient_raises(self, tmp_path):
+        skill_dir = tmp_path / "bad-enc"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(b"\xff\xfe\xfd")
+
+        loader = SkillLoader()
+        with pytest.raises(SkillLoadError, match="not valid UTF-8"):
+            loader.load_skill(skill_dir, lenient=True)
+
+    def test_null_byte_in_skill_md_raises(self, tmp_path):
+        skill_dir = tmp_path / "nul-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(
+            b"---\nname: x\ndescription: y\n---\nbody\x00tail",
+        )
+
+        loader = SkillLoader()
+        with pytest.raises(SkillLoadError, match="null bytes"):
+            loader.load_skill(skill_dir, lenient=True)
+
 
 # ============================================================================
 # Report.skills_skipped tests

--- a/tests/test_strict_structure.py
+++ b/tests/test_strict_structure.py
@@ -336,6 +336,26 @@ class TestFrontmatterValidation:
         codes = [e.code for e in result.errors]
         assert ValidationErrorCode.FRONTMATTER_PARSE_ERROR in codes
 
+    def test_null_bytes_in_skill_md_caught_in_frontmatter(self, tmp_path):
+        """NUL bytes in SKILL.md should produce a FRONTMATTER_PARSE_ERROR."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(
+            b"---\nname: my-skill\ndescription: ok\n---\nbody\x00tail",
+        )
+        result = SkillValidator().validate(skill_dir)
+        codes = [e.code for e in result.errors]
+        assert ValidationErrorCode.FRONTMATTER_PARSE_ERROR in codes
+
+    def test_non_utf8_skill_md_caught_in_frontmatter(self, tmp_path):
+        """Non-UTF-8 SKILL.md should produce a FRONTMATTER_PARSE_ERROR."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(b"\xff\xfe\xfd")
+        result = SkillValidator().validate(skill_dir)
+        codes = [e.code for e in result.errors]
+        assert ValidationErrorCode.FRONTMATTER_PARSE_ERROR in codes
+
 
 # ---------------------------------------------------------------------------
 # Integration


### PR DESCRIPTION
## Summary

- `_parse_skill_md` now reads as raw bytes and validates for null bytes and UTF-8 encoding before parsing frontmatter. Previously, a binary file named `SKILL.md` could pass through the loader unchecked.
- In lenient mode, `_synthesize_from_md_files` silently swallowed the error and produced an empty skill from binary `.md` files. Binary/encoding errors now propagate regardless of mode.
- Adds 4 tests covering: binary SKILL.md (strict), non-UTF-8 SKILL.md, binary SKILL.md (lenient), and lenient fallback with binary .md.

## Test plan

- [x] All 17 loader tests pass (4 new)
- [x] Full test suite passes (1287 tests)
- [x] Verify existing safe/malicious skill fixtures still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)