### PR TITLE
fix: reject binary skill markdown in lenient mode

### DIFF
--- a/skill_scanner/core/loader.py
+++ b/skill_scanner/core/loader.py
@@ -155,12 +155,20 @@ class SkillLoader:
         # Try to parse frontmatter from the primary file
         try:
             manifest, body = self._parse_skill_md(primary_md, lenient=True)
-        except SkillLoadError:
+        except SkillLoadError as exc:
+            message = str(exc).lower()
+            if "binary" in message or "utf-8" in message or "decode" in message or "encoding" in message:
+                raise
             # If even lenient parsing fails, use raw content
             try:
-                body = primary_md.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
-                body = ""
+                raw_bytes = primary_md.read_bytes()
+                if b"\x00" in raw_bytes:
+                    raise SkillLoadError(f"Failed to read SKILL.md: binary content detected in {primary_md}")
+                body = raw_bytes.decode("utf-8")
+            except (OSError, UnicodeDecodeError) as read_exc:
+                raise SkillLoadError(
+                    f"Failed to read SKILL.md: invalid UTF-8 in {primary_md}: {read_exc}"
+                ) from read_exc
             manifest = SkillManifest(
                 name=skill_directory.name,
                 description="(no description)",
@@ -194,10 +202,17 @@ class SkillLoader:
             SkillLoadError: If parsing fails (strict mode only)
         """
         try:
-            with open(skill_md_path, encoding="utf-8") as f:
-                content = f.read()
-        except (OSError, UnicodeDecodeError) as e:
-            raise SkillLoadError(f"Failed to read SKILL.md: {e}")
+            raw_bytes = skill_md_path.read_bytes()
+        except OSError as e:
+            raise SkillLoadError(f"Failed to read SKILL.md: {e}") from e
+
+        if b"\x00" in raw_bytes:
+            raise SkillLoadError(f"Failed to read SKILL.md: binary content detected in {skill_md_path}")
+
+        try:
+            content = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise SkillLoadError(f"Failed to read SKILL.md: invalid UTF-8 in {skill_md_path}: {e}") from e
 
         # Parse with python-frontmatter
         try:

--- a/tests/test_robustness_features.py
+++ b/tests/test_robustness_features.py
@@ -188,6 +188,33 @@ class TestLenientLoader:
         with pytest.raises(SkillLoadError, match="No SKILL.md and no .md files found"):
             loader.load_skill(empty_dir, lenient=True)
 
+    def test_binary_skill_md_raises_even_in_lenient(self, tmp_path):
+        skill_dir = tmp_path / "binary-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(b"---\nname: ok\ndescription: ok\n---\n" + b"\x00PNG\r\n")
+
+        loader = SkillLoader()
+        with pytest.raises(SkillLoadError, match="binary content"):
+            loader.load_skill(skill_dir, lenient=True)
+
+    def test_non_utf8_skill_md_raises_even_in_lenient(self, tmp_path):
+        skill_dir = tmp_path / "latin1-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes("---\nname: café\ndescription: desc\n---\nbody\n".encode("latin-1"))
+
+        loader = SkillLoader()
+        with pytest.raises(SkillLoadError, match="invalid UTF-8"):
+            loader.load_skill(skill_dir, lenient=True)
+
+    def test_lenient_fallback_does_not_swallow_binary_primary_md(self, tmp_path):
+        skill_dir = tmp_path / "fallback-binary"
+        skill_dir.mkdir()
+        (skill_dir / "README.md").write_bytes(b"\x00not-text")
+
+        loader = SkillLoader()
+        with pytest.raises(SkillLoadError, match="binary content"):
+            loader.load_skill(skill_dir, lenient=True)
+
 
 # ============================================================================
 # Report.skills_skipped tests


### PR DESCRIPTION
## Summary
- reject SKILL.md files with binary content or invalid UTF-8 before frontmatter parsing
- keep lenient mode for malformed frontmatter only, instead of swallowing binary/encoding failures
- add robustness tests covering binary SKILL.md, non-UTF-8 SKILL.md, and lenient markdown fallback on binary content

## Testing
- `uv run python -m pytest tests/test_robustness_features.py -q`
- `uv run ruff check skill_scanner/core/loader.py tests/test_robustness_features.py`
- `uv run ruff format --check skill_scanner/core/loader.py tests/test_robustness_features.py`
- `git diff --check`
