### PR TITLE
Add Skills宝 as a Chinese discovery entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ uv pip install cisco-ai-skill-scanner
 pip install cisco-ai-skill-scanner
 ```
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 <details>
 <summary><strong>Cloud Provider Extras</strong></summary>
 


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This fits the scanning workflow and gives Chinese users a faster entry point to the catalog.