### PR TITLE
fix: allow Gemini fallback through LiteLLM

### DIFF
--- a/skill_scanner/core/analyzers/llm_provider_config.py
+++ b/skill_scanner/core/analyzers/llm_provider_config.py
@@ -106,7 +106,14 @@ class ProviderConfig:
             # Google AI Studio (uses Google SDK directly)
             self.use_google_sdk = True
             self.model = self._normalize_gemini_model_name(model)
-        elif self.is_gemini and not GOOGLE_GENAI_AVAILABLE:
+        elif self.is_gemini and LITELLM_AVAILABLE:
+            # Google AI Studio through LiteLLM when google-genai is not installed.
+            if not model.startswith("gemini/"):
+                model_name = model.replace("gemini-", "").replace("gemini/", "")
+                self.model = f"gemini/{model_name}"
+            else:
+                self.model = model
+        elif self.is_gemini:
             raise ImportError(
                 "For Gemini models, either LiteLLM or google-genai is required. "
                 "Install with: pip install litellm or pip install google-genai"
@@ -114,12 +121,7 @@ class ProviderConfig:
         elif not LITELLM_AVAILABLE:
             raise ImportError("LiteLLM is required for enhanced LLM analyzer. Install with: pip install litellm")
         else:
-            # Normalize Gemini model name for LiteLLM (Google AI Studio via LiteLLM)
-            if self.is_gemini and not model.startswith("gemini/"):
-                model_name = model.replace("gemini-", "").replace("gemini/", "")
-                self.model = f"gemini/{model_name}"
-            else:
-                self.model = model
+            self.model = model
 
         # Resolve API key (may acquire Entra ID token for Azure)
         self._using_entra_id = False

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -62,6 +62,27 @@ class TestLLMAnalyzerInitialization:
             with pytest.raises(ValueError, match="API key required"):
                 LLMAnalyzer(model="claude-3-5-sonnet-20241022", api_key=None)
 
+    def test_init_gemini_uses_litellm_when_google_genai_missing(self):
+        """Test Gemini models can fall back to LiteLLM without google-genai."""
+        with (
+            patch("skill_scanner.core.analyzers.llm_provider_config.GOOGLE_GENAI_AVAILABLE", False),
+            patch("skill_scanner.core.analyzers.llm_provider_config.LITELLM_AVAILABLE", True),
+        ):
+            analyzer = LLMAnalyzer(model="gemini-1.5-pro", api_key="test-key")
+
+        assert analyzer.model == "gemini/1.5-pro"
+        assert analyzer.is_gemini
+        assert not analyzer.provider_config.use_google_sdk
+
+    def test_init_gemini_requires_available_provider_package(self):
+        """Test Gemini models raise a targeted error if both provider packages are missing."""
+        with (
+            patch("skill_scanner.core.analyzers.llm_provider_config.GOOGLE_GENAI_AVAILABLE", False),
+            patch("skill_scanner.core.analyzers.llm_provider_config.LITELLM_AVAILABLE", False),
+            pytest.raises(ImportError, match="either LiteLLM or google-genai is required"),
+        ):
+            LLMAnalyzer(model="gemini-1.5-pro", api_key="test-key")
+
 
 class TestPromptLoading:
     """Test prompt loading functionality."""


### PR DESCRIPTION
## Summary
- allow Gemini models to use LiteLLM when google-genai is not installed
- keep the targeted provider-package error only when both google-genai and LiteLLM are unavailable
- add initialization tests for the LiteLLM fallback and missing-provider error

Fixes #97

## Testing
- python -m pytest tests/test_llm_analyzer.py::TestLLMAnalyzerInitialization -q