### PR TITLE
fix: upload release assets before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       url: https://pypi.org/p/cisco-ai-skill-scanner
     permissions:
       id-token: write
-      contents: write  # needed to attach requirements.txt to the GitHub release
+      contents: write  # needed to create/update the GitHub release assets
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -53,12 +53,46 @@ jobs:
             --no-emit-project \
             --output-file release-assets/requirements.txt
 
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Check GitHub release state
+        id: release-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if gh release view "$VERSION" --json isDraft --jq '.isDraft' >/tmp/release-is-draft; then
+            is_draft="$(</tmp/release-is-draft)"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "draft=$is_draft" >> "$GITHUB_OUTPUT"
 
-      - name: Attach requirements.txt to GitHub release
+            if [[ "$is_draft" == "false" ]]; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::GitHub release $VERSION is already published. Immutable releases cannot accept new assets, so requirements.txt upload will be skipped."
+            else
+              echo "published=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attach requirements.txt to draft GitHub release
+        if: steps.release-state.outputs.published != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.version }}
           files: release-assets/requirements.txt
           fail_on_unmatched_files: true
+          draft: true
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+      - name: Publish GitHub release
+        if: steps.release-state.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: gh release edit "$VERSION" --draft=false


### PR DESCRIPTION
## Summary
- Upload `requirements.txt` to a draft GitHub release before publishing, which avoids immutable release asset failures.
- Skip GitHub asset upload when the release is already published, and make PyPI reruns tolerate existing distributions.

## Test plan
- `ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'YAML parsed successfully'\"`
- `git diff --check --cached`
- Pre-commit hooks, including `check yaml`, `detect private key`, `Detect hardcoded secrets`, and `Validate GitHub Workflows`