### PR TITLE
fix: handle space-separated strings in SkillManifest.allowed_tools

### DIFF
--- a/skill_scanner/core/models.py
+++ b/skill_scanner/core/models.py
@@ -84,9 +84,10 @@ class SkillManifest:
         if self.allowed_tools is None:
             self.allowed_tools = []
         elif isinstance(self.allowed_tools, str):
-            # Agent skill docs commonly show comma-separated tool lists in YAML frontmatter
-            # (e.g., "allowed-tools: Read, Grep, Glob"). Treat this as a list.
-            parts = [p.strip() for p in self.allowed_tools.split(",")]
+            # Agent skill docs show comma-separated or space-separated tool lists in YAML frontmatter
+            # (e.g., "allowed-tools: Read, Grep, Glob" or "allowed-tools: Read Grep Glob").
+            sep = "," if "," in self.allowed_tools else None
+            parts = [p.strip() for p in self.allowed_tools.split(sep)]
             self.allowed_tools = [p for p in parts if p]
 
     @property

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,19 @@ from datetime import datetime
 
 import pytest
 
-from skill_scanner.core.models import Finding, Report, ScanResult, Severity, ThreatCategory
+from skill_scanner.core.models import Finding, Report, ScanResult, Severity, SkillManifest, ThreatCategory
+
+
+class TestSkillManifestAllowedTools:
+    """Test SkillManifest.allowed_tools normalization."""
+
+    def test_comma_separated_string(self):
+        m = SkillManifest(name="s", description="d", allowed_tools="Read, Write, Bash")
+        assert m.allowed_tools == ["Read", "Write", "Bash"]
+
+    def test_space_separated_string(self):
+        m = SkillManifest(name="s", description="d", allowed_tools="Read Write Bash")
+        assert m.allowed_tools == ["Read", "Write", "Bash"]
 
 
 class TestFindingModel:


### PR DESCRIPTION
# Pull Request

## Description

SkillManifest.__post_init__ only split allowed_tools on commas, but the Claude Code [agent skill specification](https://code.claude.com/docs/en/skills#frontmatter-reference) documents allowed-tools as accepting a space-separated string or a YAML list. Skills using the space-separated format had their entire value treated as a single tool name, causing false-positive ALLOWED_TOOLS_BASH_VIOLATION findings even when Bash was explicitly listed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test coverage improvement

## Related Issues

N/A

## Changes Made

- skill_scanner/core/models.py: in SkillManifest.__post_init__, fall back to str.split(None) (whitespace split) when the string contains no commas
- tests/test_models.py: add TestSkillManifestAllowedTools with tests for comma-separated and space-separated string parsing

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

### Manual Testing

```bash
uv run python -m pytest tests/ -x -q
```

**Results:**
- Expected: 1300 passed, 5 skipped
- Actual: 1300 passed, 5 skipped

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [ ] Type hints added where applicable
- [ ] Docstrings added/updated for public APIs
- [ ] No hardcoded credentials or secrets
- [ ] Error handling is comprehensive
- [ ] Logging is appropriate

### Documentation
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] CHANGELOG updated
- [ ] Code comments added for complex logic

### Security
- [x] No new security vulnerabilities introduced
- [ ] Input validation added where needed
- [x] Follows security best practices from workspace rules
- [ ] No eval/exec on user input without sanitization

### Testing
- [x] Tests pass: `uv run pre-commit run --all-files`
- [ ] Benchmark passes: `uv run python evals/runners/benchmark_runner.py`
- [x] No regressions in existing functionality
- [x] Edge cases covered

## Performance Impact

- [x] No significant performance regression
- [ ] Performance benchmarks run (if applicable)
- [ ] Resource usage is acceptable

## Screenshots (if applicable)

Add screenshots or output examples if relevant.

## Additional Notes

YAML lists arrive as a Python list and bypass this branch entirely, so that path is unaffected.

## Reviewer Checklist

For reviewers:
- [ ] Code changes are clear and well-documented
- [ ] Tests are comprehensive
- [ ] No security issues introduced
- [ ] Performance is acceptable
- [ ] Documentation is updated
