### PR TITLE
fix(api): return validation errors for malformed skills

### DIFF
--- a/docs/user-guide/api-endpoints-detail.md
+++ b/docs/user-guide/api-endpoints-detail.md
@@ -151,6 +151,9 @@ API keys (`X-VirusTotal-Key`, `X-AIDefense-Key`) are passed as request headers, 
 
 **Response:** Same as `/scan`
 
+Malformed skill metadata, such as a `SKILL.md` missing required fields, returns `422` with
+an actionable validation message instead of a generic server error.
+
 ## Batch Scan (Async)
 
 ```http
@@ -303,5 +306,5 @@ GET /analyzers
 | 400 | Invalid request | Check JSON format and required fields |
 | 404 | Skill not found | Verify directory path exists |
 | 413 | Upload too large | Reduce ZIP size below upload limit |
-| 422 | Validation error | Check field names/types in request body |
+| 422 | Validation error | Check field names/types in request body or required `SKILL.md` metadata fields |
 | 500 | Scan failed | Check logs for detailed error |

--- a/skill_scanner/api/router.py
+++ b/skill_scanner/api/router.py
@@ -44,6 +44,7 @@ except ImportError:
 
 from .. import __version__ as PACKAGE_VERSION
 from ..core.analyzer_factory import build_analyzers
+from ..core.exceptions import SkillLoadError
 from ..core.scan_policy import ScanPolicy
 from ..core.scanner import SkillScanner
 
@@ -269,6 +270,12 @@ def _resolve_policy(policy_str: str | None) -> ScanPolicy:
     raise ValueError(f"Unknown policy '{policy_str}'. Use a preset name or a path to a YAML file.")
 
 
+def _skill_load_error_detail(error: SkillLoadError, skill_dir: Path) -> str:
+    """Return client-safe validation detail for skill loading failures."""
+    detail = str(error).replace(str(skill_dir), "skill directory")
+    return f"Invalid skill package: {detail}"
+
+
 def _build_analyzers(
     policy: ScanPolicy,
     *,
@@ -464,6 +471,8 @@ async def scan_skill(
             findings=[f.to_dict() for f in result.findings],
         )
 
+    except SkillLoadError as e:
+        raise HTTPException(status_code=422, detail=_skill_load_error_detail(e, skill_dir)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -478,6 +478,25 @@ class TestUploadEndpoint:
         response = client.post("/scan-upload", files=files, data=data)
         assert response.status_code == 422
 
+    def test_upload_malformed_skill_returns_validation_error(self, client):
+        """Test malformed skill metadata returns a validation error."""
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(
+                "bad-skill/SKILL.md",
+                "---\ndescription: Missing required name field\n---\nDo something useful.\n",
+            )
+
+        zip_buffer.seek(0)
+        files = {"file": ("skill.zip", zip_buffer, "application/zip")}
+
+        response = client.post("/scan-upload", files=files)
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert "Invalid skill package" in detail
+        assert "name" in detail
+
 
 # =============================================================================
 # Error Handling Tests


### PR DESCRIPTION
## Summary

- Map `SkillLoadError` from the scanner loader to HTTP 422 in the FastAPI router instead of allowing it to fall through to the generic HTTP 500 handler.
- Redact the resolved skill directory from validation details so upload temp paths are not exposed to API clients.
- Add a regression test for `/scan-upload` with malformed `SKILL.md` metadata, and document the 422 behavior for malformed skill packages.

## Problem

Downstream API callers currently cannot distinguish a malformed skill package from an unexpected scanner/server failure. For example, a ZIP containing a `SKILL.md` with `description` but no required `name` field raises `SkillLoadError` from the loader. The router catches only `ValueError` before the broad `Exception` handler, so the client receives:

```json
{\"detail\":\"Internal scan error\"}
```

That makes UI and CI integrations show opaque server errors even though the user can fix the submitted skill metadata. This came up while integrating `cisco-ai-skill-scanner` in `cnoe-io/ai-platform-engineering` and led to a temporary downstream image patch there.

## Downstream usage

This is needed by [cnoe-io/ai-platform-engineering](https://github.com/cnoe-io/ai-platform-engineering), which packages `cisco-ai-skill-scanner` as the `skill-scanner` service used by its skills UI and catalog flows. In that platform, users can upload or generate Agent Skills from the UI, and the backend sends the packaged skill ZIP to this service `/scan-upload` endpoint before accepting the skill.

When a generated or uploaded `SKILL.md` is malformed, such as missing the required `name` field, CAIPE needs to show actionable validation feedback to the user. With the current upstream behavior, the same user-correctable input error becomes an HTTP 500 and appears as a scanner/server failure. CAIPE currently carries a temporary image-local patch for this behavior; once this fix is released upstream, that downstream patch can be removed and CAIPE can consume the fixed `cisco-ai-skill-scanner` package directly.

## Approach

The change treats loader failures as client validation failures:

- `SkillLoadError` now returns HTTP 422 with `Invalid skill package: ...` detail.
- `ValueError` continues to return HTTP 400 for policy/request setup problems.
- Unexpected exceptions still return HTTP 500 and continue to be logged server-side.
- The helper replaces the resolved skill directory path with `skill directory` before returning the detail to avoid leaking upload extraction paths.

## Test plan

- [x] Added failing regression coverage first:
  - `uv run pytest tests/test_api_endpoints.py::TestUploadEndpoint::test_upload_malformed_skill_returns_validation_error -q`
  - Initially failed with `500 == 422`.
- [x] Verified the targeted regression passes after the fix:
  - `uv run pytest tests/test_api_endpoints.py::TestUploadEndpoint::test_upload_malformed_skill_returns_validation_error -q`
- [x] Ran API endpoint suite:
  - `uv run pytest tests/test_api_endpoints.py -q`
  - `62 passed, 1 skipped`
- [x] Ran full test suite:
  - `uv run pytest tests/ -q`
  - `1301 passed, 5 skipped`
- [x] Ran lint and pre-commit:
  - `uv run ruff check .`
  - `uv run pre-commit run --all-files`