### PR TITLE
fix: add minimax to unsupported_json_schema_providers

### DIFF
--- a/skill_scanner/core/analyzers/llm_request_handler.py
+++ b/skill_scanner/core/analyzers/llm_request_handler.py
@@ -173,7 +173,7 @@ class LLMRequestHandler:
             return True
 
         model_lower = self.provider_config.model.lower()
-        unsupported_json_schema_providers = ["deepseek"]
+        unsupported_json_schema_providers = ["deepseek", "minimax"]
         return any(name in model_lower for name in unsupported_json_schema_providers)
 
     def _build_response_format(self) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary

LiteLLM's `response_format=json_schema` is not supported by the MiniMax API, causing LLM analysis to fail when MiniMax is used as the scan provider.

This PR adds `minimax` to `unsupported_json_schema_providers` in `llm_request_handler.py`, following the existing pattern already used for `deepseek`. The scanner will then use `json_object` mode instead of `json_schema` when the model name contains "minimax".

## Change

```diff
- unsupported_json_schema_providers = ["deepseek"]
+ unsupported_json_schema_providers = ["deepseek", "minimax"]
```

## Testing

- Scanned multiple skills using MiniMax M2.5 via LiteLLM — LLM analysis completes without json_schema errors