### PR TITLE
Fix/issue 114 parser error colon

### DIFF
--- a/skill_scanner/core/loader.py
+++ b/skill_scanner/core/loader.py
@@ -18,6 +18,7 @@
 Skill package loader and SKILL.md parser.
 """
 
+import json
 import logging
 import re
 import sys
@@ -32,6 +33,11 @@ from .models import Skill, SkillFile, SkillManifest
 logger = logging.getLogger(__name__)
 
 _FRONTMATTER_QUOTE_RE = re.compile(r'^(description|name):[^\S\n]+(?!["\'])(.*:.*)$', re.MULTILINE)
+
+
+def _quote_frontmatter_scalar(match: re.Match[str]) -> str:
+    """Quote a YAML scalar while preserving literal backslashes and quotes."""
+    return f"{match.group(1)}: {json.dumps(match.group(2), ensure_ascii=False)}"
 
 
 class SkillLoader:
@@ -197,10 +203,7 @@ class SkillLoader:
         if "---" in content:
             parts = content.split("---", 2)
             if len(parts) >= 3:
-                fm = _FRONTMATTER_QUOTE_RE.sub(
-                    lambda m: f'{m.group(1)}: "{m.group(2).replace(chr(34), chr(92) + chr(34))}"',
-                    parts[1],
-                )
+                fm = _FRONTMATTER_QUOTE_RE.sub(_quote_frontmatter_scalar, parts[1])
                 content = f"---{fm}---{parts[2]}"
 
         # Parse with python-frontmatter

--- a/skill_scanner/core/loader.py
+++ b/skill_scanner/core/loader.py
@@ -31,6 +31,8 @@ from .models import Skill, SkillFile, SkillManifest
 
 logger = logging.getLogger(__name__)
 
+_FRONTMATTER_QUOTE_RE = re.compile(r'^(description|name):[^\S\n]+(?!["\'])(.*:.*)$', re.MULTILINE)
+
 
 class SkillLoader:
     """Loads and parses Agent Skill packages.
@@ -191,6 +193,15 @@ class SkillLoader:
             SkillLoadError: If parsing fails (strict mode only)
         """
         content = self._read_skill_text_file(skill_md_path)
+
+        if "---" in content:
+            parts = content.split("---", 2)
+            if len(parts) >= 3:
+                fm = _FRONTMATTER_QUOTE_RE.sub(
+                    lambda m: f'{m.group(1)}: "{m.group(2).replace(chr(34), chr(92) + chr(34))}"',
+                    parts[1],
+                )
+                content = f"---{fm}---{parts[2]}"
 
         # Parse with python-frontmatter
         try:

--- a/tests/test_robustness_features.py
+++ b/tests/test_robustness_features.py
@@ -180,6 +180,56 @@ class TestLenientLoader:
         skill = loader.load_skill(tmp_path / "dict-name")
         assert isinstance(skill.name, str)
 
+    def test_colon_in_description_value(self, tmp_path):
+        """Description values containing ': ' should not crash the YAML parser."""
+        _write_skill_md(
+            tmp_path / "colon-desc",
+            """\
+            ---
+            name: colon-skill
+            description: This does X: more text here
+            ---
+            body
+            """,
+        )
+        loader = SkillLoader()
+        skill = loader.load_skill(tmp_path / "colon-desc")
+        assert skill.name == "colon-skill"
+        assert "more text" in skill.description
+
+    def test_colon_in_name_value(self, tmp_path):
+        """Name values containing ': ' should not crash the YAML parser."""
+        _write_skill_md(
+            tmp_path / "colon-name",
+            """\
+            ---
+            name: evil: skill
+            description: test
+            ---
+            body
+            """,
+        )
+        loader = SkillLoader()
+        skill = loader.load_skill(tmp_path / "colon-name")
+        assert "evil" in skill.name
+
+    def test_colon_with_embedded_quotes(self, tmp_path):
+        """Value with both ': ' and embedded double quotes should round-trip."""
+        _write_skill_md(
+            tmp_path / "colon-quote",
+            """\
+            ---
+            name: test
+            description: He said "hello": then left
+            ---
+            body
+            """,
+        )
+        loader = SkillLoader()
+        skill = loader.load_skill(tmp_path / "colon-quote")
+        assert "hello" in skill.description
+        assert "then left" in skill.description
+
     def test_no_skill_md_still_raises_in_lenient(self, tmp_path):
         """Even in lenient mode, a completely empty dir (no .md files) is fatal."""
         empty_dir = tmp_path / "empty"

--- a/tests/test_robustness_features.py
+++ b/tests/test_robustness_features.py
@@ -230,6 +230,23 @@ class TestLenientLoader:
         assert "hello" in skill.description
         assert "then left" in skill.description
 
+    def test_colon_value_with_backslashes(self, tmp_path):
+        """Auto-quoted values must preserve literal backslashes."""
+        _write_skill_md(
+            tmp_path / "colon-backslash",
+            """\
+            ---
+            name: test
+            description: Windows path C:\\temp\\data: keep backslashes
+            ---
+            body
+            """,
+        )
+        loader = SkillLoader()
+        skill = loader.load_skill(tmp_path / "colon-backslash")
+        assert "C:\\temp\\data" in skill.description
+        assert "keep backslashes" in skill.description
+
     def test_no_skill_md_still_raises_in_lenient(self, tmp_path):
         """Even in lenient mode, a completely empty dir (no .md files) is fatal."""
         empty_dir = tmp_path / "empty"


### PR DESCRIPTION
# Pull Request

## Description

Unquoted : characters in description or name YAML frontmatter values cause PyYAML to throw ScannerError: mapping values are not allowed here, crashing frontmatter.loads() before metadata is returned. In strict mode the skill refuses to load entirely; in lenient mode all frontmatter is silently discarded.
Example trigger:
---
name: my-skill
description: This does X: more text here
---
Root cause: PyYAML (YAML 1.1) interprets :  as an implicit mapping key separator inside a scalar value. The fix auto-quotes affected values before frontmatter.loads() runs, transparent to downstream consumers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Closes #114

## Changes Made

- skill_scanner/core/loader.py — Added module-level regex _FRONTMATTER_QUOTE_RE matching description: / name: lines with unquoted colon-containing values. Added pre-processing block in _parse_skill_md() that isolates the YAML frontmatter block, applies the regex to auto-quote affected values (escaping embedded " to \"), and reconstructs the content before frontmatter.loads(). Already-quoted values, block mappings, and metadata: are untouched.
- tests/test_robustness_features.py — 3 new test cases covering colon in description, colon in name, and colon with embedded double-quotes.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Test coverage maintained or improved
- [ ] All tests pass locally
- [x] All relevant tests pass locally (51/51 in test_robustness_features.py, 3/3 new colon tests). 
      Pre-existing Windows-only failures (symlink admin rights, `\` path separator) are unrelated 
      and pass on Linux CI.

### Manual Testing

# Before fix — all 3 colon tests fail
.venv\Scripts\python.exe -m pytest tests/test_robustness_features.py -v -k "colon"

# After fix — all 3 colon tests pass
.venv\Scripts\python.exe -m pytest tests/test_robustness_features.py -v -k "colon"

# Full robustness suite — all 51 pass
.venv\Scripts\python.exe -m pytest tests/test_robustness_features.py -v

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Type hints added where applicable
- [ ] Docstrings added/updated for public APIs
- [x] No hardcoded credentials or secrets
- [x] Error handling is comprehensive
- [ ] Logging is appropriate

### Documentation
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] CHANGELOG updated
- [ ] Code comments added for complex logic

### Security
- [x] No new security vulnerabilities introduced
- [x] Input validation added where needed
- [x] Follows security best practices from workspace rules
- [ ] No eval/exec on user input without sanitization

### Testing
- [ ] Tests pass: `uv run pre-commit run --all-files`
- [x] Benchmark passes: `uv run python evals/runners/benchmark_runner.py`
- [x] No regressions in existing functionality
- [x] Edge cases covered

## Performance Impact

- [x] No significant performance regression
- [ ] Performance benchmarks run (if applicable)
- [x] Resource usage is acceptable

## Screenshots (if applicable)

<img width="989" height="394" alt="Screenshot 2026-06-06 010335" src="https://github.com/user-attachments/assets/f7333c17-ffac-44f6-9817-2cdf9e2bc66c" />
(before; 3 added test cases fail)
<img width="1380" height="272" alt="Screenshot 2026-06-06 021044" src="https://github.com/user-attachments/assets/e4a24908-e04b-499a-92e3-1fd1b2c5f606" />
(after; all required testcases pass including new ones)

## Additional Notes

Any additional information reviewers should know.

## Reviewer Checklist

For reviewers:
- [ ] Code changes are clear and well-documented
- [ ] Tests are comprehensive
- [ ] No security issues introduced
- [ ] Performance is acceptable
- [ ] Documentation is updated
