### PR TITLE
fix(sarif): emit scan-root-relative artifact URIs

### DIFF
--- a/skill_scanner/core/reporters/sarif_reporter.py
+++ b/skill_scanner/core/reporters/sarif_reporter.py
@@ -22,6 +22,8 @@ https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
 """
 
 import json
+import os
+from pathlib import Path
 from typing import Any
 
 from ...core.models import Finding, Report, ScanResult, Severity
@@ -74,7 +76,7 @@ class SARIFReporter:
     def _generate_from_scan_result(self, result: ScanResult) -> dict[str, Any]:
         """Generate SARIF from a single ScanResult."""
         rules = self._extract_rules(result.findings)
-        results = self._convert_findings(result.findings)
+        results = self._convert_findings(result.findings, result.skill_directory)
 
         return {
             "$schema": self.SARIF_SCHEMA,
@@ -105,7 +107,7 @@ class SARIFReporter:
         # Create results with proper artifact locations
         all_results = []
         for scan_result in report.scan_results:
-            results = self._convert_findings(scan_result.findings)
+            results = self._convert_findings(scan_result.findings, scan_result.skill_directory)
             all_results.extend(results)
         all_results.extend(self._convert_findings(report.cross_skill_findings))
 
@@ -176,7 +178,37 @@ class SARIFReporter:
 
         return rules
 
-    def _convert_findings(self, findings: list[Finding]) -> list[dict[str, Any]]:
+    @staticmethod
+    def _artifact_uri(finding: Finding, skill_directory: str | None) -> str:
+        """Build the artifact URI for a finding, relative to the scan root.
+
+        Finding.file_path is relative to the skill's own directory. GitHub Code
+        Scanning resolves URIs against %SRCROOT% (the repository root), so when
+        skills are discovered in subdirectories the skill path must be included
+        for results to be tied to files in a PR. The scanner's working directory
+        is taken as the scan root; when the skill directory lies outside it
+        (or on a different drive), the skill-relative path is kept as before.
+        """
+        file_path = finding.file_path if finding.file_path else "SKILL.md"
+        if not skill_directory or Path(file_path).is_absolute():
+            return Path(file_path).as_posix()
+
+        try:
+            skill_rel = os.path.relpath(skill_directory, os.getcwd())
+        except ValueError:
+            # Windows: skill directory and CWD on different drives
+            return Path(file_path).as_posix()
+
+        if skill_rel == os.curdir:
+            return Path(file_path).as_posix()
+        if skill_rel == os.pardir or skill_rel.startswith(os.pardir + os.sep):
+            # Skill directory is outside the scan root; a %SRCROOT%-relative
+            # path cannot be formed, and ".." segments are invalid in SARIF.
+            return Path(file_path).as_posix()
+
+        return (Path(skill_rel) / file_path).as_posix()
+
+    def _convert_findings(self, findings: list[Finding], skill_directory: str | None = None) -> list[dict[str, Any]]:
         """Convert findings to SARIF results."""
         results = []
 
@@ -194,7 +226,7 @@ class SARIFReporter:
                 },
             }
 
-            artifact_uri = finding.file_path if finding.file_path else "SKILL.md"
+            artifact_uri = self._artifact_uri(finding, skill_directory)
             location: dict[str, Any] = {
                 "physicalLocation": {
                     "artifactLocation": {

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -239,3 +239,70 @@ def test_sarif_reporter_multi_skill_github_compat(report: Report):
     for result in results:
         assert "locations" in result
         assert "fixes" not in result
+
+
+def _result_uris(sarif_output: str) -> list[str]:
+    data = json.loads(sarif_output)
+    return [
+        result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"] for result in data["runs"][0]["results"]
+    ]
+
+
+def test_sarif_reporter_uri_includes_skill_subpath_inside_scan_root(tmp_path, monkeypatch):
+    """URIs must be scan-root-relative so GitHub ties results to PR files (issue #107)."""
+    monkeypatch.chdir(tmp_path)
+    skill_dir = tmp_path / "plugins" / "hello-world" / "skills" / "hello-world"
+
+    result = ScanResult(
+        skill_name="hello-world",
+        skill_directory=str(skill_dir),
+        findings=_sample_findings(),
+        scan_duration_seconds=0.1,
+        analyzers_used=["static"],
+        timestamp=datetime(2026, 1, 2, 3, 4, 5),
+    )
+
+    uris = _result_uris(SARIFReporter().generate_report(result))
+
+    prefix = "plugins/hello-world/skills/hello-world"
+    assert f"{prefix}/scripts/decoder.py" in uris
+    assert f"{prefix}/SKILL.md" in uris
+    for uri in uris:
+        assert ".." not in uri
+        assert "\\" not in uri
+
+
+def test_sarif_reporter_uri_in_report_is_prefixed_per_skill(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    first = ScanResult(
+        skill_name="alpha",
+        skill_directory=str(tmp_path / "skills" / "alpha"),
+        findings=[_sample_findings()[2]],  # SKILL.md finding
+        timestamp=datetime(2026, 1, 2, 3, 4, 5),
+    )
+    second = ScanResult(
+        skill_name="beta",
+        skill_directory=str(tmp_path / "skills" / "beta"),
+        findings=[_sample_findings()[2]],
+        timestamp=datetime(2026, 1, 2, 3, 5, 0),
+    )
+
+    aggregate = Report(timestamp=datetime(2026, 1, 2, 3, 6, 0))
+    aggregate.add_scan_result(first)
+    aggregate.add_scan_result(second)
+
+    uris = _result_uris(SARIFReporter().generate_report(aggregate))
+
+    assert "skills/alpha/SKILL.md" in uris
+    assert "skills/beta/SKILL.md" in uris
+
+
+def test_sarif_reporter_uri_unchanged_when_skill_outside_scan_root(scan_result: ScanResult):
+    """Skills outside the working directory keep skill-relative URIs (no ".." segments)."""
+    uris = _result_uris(SARIFReporter().generate_report(scan_result))
+
+    assert "SKILL.md" in uris
+    assert "scripts/decoder.py" in uris
+    for uri in uris:
+        assert ".." not in uri


### PR DESCRIPTION
﻿# Pull Request

## Description

SARIF reports emitted only the skill-relative file path (often just `SKILL.md`) in `results[].locations[].physicalLocation.artifactLocation.uri`. When skills are discovered in subdirectories (`scan-all <dir> --recursive`), GitHub Code Scanning resolves URIs against `%SRCROOT%` (the repository root), so it cannot tie results to files changed in a PR.

This PR makes the SARIF reporter prefix each finding's path with the skill's directory, relativized against the scanner's working directory (the scan root), emitting POSIX separators. Example: `SKILL.md` becomes `plugins/hello-world/skills/hello-world/SKILL.md`.

When the skill directory lies outside the working directory (or on a different Windows drive), the previous skill-relative URI is kept, since `..` segments are invalid in SARIF artifact locations and no `%SRCROOT%`-relative path can be formed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #107

## Changes Made

- `skill_scanner/core/reporters/sarif_reporter.py`: added `_artifact_uri()` helper; `_convert_findings()` now accepts the skill directory and builds scan-root-relative URIs; both `_generate_from_scan_result()` and `_generate_from_report()` pass `ScanResult.skill_directory` through (cross-skill findings are unchanged).
- `tests/test_reporters.py`: three new tests covering skills inside the scan root (single result and multi-skill report) and the fallback for skills outside the scan root; asserts no `..` segments and no backslashes in URIs.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing

```bash
uv run pytest tests/test_reporters.py -v   # 14 passed (11 existing + 3 new)
uv run pytest tests/ -q                    # 263 passed, 1 skipped; 1 pre-existing failure in
                                           # test_bytecode_analyzer.py reproduces identically on
                                           # clean main (verified via git stash), unrelated to this change
uv run pre-commit run --files skill_scanner/core/reporters/sarif_reporter.py tests/test_reporters.py  # all hooks pass
```

**Results:**
- Expected: SARIF `artifactLocation.uri` contains the path relative to the scan root for recursively discovered skills.
- Actual: URIs now include the skill subpath (e.g. `skills/alpha/SKILL.md`); previous behavior preserved for out-of-tree skills.

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Type hints added where applicable
- [x] Docstrings added/updated for public APIs
- [x] No hardcoded credentials or secrets
- [x] Error handling is comprehensive
- [x] Logging is appropriate

### Security
- [x] No new security vulnerabilities introduced
- [x] Follows security best practices from workspace rules

### Testing
- [x] Tests pass: `uv run pre-commit run --all-files`
- [x] Benchmark passes: `uv run python evals/runners/benchmark_runner.py` (100% accuracy/precision/recall/F1 — reporter-only change, no analyzer or detection behavior affected)
- [x] No regressions in existing functionality
- [x] Edge cases covered

## Performance Impact

- [x] No significant performance regression
