### PR TITLE
fix: count JavaScript/TypeScript as analyzable in analyzability scoring

### DIFF
--- a/skill_scanner/core/analyzability.py
+++ b/skill_scanner/core/analyzability.py
@@ -86,36 +86,6 @@ class AnalyzabilityReport:
 # analyzer, so they are fully inspectable, not opaque.
 _ANALYZABLE_TYPES = {"python", "bash", "javascript", "typescript", "markdown", "other"}
 
-# Extensions we can analyze as text
-_TEXT_EXTENSIONS = {
-    ".py",
-    ".sh",
-    ".bash",
-    ".rb",
-    ".pl",
-    ".js",
-    ".ts",
-    ".php",
-    ".md",
-    ".markdown",
-    ".txt",
-    ".rst",
-    ".json",
-    ".yaml",
-    ".yml",
-    ".xml",
-    ".html",
-    ".css",
-    ".toml",
-    ".cfg",
-    ".ini",
-    ".conf",
-    ".csv",
-    ".env",
-    ".gitignore",
-    ".dockerignore",
-}
-
 # Extensions that are inert (viewable but no executable concern)
 _INERT_EXTENSIONS = {
     ".png",

--- a/skill_scanner/core/analyzability.py
+++ b/skill_scanner/core/analyzability.py
@@ -80,8 +80,11 @@ class AnalyzabilityReport:
         }
 
 
-# File types we can fully analyze
-_ANALYZABLE_TYPES = {"python", "bash", "markdown", "other"}
+# File types we can fully analyze. Must stay in sync with the file_type values
+# emitted by utils.file_utils.get_file_type -- JavaScript/TypeScript get their
+# own static rule sets (see analyzers/static.py) and are read by the LLM
+# analyzer, so they are fully inspectable, not opaque.
+_ANALYZABLE_TYPES = {"python", "bash", "javascript", "typescript", "markdown", "other"}
 
 # Extensions we can analyze as text
 _TEXT_EXTENSIONS = {

--- a/tests/test_analyzability.py
+++ b/tests/test_analyzability.py
@@ -104,6 +104,38 @@ class TestAnalyzabilityScoring:
         report = compute_analyzability(skill)
         assert report.score == 100.0
 
+    def test_javascript_is_analyzable(self, tmp_path):
+        """JS/TS files are scanned (static JS rule sets + LLM), so they must not
+        count as opaque. Regression for the analyzability scorer falling out of
+        sync with get_file_type after JS/TS got their own file_type."""
+        skill = _make_skill(
+            tmp_path,
+            {
+                "scripts/search.js": ("javascript", "const x = fetch('https://api');"),
+                "scripts/index.ts": ("typescript", "const y: number = 1;"),
+                "README.md": ("markdown", "# Readme"),
+            },
+        )
+        report = compute_analyzability(skill)
+        assert report.score == 100.0
+        assert report.unanalyzable_files == 0
+        assert report.risk_level == "LOW"
+
+    def test_javascript_does_not_lower_score_with_binary(self, tmp_path):
+        """A large JS file alongside a real binary: only the binary should be
+        opaque. Guards against a JS file being wrongly counted as the sole
+        opaque file and dragging the score below the MEDIUM threshold."""
+        skill = _make_skill(
+            tmp_path,
+            {
+                "scripts/search.js": ("javascript", "x" * 8000),
+                "data/blob.bin": ("binary", None),
+            },
+        )
+        report = compute_analyzability(skill)
+        unanalyzable = {fd.relative_path for fd in report.file_details if not fd.is_analyzable}
+        assert unanalyzable == {"data/blob.bin"}
+
     def test_empty_skill_100_percent(self, tmp_path):
         """Skill with no files should be 100%."""
         skill = _make_skill(tmp_path, {})


### PR DESCRIPTION
# Pull Request

## Description

JS/TS files were getting scored as opaque because `_ANALYZABLE_TYPES` was missing
the `"javascript"` and `"typescript"` file_type strings that `get_file_type`
emits for `.js`/`.mjs`/`.cjs`/`.ts`/`.tsx`. Those files are actually fully
inspectable (they have their own static rule sets and get read by the LLM
analyzer), so scoring them as opaque threw false `LOW_ANALYZABILITY` findings
and dragged down the score on any skill with much JS or TS in it.

This adds both types to `_ANALYZABLE_TYPES` and leaves a comment tying the set
back to `get_file_type`, so it won't quietly drift again the next time a new
file_type gets split out of `"other"`.

Tests cover a pure JS/TS skill (scores 100%, nothing opaque) and a JS file
sitting next to a real binary (only the binary is opaque).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Test coverage improvement

## Related Issues

N/A — no tracking issue.

## Changes Made

- Added `"javascript"` and `"typescript"` to `_ANALYZABLE_TYPES` in
  `skill_scanner/core/analyzability.py` so JS/TS source files count as
  inspectable rather than opaque.
- Added a comment on `_ANALYZABLE_TYPES` documenting that it must stay in sync
  with the file_type values emitted by `utils.file_utils.get_file_type`.
- Added two regression tests in `tests/test_analyzability.py`.
- Removed the unused `_TEXT_EXTENSIONS` set from the same module: it was
  referenced nowhere (analyzability is decided by file_type, not by this
  extension list) and misleadingly implied an extension allowlist that does
  not exist.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing

Reproduced against JS/TS-heavy skills before and after the change:

```bash
uv run pytest tests/test_analyzability.py -v
uv run python evals/runners/benchmark_runner.py
```

**Results:**
- Expected: JS/TS files no longer flagged opaque; affected skills return to a
  100% analyzability score with 0 opaque files.
- Actual: matches. Skills that previously scored MEDIUM/HIGH (roughly 70–79%)
  solely because a `.js`/`.mjs` file was counted opaque now return
  score=100.0 / risk=LOW / 0 opaque. The detection benchmark held at 100%
  accuracy/precision/recall/F1.

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Type hints added where applicable
- [ ] Docstrings added/updated for public APIs
- [x] No hardcoded credentials or secrets
- [ ] Error handling is comprehensive
- [ ] Logging is appropriate

### Documentation
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] CHANGELOG updated
- [x] Code comments added for complex logic

### Security
- [x] No new security vulnerabilities introduced
- [ ] Input validation added where needed
- [x] Follows security best practices from workspace rules
- [x] No eval/exec on user input without sanitization

### Testing
- [x] Tests pass: `uv run pre-commit run --all-files`
- [x] Benchmark passes: `uv run python evals/runners/benchmark_runner.py`
- [x] No regressions in existing functionality
- [x] Edge cases covered

## Performance Impact

- [x] No significant performance regression
- [ ] Performance benchmarks run (if applicable)
- [x] Resource usage is acceptable

## Screenshots (if applicable)

N/A

## Additional Notes

The core change is a one-line set membership fix plus a guard comment; no public
API, signature, or behavior changes beyond JS/TS files now being scored as
analyzable. This PR also includes a second commit removing the unrelated dead
`_TEXT_EXTENSIONS` set in the same module (no behavior change).

## Reviewer Checklist

For reviewers:
- [ ] Code changes are clear and well-documented
- [ ] Tests are comprehensive
- [ ] No security issues introduced
- [ ] Performance is acceptable
- [ ] Documentation is updated
