### PR TITLE
feat(llm): allow temperature override + omit for newer Claude/o1 models

### DIFF
--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
@@ -29,7 +29,9 @@ The client manages:
 import asyncio
 import logging
 import os
+from typing import Any
 
+from ...llm_request_handler import _TEMPERATURE_UNSET, _resolve_temperature
 from ...llm_request_options import resolve_llm_user, supports_openai_user_param
 
 try:
@@ -63,7 +65,7 @@ class AlignmentLLMClient:
         base_url: str | None = None,
         api_version: str | None = None,
         llm_user: str | None = None,
-        temperature: float = 0.1,
+        temperature: Any = _TEMPERATURE_UNSET,
         max_tokens: int = 4096,
         timeout: int = 120,
     ):
@@ -75,7 +77,11 @@ class AlignmentLLMClient:
             base_url: Optional base URL for API
             api_version: Optional API version
             llm_user: Optional raw Chat Completions user field for OpenAI-compatible routes
-            temperature: Temperature for responses
+            temperature: Temperature for responses.  Pass ``None`` to omit
+                ``temperature`` from the request - required for models that
+                reject it (Claude 4.x via Bedrock, OpenAI o1-series).
+                When omitted, resolves from ``SKILL_SCANNER_LLM_TEMPERATURE``
+                (numeric value or ``"none"``).
             max_tokens: Max tokens for responses
             timeout: Request timeout in seconds
 
@@ -97,7 +103,7 @@ class AlignmentLLMClient:
         self._api_version = api_version
         self._provider = os.getenv("SKILL_SCANNER_LLM_PROVIDER")
         self._llm_user = resolve_llm_user(llm_user)
-        self._temperature = temperature
+        self._temperature = _resolve_temperature(temperature, "SKILL_SCANNER_LLM_TEMPERATURE", default=0.1)
         self._max_tokens = max_tokens
         self._timeout = timeout
 
@@ -209,9 +215,10 @@ class AlignmentLLMClient:
                     {"role": "user", "content": prompt},
                 ],
                 "max_tokens": self._max_tokens,
-                "temperature": self._temperature,
                 "timeout": self._timeout,
             }
+            if self._temperature is not None:
+                request_params["temperature"] = self._temperature
 
             # Add API key if available
             if self._api_key:

--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
@@ -30,6 +30,7 @@ import logging
 from typing import Any
 
 from .....core.static_analysis.context_extractor import SkillFunctionContext
+from ...llm_request_handler import _TEMPERATURE_UNSET
 from .alignment_llm_client import AlignmentLLMClient
 from .alignment_prompt_builder import AlignmentPromptBuilder
 from .alignment_response_validator import AlignmentResponseValidator
@@ -54,7 +55,7 @@ class AlignmentOrchestrator:
         llm_model: str = "gemini/gemini-2.0-flash",
         llm_api_key: str | None = None,
         llm_base_url: str | None = None,
-        llm_temperature: float = 0.1,
+        llm_temperature: Any = _TEMPERATURE_UNSET,
         llm_max_tokens: int = 4096,
         llm_timeout: int = 120,
     ):

--- a/skill_scanner/core/analyzers/llm_analyzer.py
+++ b/skill_scanner/core/analyzers/llm_analyzer.py
@@ -40,7 +40,7 @@ from ...threats.threats import ThreatMapping
 from .base import BaseAnalyzer
 from .llm_prompt_builder import PromptBuilder
 from .llm_provider_config import ProviderConfig
-from .llm_request_handler import LLMRequestHandler
+from .llm_request_handler import _TEMPERATURE_UNSET, LLMRequestHandler
 from .llm_response_parser import ResponseParser
 
 if TYPE_CHECKING:
@@ -127,7 +127,7 @@ class LLMAnalyzer(BaseAnalyzer):
         model: str | None = None,
         api_key: str | None = None,
         max_tokens: int = 8192,
-        temperature: float = 0.0,
+        temperature: Any = _TEMPERATURE_UNSET,
         max_retries: int = 3,
         rate_limit_delay: float = 2.0,
         timeout: int = 120,
@@ -151,7 +151,12 @@ class LLMAnalyzer(BaseAnalyzer):
             model: Model identifier (e.g., "claude-3-5-sonnet-20241022", "gpt-4o", "bedrock/anthropic.claude-v2")
             api_key: API key (if None, reads from environment)
             max_tokens: Maximum tokens for response
-            temperature: Sampling temperature (0.0 for deterministic)
+            temperature: Sampling temperature (0.0 for deterministic). Pass
+                ``None`` to omit the parameter from the request entirely —
+                required for models that reject it (Claude 4.x via Bedrock,
+                OpenAI o1-series). When omitted, resolves from the
+                ``SKILL_SCANNER_LLM_TEMPERATURE`` env var (numeric value, or
+                ``"none"`` to drop the parameter).
             max_retries: Max retry attempts on rate limits
             rate_limit_delay: Base delay for exponential backoff
             timeout: Request timeout in seconds
@@ -242,7 +247,8 @@ class LLMAnalyzer(BaseAnalyzer):
         self.aws_profile = self.provider_config.aws_profile
         self.aws_session_token = self.provider_config.aws_session_token
         self.max_tokens = max_tokens
-        self.temperature = temperature
+        # Mirror the resolved value (env-overrideable; ``None`` = omit from request).
+        self.temperature = self.request_handler.temperature
         self.max_retries = max_retries
         self.rate_limit_delay = rate_limit_delay
         self.timeout = timeout

--- a/skill_scanner/core/analyzers/llm_request_handler.py
+++ b/skill_scanner/core/analyzers/llm_request_handler.py
@@ -54,6 +54,53 @@ except (ImportError, ModuleNotFoundError):
     GOOGLE_GENAI_AVAILABLE = False
     genai = None
 
+# Sentinel: caller did not supply ``temperature``; resolve from env (or use default).
+_TEMPERATURE_UNSET = object()
+
+# Env values that explicitly disable the temperature parameter so newer models
+# that reject ``temperature`` (e.g. Claude 4.x via Bedrock, OpenAI o1) work
+# without code changes.
+_TEMPERATURE_OMIT_VALUES = frozenset({"none", "null", "unset", "omit", "skip"})
+
+
+def _resolve_temperature(
+    explicit: Any,
+    env_var: str,
+    default: float,
+) -> float | None:
+    """Resolve the request-time ``temperature`` from constructor + env.
+
+    Precedence:
+        1. An explicit non-sentinel argument always wins (including ``None``,
+           which means "drop the parameter from the request").
+        2. ``os.environ[env_var]`` — a numeric value is parsed as a float, and
+           a value in ``_TEMPERATURE_OMIT_VALUES`` returns ``None`` to drop the
+           parameter.
+        3. ``default`` (today: 0.0 for the per-file analyzer, 0.1 for meta).
+
+    Returns:
+        ``float`` to send as ``temperature``, or ``None`` to omit it entirely.
+    """
+    if explicit is not _TEMPERATURE_UNSET:
+        return explicit
+
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return default
+    if raw.lower() in _TEMPERATURE_OMIT_VALUES:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid %s=%r (expected a float or 'none'); using %s",
+            env_var,
+            raw,
+            default,
+        )
+        return default
+
+
 # Suppress LiteLLM cosmetic warnings (doesn't affect functionality)
 warnings.filterwarnings("ignore", message=".*Pydantic serializer warnings.*")
 warnings.filterwarnings("ignore", message=".*Expected `Message`.*")
@@ -71,7 +118,7 @@ class LLMRequestHandler:
         self,
         provider_config: ProviderConfig,
         max_tokens: int = 8192,
-        temperature: float = 0.0,
+        temperature: Any = _TEMPERATURE_UNSET,
         max_retries: int = 3,
         rate_limit_delay: float = 2.0,
         timeout: int = 120,
@@ -82,14 +129,20 @@ class LLMRequestHandler:
         Args:
             provider_config: Provider configuration
             max_tokens: Maximum tokens for response
-            temperature: Sampling temperature
+            temperature: Sampling temperature.  Pass ``None`` to omit the
+                ``temperature`` parameter from the LLM request entirely —
+                required for models that reject it (e.g. Claude 4.x via
+                Bedrock, OpenAI o1-series).  When omitted, the value is
+                resolved from ``SKILL_SCANNER_LLM_TEMPERATURE`` (numeric
+                value, or ``"none"`` to drop the parameter), falling back
+                to ``0.0``.
             max_retries: Max retry attempts on rate limits
             rate_limit_delay: Base delay for exponential backoff
             timeout: Request timeout in seconds
         """
         self.provider_config = provider_config
         self.max_tokens = max_tokens
-        self.temperature = temperature
+        self.temperature = _resolve_temperature(temperature, "SKILL_SCANNER_LLM_TEMPERATURE", default=0.0)
         self.max_retries = max_retries
         self.rate_limit_delay = rate_limit_delay
         self.timeout = timeout
@@ -257,10 +310,11 @@ class LLMRequestHandler:
                     "model": self.provider_config.model,
                     "messages": messages,
                     "max_tokens": self.max_tokens,
-                    "temperature": self.temperature,
                     "timeout": self.timeout,
                     **self.provider_config.get_request_params(),
                 }
+                if self.temperature is not None:
+                    request_params["temperature"] = self.temperature
 
                 response_format = self._build_response_format()
                 if response_format:
@@ -325,8 +379,9 @@ class LLMRequestHandler:
                 # New SDK uses GenerateContentConfig type
                 config_dict: dict[str, Any] = {
                     "max_output_tokens": self.max_tokens,
-                    "temperature": self.temperature,
                 }
+                if self.temperature is not None:
+                    config_dict["temperature"] = self.temperature
 
                 # Add structured output support using Google Gemini SDK format
                 # According to Gemini docs: https://ai.google.dev/gemini-api/docs/structured-output

--- a/skill_scanner/core/analyzers/meta_analyzer.py
+++ b/skill_scanner/core/analyzers/meta_analyzer.py
@@ -48,7 +48,7 @@ from ...threats.threats import ThreatMapping
 from ..models import Finding, Severity, Skill, ThreatCategory
 from .base import BaseAnalyzer
 from .llm_provider_config import ProviderConfig
-from .llm_request_handler import LLMRequestHandler
+from .llm_request_handler import _TEMPERATURE_UNSET, LLMRequestHandler, _resolve_temperature
 from .llm_request_options import resolve_llm_user, supports_openai_user_param
 
 if TYPE_CHECKING:
@@ -242,7 +242,7 @@ class MetaAnalyzer(BaseAnalyzer):
         model: str | None = None,
         api_key: str | None = None,
         max_tokens: int = 8192,
-        temperature: float = 0.1,
+        temperature: Any = _TEMPERATURE_UNSET,
         max_retries: int = 3,
         timeout: int = 180,
         # Azure-specific
@@ -262,7 +262,13 @@ class MetaAnalyzer(BaseAnalyzer):
             model: Model identifier (defaults to claude-3-5-sonnet-20241022)
             api_key: API key (if None, reads from environment)
             max_tokens: Maximum tokens for response
-            temperature: Sampling temperature (low for consistency)
+            temperature: Sampling temperature (low for consistency).  Pass
+                ``None`` to omit the parameter from the request entirely —
+                required for models that reject ``temperature`` (e.g. Claude
+                4.x via Bedrock, OpenAI o1-series).  When omitted, resolves
+                from ``SKILL_SCANNER_META_LLM_TEMPERATURE`` (then
+                ``SKILL_SCANNER_LLM_TEMPERATURE``); a numeric value is
+                parsed as a float and ``"none"`` drops the parameter.
             max_retries: Max retry attempts on rate limits
             timeout: Request timeout in seconds
             base_url: Custom base URL (for Azure)
@@ -341,7 +347,21 @@ class MetaAnalyzer(BaseAnalyzer):
                 )
 
         self.max_tokens = max_tokens
-        self.temperature = temperature
+        # Resolve temperature: explicit arg > meta-specific env > scanner-wide
+        # env > default.  ``None`` here means "omit ``temperature`` from the
+        # outgoing request" (Claude 4.x on Bedrock, OpenAI o1-series).
+        if temperature is _TEMPERATURE_UNSET and "SKILL_SCANNER_META_LLM_TEMPERATURE" in os.environ:
+            self.temperature = _resolve_temperature(
+                _TEMPERATURE_UNSET,
+                "SKILL_SCANNER_META_LLM_TEMPERATURE",
+                default=0.1,
+            )
+        else:
+            self.temperature = _resolve_temperature(
+                temperature,
+                "SKILL_SCANNER_LLM_TEMPERATURE",
+                default=0.1,
+            )
         self.max_retries = max_retries
         self.timeout = timeout
 
@@ -822,13 +842,14 @@ Respond with a JSON object following the schema in the system prompt."""
             {"role": "user", "content": user_prompt},
         ]
 
-        api_params = {
+        api_params: dict[str, Any] = {
             "model": self.model,
             "messages": messages,
-            "temperature": self.temperature,
             "max_tokens": self.max_tokens,
             "timeout": float(self.timeout),
         }
+        if self.temperature is not None:
+            api_params["temperature"] = self.temperature
 
         if self.api_key:
             api_params["api_key"] = self.api_key

--- a/tests/test_temperature_resolution.py
+++ b/tests/test_temperature_resolution.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for env-driven ``temperature`` resolution and the omit option.
+
+Models like Anthropic Claude 4.x on Bedrock and OpenAI's o1-series reject
+the ``temperature`` parameter outright.  The handlers need to be able to
+omit the parameter from outgoing requests entirely when configured to do
+so via ``SKILL_SCANNER_LLM_TEMPERATURE`` (or its meta-analyzer variant).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from skill_scanner.core.analyzers.llm_request_handler import (
+    _TEMPERATURE_UNSET,
+    LLMRequestHandler,
+    _resolve_temperature,
+)
+from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip any inherited temperature/meta env vars per test."""
+    monkeypatch.delenv("SKILL_SCANNER_LLM_TEMPERATURE", raising=False)
+    monkeypatch.delenv("SKILL_SCANNER_META_LLM_TEMPERATURE", raising=False)
+
+
+class TestResolveTemperature:
+    """``_resolve_temperature`` is the shared waterfall used by every handler."""
+
+    def test_default_when_env_unset(self) -> None:
+        assert _resolve_temperature(_TEMPERATURE_UNSET, "MISSING_VAR", default=0.0) == 0.0
+
+    def test_env_numeric_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TEMP", "0.7")
+        assert _resolve_temperature(_TEMPERATURE_UNSET, "MY_TEMP", default=0.0) == pytest.approx(0.7)
+
+    @pytest.mark.parametrize("value", ["none", "NONE", "null", "unset", "omit", "skip"])
+    def test_env_omit_values_return_none(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("MY_TEMP", value)
+        assert _resolve_temperature(_TEMPERATURE_UNSET, "MY_TEMP", default=0.0) is None
+
+    def test_env_empty_string_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TEMP", "")
+        assert _resolve_temperature(_TEMPERATURE_UNSET, "MY_TEMP", default=0.3) == 0.3
+
+    def test_env_invalid_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TEMP", "not-a-float")
+        assert _resolve_temperature(_TEMPERATURE_UNSET, "MY_TEMP", default=0.5) == 0.5
+
+    def test_explicit_argument_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TEMP", "0.9")
+        assert _resolve_temperature(0.2, "MY_TEMP", default=0.0) == 0.2
+
+    def test_explicit_none_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit ``temperature=None`` means "omit" even if env sets a number."""
+        monkeypatch.setenv("MY_TEMP", "0.5")
+        assert _resolve_temperature(None, "MY_TEMP", default=0.0) is None
+
+
+class TestLLMRequestHandlerTemperature:
+    """``LLMRequestHandler`` resolves temperature once at init."""
+
+    def _make(self, **kwargs: object) -> LLMRequestHandler:
+        return LLMRequestHandler(provider_config=MagicMock(), **kwargs)
+
+    def test_default_is_zero(self) -> None:
+        assert self._make().temperature == 0.0
+
+    def test_env_numeric_applied_when_arg_omitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_TEMPERATURE", "0.4")
+        assert self._make().temperature == pytest.approx(0.4)
+
+    def test_env_none_drops_temperature(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_TEMPERATURE", "none")
+        assert self._make().temperature is None
+
+    def test_explicit_none_drops_temperature(self) -> None:
+        assert self._make(temperature=None).temperature is None
+
+    def test_explicit_value_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_TEMPERATURE", "0.9")
+        assert self._make(temperature=0.2).temperature == pytest.approx(0.2)
+
+
+class TestMetaAnalyzerTemperature:
+    """The meta-analyzer prefers its own env var, falling back to the global one."""
+
+    def _make(self, **kwargs: object) -> MetaAnalyzer:
+        # api_key bypasses the no-key validation; model selects a non-Bedrock
+        # path so we don't trigger AWS-specific validation branches.
+        return MetaAnalyzer(api_key="sk-test", model="claude-3-5-sonnet-20241022", **kwargs)
+
+    def test_default_is_point_one(self) -> None:
+        assert self._make().temperature == pytest.approx(0.1)
+
+    def test_meta_specific_env_wins_over_scanner_wide(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_TEMPERATURE", "0.5")
+        monkeypatch.setenv("SKILL_SCANNER_META_LLM_TEMPERATURE", "0.05")
+        assert self._make().temperature == pytest.approx(0.05)
+
+    def test_meta_specific_none_drops_temperature(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_META_LLM_TEMPERATURE", "none")
+        assert self._make().temperature is None
+
+    def test_falls_back_to_scanner_wide_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_TEMPERATURE", "none")
+        assert self._make().temperature is None
+
+    def test_explicit_none_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_TEMPERATURE", "0.7")
+        assert self._make(temperature=None).temperature is None


### PR DESCRIPTION
Closes #123.

## Summary

Adds an env-var override and "omit" sentinel for the `temperature` parameter so newer LLMs that reject `temperature` can be used as scanner backends without code changes.

### The bug

Claude 4.x via Bedrock and OpenAI's o1-series reject the `temperature` parameter outright. Today, every scan against those models fails LLM analysis with a 400:

```
BedrockException - {"message":"The model returned the following errors:
`temperature` is deprecated for this model."}
```

The four `temperature: float = 0.0|0.1` defaults sprinkled across the LLM stack make the parameter unconditional in outgoing requests, so users on Bedrock are stuck downgrading to Claude 3.x to use the scanner. Full details and repro in #123.

### The change

Three new behaviors, default behavior unchanged:

1. **`SKILL_SCANNER_LLM_TEMPERATURE`** env var — numeric value (parsed as float) or one of `none` / `null` / `unset` / `omit` / `skip` (drops `temperature` from the request entirely).
2. **`SKILL_SCANNER_META_LLM_TEMPERATURE`** — meta-analyzer-specific override that falls back to the scanner-wide var when unset, mirroring the existing meta env-var pattern (`*_META_LLM_API_KEY`, `*_META_LLM_MODEL`, etc.).
3. **Programmatic `temperature=None`** — explicit `None` from a constructor caller also drops the parameter. Explicit numeric args still win over env.

The omission is applied in every outbound request path:
- `LLMRequestHandler._make_litellm_request` (per-file analyzer)
- `LLMRequestHandler._make_google_sdk_request` (Gemini)
- `MetaAnalyzer._make_llm_request` (meta)
- `AlignmentLLMClient._make_llm_request` (behavioral alignment)

A single shared `_resolve_temperature` helper handles the waterfall.

### Why this design

- **Default-preserving**: with no env var set, every existing caller keeps its current `0.0` / `0.1` default. Zero risk of regressing someone's existing benchmark.
- **Sentinel pattern**: a private `_TEMPERATURE_UNSET` sentinel lets us distinguish "caller didn't pass temperature" from "caller explicitly passed `None`" without breaking the public `float` typing for callers that don't care.
- **No new CLI flags**: env-driven keeps it consistent with the rest of `SKILL_SCANNER_LLM_*` configuration.

### Test plan

- [x] `tests/test_temperature_resolution.py`: 22 new tests covering the resolver (default / numeric env / omit env / invalid env / explicit override / explicit `None`), the per-file handler, and the meta-analyzer's two-tier env fallback.
- [x] **Full suite**: `pytest tests/` → **1322 passed, 5 skipped**.
- [x] Verified on **Python 3.10, 3.12, 3.13** matching the CI matrix (`uv run --python <ver>`).
- [x] `pre-commit run --all-files` clean (ruff, ruff-format, gitleaks, addlicense, check-taxonomy, check-yaml, check-toml, GH workflow validation).
- [x] **Live end-to-end against AWS Bedrock**, Claude 4.x via application-inference-profile ARN:
  ```bash
  SKILL_SCANNER_LLM_PROVIDER=aws-bedrock \
  SKILL_SCANNER_LLM_MODEL='bedrock/converse/<claude-4-arn>' \
  SKILL_SCANNER_LLM_TEMPERATURE=none \
  AWS_PROFILE=<profile> AWS_REGION=us-west-2 \
  skill-scanner scan /tmp/cursed-skills/skills/pipe-to-shell/ \
    --use-llm --enable-meta --policy strict --lenient
  ```
  Result: `Status: [FAIL] · 12 findings (8 HIGH / 2 MED / 1 LOW / 1 INFO) · 28.85s`. Previously this exact configuration failed every LLM call with a 400.
- [x] `evals/runners/benchmark_runner.py --eval-dir evals/skills` → 100% Accuracy / Precision / Recall / F1.
- [x] `pip-audit` reports the same pre-existing CVEs as `main`, no new ones introduced.

### Usage

```bash
# Claude 4.x on Bedrock — temperature must be omitted
export SKILL_SCANNER_LLM_TEMPERATURE=none

# Or a custom value for compatible models
export SKILL_SCANNER_LLM_TEMPERATURE=0.2

# Meta-analyzer can have its own override (falls back to LLM_TEMPERATURE)
export SKILL_SCANNER_META_LLM_TEMPERATURE=none
```

### Notes / scope

- I deliberately scoped this to `temperature` only. Several newer-model parameter incompatibilities (e.g. `top_p`, `top_k`) likely deserve the same treatment but seem better as follow-ups once the maintainers signal a preferred direction.
- The dead `llm_temperature: float = 0.0` field in `config/config.py` is unread; not touched in this PR to keep the diff focused.
- DCO sign-off included.
- **Happy to narrow scope** — if you'd prefer this only land in `LLMRequestHandler` (per-file analyzer) and skip the meta / behavioral-alignment paths, just say the word and I'll split it.
