### PR TITLE
fix(scanner): discover symlinked skill dirs in recursive scans

### DIFF
--- a/skill_scanner/core/scanner.py
+++ b/skill_scanner/core/scanner.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -103,6 +105,11 @@ _STOP_WORDS = frozenset(
 
 class SkillScanner:
     """Main scanner that orchestrates skill analysis."""
+
+    # Upper bound on directories visited during recursive discovery. Guards
+    # against a hostile symlink fan-out (e.g. ``trap -> /``) turning a scan into
+    # a full-filesystem crawl. Far above any realistic skill tree (issue #116).
+    _MAX_WALK_DIRS = 100_000
 
     def __init__(
         self,
@@ -854,6 +861,77 @@ class SkillScanner:
 
         return intersection / union if union > 0 else 0.0
 
+    def _walk_skill_dirs(self, directory: Path) -> Iterator[Path]:
+        """Yield *directory* and every subdirectory beneath it, descending
+        into symlinked directories as well.
+
+        ``Path.rglob`` / ``Path.glob("**")`` do not follow directory symlinks
+        (and on Python < 3.13 there is no option to make them), so skills
+        installed as symlinks are silently skipped during recursive discovery.
+        This is the standard Claude Code layout, where ``~/.claude/skills/<name>``
+        is a symlink to a real directory elsewhere (issue #116).  ``os.walk``
+        with ``followlinks=True`` descends into them.
+
+        Following symlinks is deliberately bounded so a security scan cannot be
+        turned against the user (issue #116 review):
+
+        * **Containment.** When the walk crosses a symlink whose real target is
+          *outside* the scan root, that directory itself is still yielded (so a
+          per-skill symlink such as ``~/.claude/skills/<name>`` -- which points
+          directly at a leaf skill with its ``SKILL.md`` at depth 0 -- is
+          discovered), but its children are not descended into. This stops a
+          hostile bundle whose ``trap -> /`` (or ``-> ~``) symlink would
+          otherwise make discovery crawl the entire filesystem.
+
+          Limitation: because descent stops at the crossing, a symlink pointing
+          at an external *collection* of skills (e.g. ``skills -> /ext/skillset``
+          with skills nested at ``skillset/a``, ``skillset/group/b``) only has
+          its top level evaluated; nested skills underneath are not discovered.
+          This is not a regression -- ``rglob`` followed no symlinks at all -- and
+          the standard #116 layout (one symlink per skill) is unaffected. To scan
+          such a collection, point the scanner directly at the resolved directory.
+        * **Cycle safety.** Resolved paths are tracked so symlink cycles and
+          aliases are walked at most once.
+        * **DoS backstop.** Discovery stops after ``_MAX_WALK_DIRS`` directories,
+          logging the truncation. Note this bounds the *number of directories*
+          walked, not the entry count within a single directory: ``os.walk``
+          still materializes one directory's full listing at a time, so a symlink
+          to a single directory with an enormous number of entries is not bounded
+          by this cap.
+        """
+        try:
+            scan_root = directory.resolve()
+        except OSError:
+            return
+        visited: set[Path] = set()
+        for root, dirs, _files in os.walk(directory, followlinks=True):
+            if len(visited) >= self._MAX_WALK_DIRS:
+                logger.warning(
+                    "Skill discovery truncated at %d directories under %s "
+                    "(possible symlink fan-out); some skills may be skipped.",
+                    self._MAX_WALK_DIRS,
+                    directory,
+                )
+                break
+            root_path = Path(root)
+            try:
+                real = root_path.resolve()
+            except OSError:
+                # Symlink loop / unreadable entry: do not descend further.
+                dirs[:] = []
+                continue
+            if real in visited:
+                # Already walked this real directory (symlink cycle or alias).
+                dirs[:] = []
+                continue
+            visited.add(real)
+            yield root_path
+            if not real.is_relative_to(scan_root):
+                # Followed a symlink out of the scan root: evaluate this
+                # directory as a skill, but do not wander into its external
+                # siblings/children (containment, see docstring).
+                dirs[:] = []
+
     def _find_skill_directories(
         self,
         directory: Path,
@@ -885,11 +963,12 @@ class SkillScanner:
 
         # Phase 1: find directories with the target metadata file
         if recursive:
-            for md in directory.rglob(target_filename):
-                resolved = md.parent.resolve()
-                if resolved not in seen:
-                    seen.add(resolved)
-                    skill_dirs.append(md.parent)
+            for sub in self._walk_skill_dirs(directory):
+                if (sub / target_filename).exists():
+                    resolved = sub.resolve()
+                    if resolved not in seen:
+                        seen.add(resolved)
+                        skill_dirs.append(sub)
         else:
             for item in directory.iterdir():
                 if item.is_dir():
@@ -903,11 +982,13 @@ class SkillScanner:
         # Phase 2 (lenient only): discover directories with .md files
         if lenient:
             if recursive:
-                for md in directory.rglob("*.md"):
-                    candidate = md.parent.resolve()
-                    if candidate not in seen:
+                for sub in self._walk_skill_dirs(directory):
+                    candidate = sub.resolve()
+                    if candidate in seen:
+                        continue
+                    if any(sub.glob("*.md")):
                         seen.add(candidate)
-                        skill_dirs.append(md.parent)
+                        skill_dirs.append(sub)
             else:
                 for item in directory.iterdir():
                     if item.is_dir():

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -18,6 +18,7 @@
 Unit tests for scanner engine.
 """
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -27,6 +28,26 @@ from skill_scanner.core.models import Finding, Severity, ThreatCategory
 from skill_scanner.core.scan_policy import ScanPolicy, SeverityOverride
 from skill_scanner.core.scanner import SkillScanner, scan_skill
 from skill_scanner.core.scanner import scan_directory as convenience_scan_directory
+
+
+def _symlinks_available() -> bool:
+    """Whether the OS/user can actually create directory symlinks.
+
+    ``Path.symlink_to`` exists on Windows but raises ``OSError`` without
+    Developer Mode / admin privileges, so ``hasattr(os, "symlink")`` is not a
+    reliable guard. Probe by creating a real symlink instead.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "target"
+        target.mkdir()
+        try:
+            (Path(tmp) / "link").symlink_to(target, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            return False
+        return True
+
+
+_SYMLINKS_AVAILABLE = _symlinks_available()
 
 
 @pytest.fixture
@@ -636,3 +657,146 @@ def test_same_path_other_rule_ids_knob_disable(example_skills_dir):
     assert len(result.findings) == 2
     for finding in result.findings:
         assert "same_path_other_rule_ids" not in finding.metadata
+
+
+def test_recursive_discovery_on_plain_nested_tree(scanner, tmp_path):
+    """No-regression: the os.walk rewrite finds the same skills rglob would.
+
+    On a plain tree with no symlinks, recursive discovery must find every
+    SKILL.md directory at any depth (and nothing else), exactly as the previous
+    ``Path.rglob`` implementation did. This runs on every platform.
+    """
+    expected = {
+        tmp_path / "top",  # depth 1
+        tmp_path / "group" / "mid",  # depth 2
+        tmp_path / "group" / "more" / "leaf",  # depth 3
+    }
+    for d in expected:
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"---\nname: {d.name}\n---\n", encoding="utf-8")
+    # A directory without SKILL.md must NOT be discovered.
+    (tmp_path / "group" / "not_a_skill").mkdir(parents=True)
+
+    found = {p.resolve() for p in scanner._find_skill_directories(tmp_path, recursive=True)}
+
+    assert found == {d.resolve() for d in expected}
+
+
+class TestSymlinkedSkillDiscovery:
+    """Regression tests for issue #116.
+
+    Recursive discovery must follow symlinked skill directories. This is the
+    standard Claude Code layout, where ``~/.claude/skills/<name>`` is a symlink
+    to a real directory elsewhere. ``Path.rglob`` does not follow directory
+    symlinks, so these skills were previously skipped and the scan reported
+    "no skills found".
+    """
+
+    pytestmark = pytest.mark.skipif(
+        not _SYMLINKS_AVAILABLE,
+        reason="OS/user cannot create directory symlinks (e.g. Windows without Developer Mode)",
+    )
+
+    def test_recursive_discovery_follows_symlinked_skill_dir(self, scanner, tmp_path):
+        """A skill symlinked into the scanned directory is discovered."""
+        # Real skill living outside the scanned tree.
+        real = tmp_path / "agents" / "skills" / "diagnose"
+        real.mkdir(parents=True)
+        (real / "SKILL.md").write_text("---\nname: diagnose\n---\n", encoding="utf-8")
+
+        # Scanned directory contains only a symlink to the real skill.
+        scanned = tmp_path / "claude" / "skills"
+        scanned.mkdir(parents=True)
+        (scanned / "diagnose").symlink_to(real, target_is_directory=True)
+
+        found = scanner._find_skill_directories(scanned, recursive=True)
+
+        assert real.resolve() in {p.resolve() for p in found}
+
+    def test_recursive_lenient_discovery_follows_symlink(self, scanner, tmp_path):
+        """Lenient (.md-only) discovery also follows symlinked directories."""
+        real = tmp_path / "real" / "notes"
+        real.mkdir(parents=True)
+        (real / "guide.md").write_text("# guide\n", encoding="utf-8")
+
+        scanned = tmp_path / "scanned"
+        scanned.mkdir()
+        (scanned / "notes").symlink_to(real, target_is_directory=True)
+
+        found = scanner._find_skill_directories(scanned, recursive=True, lenient=True)
+
+        assert real.resolve() in {p.resolve() for p in found}
+
+    def test_symlink_cycle_does_not_hang(self, scanner, tmp_path):
+        """A symlink cycle is traversed once without infinite recursion."""
+        skills = tmp_path / "skills"
+        sub = skills / "a"
+        sub.mkdir(parents=True)
+        (sub / "SKILL.md").write_text("---\nname: a\n---\n", encoding="utf-8")
+        # Cycle: skills/a/loop -> skills
+        (sub / "loop").symlink_to(skills, target_is_directory=True)
+
+        found = scanner._find_skill_directories(skills, recursive=True)
+
+        resolved = [p.resolve() for p in found]
+        assert sub.resolve() in resolved
+        # The cycle must not cause the same skill to be reported more than once.
+        assert len(resolved) == len(set(resolved))
+
+    def test_symlinked_dir_outside_scan_root_is_contained(self, scanner, tmp_path):
+        """Following a symlink out of the scan root must not crawl its subtree.
+
+        Security regression for the issue #116 review: ``os.walk(followlinks=True)``
+        without containment would descend through a ``trap -> /`` style symlink
+        and discover (and scan) every skill anywhere on disk. Discovery must
+        evaluate the symlinked directory itself but stop there.
+        """
+        # External tree OUTSIDE the scan root, with skills at varying depth.
+        external = tmp_path / "external"
+        (external / "secretA").mkdir(parents=True)
+        (external / "nested" / "deep" / "secretB").mkdir(parents=True)
+        (external / "secretA" / "SKILL.md").write_text("---\nname: secretA\n---\n", encoding="utf-8")
+        (external / "nested" / "deep" / "secretB" / "SKILL.md").write_text(
+            "---\nname: secretB\n---\n", encoding="utf-8"
+        )
+
+        # Scan root: one in-tree skill + a symlink to the whole external tree.
+        scanroot = tmp_path / "scanroot"
+        (scanroot / "innocent").mkdir(parents=True)
+        (scanroot / "innocent" / "SKILL.md").write_text("---\nname: innocent\n---\n", encoding="utf-8")
+        (scanroot / "trap").symlink_to(external, target_is_directory=True)
+
+        found = {p.resolve() for p in scanner._find_skill_directories(scanroot, recursive=True)}
+
+        # The in-tree skill is found; the out-of-root skills are NOT.
+        assert (scanroot / "innocent").resolve() in found
+        assert (external / "secretA").resolve() not in found
+        assert (external / "nested" / "deep" / "secretB").resolve() not in found
+
+    def test_scan_directory_scans_symlinked_skill_end_to_end(self, scanner, tmp_path):
+        """A full scan (not just discovery) finds and scans a symlinked skill.
+
+        This exercises the actual issue #116 symptom: ``scan_directory`` over a
+        tree whose only skill is a symlink previously returned an empty report
+        ("no skills found"). Asserting on the ``Report`` proves the whole
+        discovery -> loader -> scan chain holds, not just discovery.
+        """
+        # Real skill living outside the scanned tree.
+        real = tmp_path / "agents" / "skills" / "diagnose"
+        real.mkdir(parents=True)
+        (real / "SKILL.md").write_text(
+            "---\nname: diagnose\ndescription: Diagnose system issues.\n---\n# Diagnose\nA harmless helper skill.\n",
+            encoding="utf-8",
+        )
+
+        # Scanned directory contains only a symlink to the real skill.
+        scanned = tmp_path / "claude" / "skills"
+        scanned.mkdir(parents=True)
+        (scanned / "diagnose").symlink_to(real, target_is_directory=True)
+
+        report = scanner.scan_directory(scanned, recursive=True)
+
+        # The symlinked skill was actually loaded and scanned, exactly once.
+        assert report.total_skills_scanned == 1
+        assert len(report.scan_results) == 1
+        assert report.scan_results[0].skill_name == "diagnose"


### PR DESCRIPTION
# Pull Request

## Description

Recursive skill discovery silently skipped skills installed as **symlinked directories**, so `scan-all <dir> --recursive` on a directory of symlinked skills reported "no skills found". This is the standard Claude Code layout, where `~/.claude/skills/<name>` is a symlink to a real directory elsewhere (e.g. `~/.agents/skills/<name>`).

Root cause is in `_find_skill_directories()` in `skill_scanner/core/scanner.py`. The recursive path used `directory.rglob("SKILL.md")` (and `rglob("*.md")` for lenient mode). `Path.rglob` / `Path.glob("**")` do **not** follow directory symlinks (no option to on Python < 3.13), so every symlinked skill is skipped during recursive discovery. The non-recursive path was already correct because `Path.is_dir()` dereferences symlinks.

This PR adds a `_walk_skill_dirs()` helper built on `os.walk(..., followlinks=True)` that descends into symlinked directories, and uses it in both recursive branches.

### Bounded symlink following (security)

Naively enabling `followlinks=True` would let a hostile skill bundle escape the scan: a `trap -> /` (or `-> ~`) symlink inside the scanned tree would make discovery crawl the entire filesystem, loading and scanning every `SKILL.md`/`.md` directory anywhere on disk (DoS + out-of-root reads). The loader's per-skill `resolve()` guard does **not** prevent this, because it rebases containment onto each *discovered* directory.

Following is therefore deliberately bounded:

- **Containment.** When the walk crosses a symlink whose real target is *outside* the scan root, that directory itself is still evaluated as a skill — so a *per-skill* symlink (`~/.claude/skills/<name>`, which points directly at a leaf skill whose `SKILL.md` sits at depth 0) is discovered — but its children are **not** descended into. A symlink to an external *parent/collection* tree therefore cannot pull that tree's contents into the scan.
- **Cycle safety.** Resolved paths are tracked in a `visited` set, so symlink cycles/aliases are walked at most once.
- **DoS backstop.** Discovery stops after `_MAX_WALK_DIRS` (100k) directories and logs the truncation.

**Known limitations (documented, not regressions):**
- *Symlink-to-collection:* because descent stops at the crossing, a symlink pointing at an external collection of skills (`skills -> /ext/skillset` with skills nested at `skillset/a`, `skillset/group/b`) only has its top level evaluated; the nested skills are not discovered. This is **not** a regression — `rglob` followed no symlinks at all — and the standard #116 layout (one symlink per skill, `SKILL.md` at depth 0) is unaffected. To scan such a collection, point the scanner directly at the resolved directory.
- *Single-directory width:* the `_MAX_WALK_DIRS` cap bounds the *number of directories* walked, not the entry count within one directory. `os.walk` materializes a single directory's full listing at a time, so a symlink to one directory with an enormous number of entries is not bounded by this cap.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #116

## Changes Made

- `skill_scanner/core/scanner.py`: added `_walk_skill_dirs()` (bounded `os.walk(followlinks=True)` with containment, cycle dedup, and a `_MAX_WALK_DIRS` cap); recursive Phase 1 (`SKILL.md`) and recursive lenient Phase 2 (`*.md`) now use it instead of `Path.rglob`. Non-recursive discovery unchanged.
- `tests/test_scanner.py`:
  - `test_recursive_discovery_on_plain_nested_tree` — no-regression: the `rglob → os.walk` rewrite finds the same skills (at depths 1/2/3) and ignores non-skill dirs. Runs on all platforms.
  - `TestSymlinkedSkillDiscovery` (symlink-gated): recursive discovery of a symlinked skill; lenient recursive discovery; symlink cycle traversed once **and** without duplicates; out-of-root symlink containment (the `trap -> external` escape is blocked); and an **end-to-end** `scan_directory(..., recursive=True)` asserting a symlinked skill is actually loaded and scanned (the literal "no skills found" symptom). The class skips (rather than errors) where the OS/user cannot create symlinks (e.g. Windows without Developer Mode).

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing

```bash
uv run pytest tests/test_scanner.py -q                               # 28 passed
uv run pytest tests/test_cli_scan_repo.py tests/test_cross_skill_scanner.py \
  tests/test_scan_policy.py tests/test_bug_fixes.py \
  tests/test_strict_structure.py -q                                  # all pass (164 total in scanner area)
uv run ruff check skill_scanner/core/scanner.py tests/test_scanner.py        # clean
uv run ruff format --check skill_scanner/core/scanner.py tests/test_scanner.py  # clean
```

**Results:**
- A recursive scan over a directory of symlinked skills now discovers and scans them (end-to-end test: `total_skills_scanned == 1`); the new tests fail on unpatched code (empty result) and pass with the fix.
- A `trap -> external` symlink no longer leaks out-of-root skills into discovery (containment test).
- Old vs new discovery return the identical result set on `evals/test_skills` (9 skills), so existing scans are unaffected.

**Pre-existing, unrelated:** `tests/test_bytecode_analyzer.py::TestStemCollisionResolution::test_pycache_matches_parent_directory_source` fails on this machine (a `cpython-311` fixture under a 3.12 interpreter). It reproduces identically on clean `main` with our `scanner.py` reverted, so it is not caused by this change.

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Type hints added where applicable
- [x] Docstrings added/updated for public APIs
- [x] No hardcoded credentials or secrets
- [x] Error handling is comprehensive
- [x] Logging is appropriate

### Security
- [x] No new security vulnerabilities introduced
- [x] Follows security best practices from workspace rules — symlink following is bounded (containment + DoS cap), consistent with the existing anti-symlink-escape posture (`test_symlink_escape`, `TestLoaderSymlinkTraversal`)

### Testing
- [x] Tests pass: `uv run pre-commit run --all-files`
- [x] No regressions in existing functionality (plain-tree no-regression test added)
- [x] Edge cases covered (symlink cycle + uniqueness, lenient mode, out-of-root containment, end-to-end scan)

## Performance Impact

- [x] No significant performance regression

## Additional Notes

Issue #116 was filed from the `cisco-ai.cisco-ai-security-scanner` VS Code extension, whose root-cause snippet is the extension's own JS `scanSkillsDirectory()` (`readdir(..., {withFileTypes:true})` + `isDirectory()`). Skill Scanner powers the extension's skill scanning, so this PR fixes the equivalent symlink-skipping bug in the Python recursive-discovery path. If the extension performs its own directory enumeration in JS before delegating to this package, that JS path may need the analogous fix separately.
