### PR TITLE
feat(pre-commit): support incremental CI skill scans

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,6 @@
   entry: skill-scanner-pre-commit
   language: python
   types: [file]
-  pass_filenames: false
+  pass_filenames: true
+  require_serial: true
   stages: [pre-commit]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: Scan agent skill packages for security vulnerabilities
   entry: skill-scanner-pre-commit
   language: python
-  types: [file]
-  pass_filenames: true
+  pass_filenames: false
   require_serial: true
+  always_run: true
   stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -341,7 +341,16 @@ Or install the built-in hook directly:
 skill-scanner-pre-commit install
 ```
 
-The hook automatically detects which skill directories have staged changes and only scans those, keeping commit times fast. Use `--all` to scan everything.
+The hook maps changed files to their nearest `SKILL.md` and scans each affected
+skill once. During a normal commit, pre-commit supplies the staged filenames.
+In CI, compare two revisions so no staged index is required:
+
+```bash
+pre-commit run skill-scanner --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"
+```
+
+Both revisions must exist in the checkout. Use `--all` with the hook to scan
+every configured skill instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -338,19 +338,26 @@ repos:
 Or install the built-in hook directly:
 
 ```bash
-skill-scanner-pre-commit install
+skill-scanner-pre-commit --install
 ```
 
 The hook maps changed files to their nearest `SKILL.md` and scans each affected
-skill once. During a normal commit, pre-commit supplies the staged filenames.
-In CI, compare two revisions so no staged index is required:
+skill once. During a normal commit, it reads the staged diff. In CI, compare two
+revisions so no staged index is required:
 
 ```bash
 pre-commit run skill-scanner --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"
 ```
 
-Both revisions must exist in the checkout. Use `--all` with the hook to scan
-every configured skill instead.
+Both revisions must exist in the checkout. To scan every configured skill,
+invoke the hook directly:
+
+```bash
+skill-scanner-pre-commit --scan-all
+```
+
+Alternatively, configure `args: [--scan-all]` for the hook in
+`.pre-commit-config.yaml`.
 
 ---
 

--- a/docs/architecture/analyzers/llm-analyzer.md
+++ b/docs/architecture/analyzers/llm-analyzer.md
@@ -109,8 +109,9 @@ analyzer = LLMAnalyzer(model="gemini-2.0-flash-exp", api_key=key)
 # Using LiteLLM format
 analyzer = LLMAnalyzer(model="gemini/gemini-2.0-flash-exp", api_key=key)
 
-# Vertex AI
-analyzer = LLMAnalyzer(model="vertex_ai/gemini-1.5-pro")  # uses GOOGLE_APPLICATION_CREDENTIALS
+# Vertex AI -- uses GOOGLE_APPLICATION_CREDENTIALS if set, otherwise falls
+# back to ambient Application Default Credentials (e.g. Workload Identity)
+analyzer = LLMAnalyzer(model="vertex_ai/gemini-1.5-pro")
 ```
 
 ### Azure OpenAI

--- a/docs/development/integrations.md
+++ b/docs/development/integrations.md
@@ -115,7 +115,8 @@ The hook entry point is `skill-scanner-pre-commit`, which is installed alongside
 ### Incremental checks in CI
 
 There is no staged index to inspect after a CI checkout. Use pre-commit's
-revision comparison so it passes the changed filenames to Skill Scanner:
+revision comparison; the hook reads those revisions from pre-commit's
+environment and computes the changed paths internally:
 
 ```bash
 pre-commit run skill-scanner \
@@ -123,10 +124,10 @@ pre-commit run skill-scanner \
   --to-ref "$HEAD_SHA"
 ```
 
-The hook resolves each changed path to its nearest parent containing
-`SKILL.md`, deduplicates paths from the same skill, and scans only those skill
-packages. Both revisions must be present locally; configure the checkout step
-to fetch enough history for the selected base and head SHAs.
+The hook uses a separate deletion diff so removed paths are included, resolves
+each changed path to its nearest parent containing `SKILL.md`, and scans each
+affected skill once. Both revisions must be present locally; configure the
+checkout step to fetch enough history for the selected base and head SHAs.
 
 ## Policy-Aware CI
 

--- a/docs/development/integrations.md
+++ b/docs/development/integrations.md
@@ -112,6 +112,22 @@ chmod +x .git/hooks/pre-commit
 
 The hook entry point is `skill-scanner-pre-commit`, which is installed alongside the main CLI.
 
+### Incremental checks in CI
+
+There is no staged index to inspect after a CI checkout. Use pre-commit's
+revision comparison so it passes the changed filenames to Skill Scanner:
+
+```bash
+pre-commit run skill-scanner \
+  --from-ref "$BASE_SHA" \
+  --to-ref "$HEAD_SHA"
+```
+
+The hook resolves each changed path to its nearest parent containing
+`SKILL.md`, deduplicates paths from the same skill, and scans only those skill
+packages. Both revisions must be present locally; configure the checkout step
+to fetch enough history for the selected base and head SHAs.
+
 ## Policy-Aware CI
 
 Keep preset strategy explicit by workflow stage:

--- a/docs/development/setup-and-testing.md
+++ b/docs/development/setup-and-testing.md
@@ -182,7 +182,21 @@ repos:
       - id: skill-scanner
 ```
 
-The hook entry point is `skill-scanner-pre-commit` (defined in `pyproject.toml`). It automatically detects staged skill directories via `git diff --cached` and only scans those.
+The hook entry point is `skill-scanner-pre-commit` (defined in `pyproject.toml`).
+The pre-commit framework passes changed filenames to the hook, which maps each
+file to the nearest parent containing `SKILL.md` and scans every affected skill
+once. Direct invocation without filenames retains the local
+`git diff --cached` fallback.
+
+For incremental CI checks, let pre-commit compute the changed files between two
+available revisions:
+
+```bash
+pre-commit run skill-scanner --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"
+```
+
+Ensure the CI checkout contains both revisions (for example, avoid a shallow
+checkout that omits the base commit).
 
 ## GitHub Actions Reusable Workflow
 

--- a/docs/development/setup-and-testing.md
+++ b/docs/development/setup-and-testing.md
@@ -183,13 +183,11 @@ repos:
 ```
 
 The hook entry point is `skill-scanner-pre-commit` (defined in `pyproject.toml`).
-The pre-commit framework passes changed filenames to the hook, which maps each
-file to the nearest parent containing `SKILL.md` and scans every affected skill
-once. Direct invocation without filenames retains the local
-`git diff --cached` fallback.
+It computes staged paths internally, maps each file to the nearest parent
+containing `SKILL.md`, and scans every affected skill once.
 
-For incremental CI checks, let pre-commit compute the changed files between two
-available revisions:
+For incremental CI checks, let pre-commit expose the two available revisions;
+the hook computes their changed paths, including deletions, internally:
 
 ```bash
 pre-commit run skill-scanner --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -273,7 +273,7 @@ See [API Server](../user-guide/api-server.md) and [API Endpoint Reference](../re
 Block risky findings before they reach the repository. The hook scans staged skill changes and fails the commit when findings exceed a severity threshold.
 
 ```bash
-skill-scanner-pre-commit install
+skill-scanner-pre-commit --install
 ```
 
 <details>

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -297,7 +297,7 @@ The LLM and Meta analyzers work with multiple LLM providers. Select a provider v
 
 ```bash
 pip install cisco-ai-skill-scanner[bedrock]   # AWS Bedrock (IAM credentials)
-pip install cisco-ai-skill-scanner[vertex]    # Google Vertex AI
+pip install cisco-ai-skill-scanner[vertex]    # Google Vertex AI (Workload Identity or service account)
 pip install cisco-ai-skill-scanner[azure]     # Azure OpenAI (managed identity)
 pip install cisco-ai-skill-scanner[all]       # All cloud providers
 ```

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -229,10 +229,11 @@ repos:
 Or install the built-in hook directly:
 
 ```bash
-skill-scanner-pre-commit install
+skill-scanner-pre-commit --install
 ```
 
-The hook only scans skill directories with staged changes. Use `--all` to scan everything.
+The hook only scans skill directories with staged changes. Run
+`skill-scanner-pre-commit --scan-all` to scan every configured skill.
 
 ## Next Steps
 

--- a/docs/reference/cli-command-reference.md
+++ b/docs/reference/cli-command-reference.md
@@ -18,7 +18,7 @@ This page is generated from live `argparse` output and should match runtime beha
 | `skill-scanner configure-policy` | Interactive TUI policy editor | `skill-scanner configure-policy` |
 | `skill-scanner interactive` | Interactive setup wizard | `skill-scanner interactive` |
 | `skill-scanner-api` | Start the REST API server | `skill-scanner-api --port 8080` |
-| `skill-scanner-pre-commit` | Git pre-commit hook | `skill-scanner-pre-commit install` |
+| `skill-scanner-pre-commit` | Git pre-commit hook | `skill-scanner-pre-commit --install` |
 
 ## Common Flags
 
@@ -523,13 +523,15 @@ Command: `python -m skill_scanner.hooks.pre_commit --help`
 
 ```text
 usage: pre_commit.py [-h] [--severity {critical,high,medium,low}]
-                     [--skills-path SKILLS_PATH] [--all] [--lenient]
-                     [install]
+                     [--skills-path SKILLS_PATH] [--scan-all] [--install]
+                     [--lenient]
+                     [FILE ...]
 
 Pre-commit hook for scanning agent skills
 
 positional arguments:
-  install               Install pre-commit hook
+  FILE                  Changed files supplied by pre-commit (falls back to
+                        staged files when omitted)
 
 options:
   -h, --help            show this help message and exit
@@ -537,7 +539,8 @@ options:
                         Override severity threshold from config
   --skills-path SKILLS_PATH
                         Override skills path from config
-  --all                 Scan all skills, not just staged ones
+  --scan-all            Scan all skills, not just staged ones
+  --install             Install the built-in pre-commit hook
   --lenient             Tolerate malformed skills instead of failing
 ```
 

--- a/docs/reference/cli-command-reference.md
+++ b/docs/reference/cli-command-reference.md
@@ -99,14 +99,13 @@ usage: cli.py scan [-h] [--format {summary,json,markdown,table,sarif,html}]
                    [--output-sarif OUTPUT_SARIF]
                    [--output-markdown OUTPUT_MARKDOWN]
                    [--output-html OUTPUT_HTML] [--output-table OUTPUT_TABLE]
-                   [--detailed] [--render-markdown | --no-render-markdown]
-                   [--compact] [--verbose] [--fail-on-findings]
-                   [--fail-on-severity LEVEL] [--use-behavioral] [--use-llm]
-                   [--use-virustotal] [--vt-api-key VT_API_KEY]
-                   [--vt-upload-files] [--use-aidefense]
-                   [--aidefense-api-key AIDEFENSE_API_KEY]
+                   [--detailed] [--no-render-markdown] [--compact] [--verbose]
+                   [--fail-on-findings] [--fail-on-severity LEVEL]
+                   [--use-behavioral] [--use-llm] [--use-virustotal]
+                   [--vt-api-key VT_API_KEY] [--vt-upload-files]
+                   [--use-aidefense] [--aidefense-api-key AIDEFENSE_API_KEY]
                    [--aidefense-api-url AIDEFENSE_API_URL]
-                   [--llm-provider {anthropic,openai,openai-compatible}]
+                   [--llm-provider {anthropic,openai}]
                    [--llm-consensus-runs N] [--llm-max-tokens N]
                    [--use-trigger] [--enable-meta] [--policy PRESET_OR_PATH]
                    [--lenient] [--skill-file FILENAME] [--custom-rules PATH]
@@ -138,8 +137,6 @@ options:
   --output-table OUTPUT_TABLE
                         Write Table report to this file
   --detailed            Include detailed findings (Markdown output only)
-  --render-markdown     With --format markdown: render markdown even when
-                        stdout is not detected as a TTY.
   --no-render-markdown  With --format markdown to terminal: print raw markdown
                         instead of rendering (for pipe/copy).
   --compact             Compact JSON output
@@ -161,9 +158,8 @@ options:
                         AI Defense API key (or set AI_DEFENSE_API_KEY)
   --aidefense-api-url AIDEFENSE_API_URL
                         AI Defense API URL (optional, defaults to US region)
-  --llm-provider {anthropic,openai,openai-compatible}
-                        LLM provider shortcut or explicit OpenAI-compatible
-                        override
+  --llm-provider {anthropic,openai}
+                        LLM provider
   --llm-consensus-runs N
                         Run LLM analysis N times and keep only findings with
                         majority agreement (reduces false positives, increases
@@ -211,15 +207,14 @@ usage: cli.py scan-all [-h] [--recursive] [--check-overlap]
                        [--output-markdown OUTPUT_MARKDOWN]
                        [--output-html OUTPUT_HTML]
                        [--output-table OUTPUT_TABLE] [--detailed]
-                       [--render-markdown | --no-render-markdown] [--compact]
-                       [--verbose] [--fail-on-findings]
-                       [--fail-on-severity LEVEL] [--use-behavioral]
-                       [--use-llm] [--use-virustotal]
+                       [--no-render-markdown] [--compact] [--verbose]
+                       [--fail-on-findings] [--fail-on-severity LEVEL]
+                       [--use-behavioral] [--use-llm] [--use-virustotal]
                        [--vt-api-key VT_API_KEY] [--vt-upload-files]
                        [--use-aidefense]
                        [--aidefense-api-key AIDEFENSE_API_KEY]
                        [--aidefense-api-url AIDEFENSE_API_URL]
-                       [--llm-provider {anthropic,openai,openai-compatible}]
+                       [--llm-provider {anthropic,openai}]
                        [--llm-consensus-runs N] [--llm-max-tokens N]
                        [--use-trigger] [--enable-meta]
                        [--policy PRESET_OR_PATH] [--lenient]
@@ -254,8 +249,6 @@ options:
   --output-table OUTPUT_TABLE
                         Write Table report to this file
   --detailed            Include detailed findings (Markdown output only)
-  --render-markdown     With --format markdown: render markdown even when
-                        stdout is not detected as a TTY.
   --no-render-markdown  With --format markdown to terminal: print raw markdown
                         instead of rendering (for pipe/copy).
   --compact             Compact JSON output
@@ -277,9 +270,8 @@ options:
                         AI Defense API key (or set AI_DEFENSE_API_KEY)
   --aidefense-api-url AIDEFENSE_API_URL
                         AI Defense API URL (optional, defaults to US region)
-  --llm-provider {anthropic,openai,openai-compatible}
-                        LLM provider shortcut or explicit OpenAI-compatible
-                        override
+  --llm-provider {anthropic,openai}
+                        LLM provider
   --llm-consensus-runs N
                         Run LLM analysis N times and keep only findings with
                         majority agreement (reduces false positives, increases
@@ -328,15 +320,14 @@ usage: cli.py scan-repo [-h] [--recursive | --no-recursive | -r]
                         [--output-markdown OUTPUT_MARKDOWN]
                         [--output-html OUTPUT_HTML]
                         [--output-table OUTPUT_TABLE] [--detailed]
-                        [--render-markdown | --no-render-markdown] [--compact]
-                        [--verbose] [--fail-on-findings]
-                        [--fail-on-severity LEVEL] [--use-behavioral]
-                        [--use-llm] [--use-virustotal]
+                        [--no-render-markdown] [--compact] [--verbose]
+                        [--fail-on-findings] [--fail-on-severity LEVEL]
+                        [--use-behavioral] [--use-llm] [--use-virustotal]
                         [--vt-api-key VT_API_KEY] [--vt-upload-files]
                         [--use-aidefense]
                         [--aidefense-api-key AIDEFENSE_API_KEY]
                         [--aidefense-api-url AIDEFENSE_API_URL]
-                        [--llm-provider {anthropic,openai,openai-compatible}]
+                        [--llm-provider {anthropic,openai}]
                         [--llm-consensus-runs N] [--llm-max-tokens N]
                         [--use-trigger] [--enable-meta]
                         [--policy PRESET_OR_PATH] [--lenient]
@@ -353,7 +344,7 @@ options:
   -h, --help            show this help message and exit
   --recursive, --no-recursive, -r
                         Recursively search for skills (default: True; use
-                        --no-recursive to disable) (default: True)
+                        --no-recursive to disable)
   --check-overlap       Enable cross-skill description overlap check
   --format {summary,json,markdown,table,sarif,html}
                         Output format (default: summary). May be specified
@@ -374,8 +365,6 @@ options:
   --output-table OUTPUT_TABLE
                         Write Table report to this file
   --detailed            Include detailed findings (Markdown output only)
-  --render-markdown     With --format markdown: render markdown even when
-                        stdout is not detected as a TTY.
   --no-render-markdown  With --format markdown to terminal: print raw markdown
                         instead of rendering (for pipe/copy).
   --compact             Compact JSON output
@@ -397,9 +386,8 @@ options:
                         AI Defense API key (or set AI_DEFENSE_API_KEY)
   --aidefense-api-url AIDEFENSE_API_URL
                         AI Defense API URL (optional, defaults to US region)
-  --llm-provider {anthropic,openai,openai-compatible}
-                        LLM provider shortcut or explicit OpenAI-compatible
-                        override
+  --llm-provider {anthropic,openai}
+                        LLM provider
   --llm-consensus-runs N
                         Run LLM analysis N times and keep only findings with
                         majority agreement (reduces false positives, increases

--- a/docs/reference/cli-command-reference.md
+++ b/docs/reference/cli-command-reference.md
@@ -99,13 +99,14 @@ usage: cli.py scan [-h] [--format {summary,json,markdown,table,sarif,html}]
                    [--output-sarif OUTPUT_SARIF]
                    [--output-markdown OUTPUT_MARKDOWN]
                    [--output-html OUTPUT_HTML] [--output-table OUTPUT_TABLE]
-                   [--detailed] [--no-render-markdown] [--compact] [--verbose]
-                   [--fail-on-findings] [--fail-on-severity LEVEL]
-                   [--use-behavioral] [--use-llm] [--use-virustotal]
-                   [--vt-api-key VT_API_KEY] [--vt-upload-files]
-                   [--use-aidefense] [--aidefense-api-key AIDEFENSE_API_KEY]
+                   [--detailed] [--render-markdown | --no-render-markdown]
+                   [--compact] [--verbose] [--fail-on-findings]
+                   [--fail-on-severity LEVEL] [--use-behavioral] [--use-llm]
+                   [--use-virustotal] [--vt-api-key VT_API_KEY]
+                   [--vt-upload-files] [--use-aidefense]
+                   [--aidefense-api-key AIDEFENSE_API_KEY]
                    [--aidefense-api-url AIDEFENSE_API_URL]
-                   [--llm-provider {anthropic,openai}]
+                   [--llm-provider {anthropic,openai,openai-compatible}]
                    [--llm-consensus-runs N] [--llm-max-tokens N]
                    [--use-trigger] [--enable-meta] [--policy PRESET_OR_PATH]
                    [--lenient] [--skill-file FILENAME] [--custom-rules PATH]
@@ -137,6 +138,8 @@ options:
   --output-table OUTPUT_TABLE
                         Write Table report to this file
   --detailed            Include detailed findings (Markdown output only)
+  --render-markdown     With --format markdown: render markdown even when
+                        stdout is not detected as a TTY.
   --no-render-markdown  With --format markdown to terminal: print raw markdown
                         instead of rendering (for pipe/copy).
   --compact             Compact JSON output
@@ -158,8 +161,9 @@ options:
                         AI Defense API key (or set AI_DEFENSE_API_KEY)
   --aidefense-api-url AIDEFENSE_API_URL
                         AI Defense API URL (optional, defaults to US region)
-  --llm-provider {anthropic,openai}
-                        LLM provider
+  --llm-provider {anthropic,openai,openai-compatible}
+                        LLM provider shortcut or explicit OpenAI-compatible
+                        override
   --llm-consensus-runs N
                         Run LLM analysis N times and keep only findings with
                         majority agreement (reduces false positives, increases
@@ -207,14 +211,15 @@ usage: cli.py scan-all [-h] [--recursive] [--check-overlap]
                        [--output-markdown OUTPUT_MARKDOWN]
                        [--output-html OUTPUT_HTML]
                        [--output-table OUTPUT_TABLE] [--detailed]
-                       [--no-render-markdown] [--compact] [--verbose]
-                       [--fail-on-findings] [--fail-on-severity LEVEL]
-                       [--use-behavioral] [--use-llm] [--use-virustotal]
+                       [--render-markdown | --no-render-markdown] [--compact]
+                       [--verbose] [--fail-on-findings]
+                       [--fail-on-severity LEVEL] [--use-behavioral]
+                       [--use-llm] [--use-virustotal]
                        [--vt-api-key VT_API_KEY] [--vt-upload-files]
                        [--use-aidefense]
                        [--aidefense-api-key AIDEFENSE_API_KEY]
                        [--aidefense-api-url AIDEFENSE_API_URL]
-                       [--llm-provider {anthropic,openai}]
+                       [--llm-provider {anthropic,openai,openai-compatible}]
                        [--llm-consensus-runs N] [--llm-max-tokens N]
                        [--use-trigger] [--enable-meta]
                        [--policy PRESET_OR_PATH] [--lenient]
@@ -249,6 +254,8 @@ options:
   --output-table OUTPUT_TABLE
                         Write Table report to this file
   --detailed            Include detailed findings (Markdown output only)
+  --render-markdown     With --format markdown: render markdown even when
+                        stdout is not detected as a TTY.
   --no-render-markdown  With --format markdown to terminal: print raw markdown
                         instead of rendering (for pipe/copy).
   --compact             Compact JSON output
@@ -270,8 +277,9 @@ options:
                         AI Defense API key (or set AI_DEFENSE_API_KEY)
   --aidefense-api-url AIDEFENSE_API_URL
                         AI Defense API URL (optional, defaults to US region)
-  --llm-provider {anthropic,openai}
-                        LLM provider
+  --llm-provider {anthropic,openai,openai-compatible}
+                        LLM provider shortcut or explicit OpenAI-compatible
+                        override
   --llm-consensus-runs N
                         Run LLM analysis N times and keep only findings with
                         majority agreement (reduces false positives, increases
@@ -320,14 +328,15 @@ usage: cli.py scan-repo [-h] [--recursive | --no-recursive | -r]
                         [--output-markdown OUTPUT_MARKDOWN]
                         [--output-html OUTPUT_HTML]
                         [--output-table OUTPUT_TABLE] [--detailed]
-                        [--no-render-markdown] [--compact] [--verbose]
-                        [--fail-on-findings] [--fail-on-severity LEVEL]
-                        [--use-behavioral] [--use-llm] [--use-virustotal]
+                        [--render-markdown | --no-render-markdown] [--compact]
+                        [--verbose] [--fail-on-findings]
+                        [--fail-on-severity LEVEL] [--use-behavioral]
+                        [--use-llm] [--use-virustotal]
                         [--vt-api-key VT_API_KEY] [--vt-upload-files]
                         [--use-aidefense]
                         [--aidefense-api-key AIDEFENSE_API_KEY]
                         [--aidefense-api-url AIDEFENSE_API_URL]
-                        [--llm-provider {anthropic,openai}]
+                        [--llm-provider {anthropic,openai,openai-compatible}]
                         [--llm-consensus-runs N] [--llm-max-tokens N]
                         [--use-trigger] [--enable-meta]
                         [--policy PRESET_OR_PATH] [--lenient]
@@ -344,7 +353,7 @@ options:
   -h, --help            show this help message and exit
   --recursive, --no-recursive, -r
                         Recursively search for skills (default: True; use
-                        --no-recursive to disable)
+                        --no-recursive to disable) (default: True)
   --check-overlap       Enable cross-skill description overlap check
   --format {summary,json,markdown,table,sarif,html}
                         Output format (default: summary). May be specified
@@ -365,6 +374,8 @@ options:
   --output-table OUTPUT_TABLE
                         Write Table report to this file
   --detailed            Include detailed findings (Markdown output only)
+  --render-markdown     With --format markdown: render markdown even when
+                        stdout is not detected as a TTY.
   --no-render-markdown  With --format markdown to terminal: print raw markdown
                         instead of rendering (for pipe/copy).
   --compact             Compact JSON output
@@ -386,8 +397,9 @@ options:
                         AI Defense API key (or set AI_DEFENSE_API_KEY)
   --aidefense-api-url AIDEFENSE_API_URL
                         AI Defense API URL (optional, defaults to US region)
-  --llm-provider {anthropic,openai}
-                        LLM provider
+  --llm-provider {anthropic,openai,openai-compatible}
+                        LLM provider shortcut or explicit OpenAI-compatible
+                        override
   --llm-consensus-runs N
                         Run LLM analysis N times and keep only findings with
                         majority agreement (reduces false positives, increases

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -58,7 +58,7 @@ Credentials for Vertex AI and Google AI Studio.
 
 | Variable | Description | Example |
 |---|---|---|
-| `GOOGLE_APPLICATION_CREDENTIALS` | Path to GCP service account credentials. | `/path/to/sa-key.json` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to GCP service account credentials. Optional -- if unset, `vertex_ai/*` models fall back to ambient Application Default Credentials (e.g. a GCE/Cloud Run attached service account or Workload Identity), same as Bedrock's IAM role fallback. | `/path/to/sa-key.json` |
 | `GEMINI_API_KEY` | Google AI Studio key; auto-set from `SKILL_SCANNER_LLM_API_KEY` when using Gemini via LiteLLM. | `(auto-set from LLM_API_KEY)` |
 
 ## VirusTotal

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -23,7 +23,7 @@ Primary settings for the LLM semantic analyzer.
 
 | Variable | Description | Example |
 |---|---|---|
-| `SKILL_SCANNER_LLM_API_KEY` | Primary API key for LLM analyzer and meta fallback. **(required)** | `sk-ant-...` |
+| `SKILL_SCANNER_LLM_API_KEY` | Primary API key for LLM analyzer and meta fallback. Required for API-key-based providers; not required for Bedrock (IAM), Ollama (local), or Vertex AI (ambient Application Default Credentials). | `sk-ant-...` |
 | `SKILL_SCANNER_LLM_MODEL` | Primary model identifier for semantic analysis. | `anthropic/claude-sonnet-4-20250514` |
 | `SKILL_SCANNER_LLM_PROVIDER` | Optional provider override, including OpenAI-compatible custom endpoint routing. | `openai` |
 | `SKILL_SCANNER_LLM_BASE_URL` | Optional custom endpoint base URL for provider routing. | `https://api.openai.com/v1` |
@@ -115,7 +115,7 @@ Paths, allowlists, and other advanced settings.
 | `ENABLE_LLM_ANALYZER` | `skill_scanner/config/config.py` |
 | `ENABLE_STATIC_ANALYZER` | `skill_scanner/config/config.py` |
 | `GEMINI_API_KEY` | `skill_scanner/core/analyzers/llm_provider_config.py` |
-| `GOOGLE_APPLICATION_CREDENTIALS` | `.env.example`, `skill_scanner/core/analyzers/llm_provider_config.py` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `.env.example` |
 | `SKILL_SCANNER_ALLOWED_ROOTS` | `skill_scanner/api/router.py` |
 | `SKILL_SCANNER_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_API_VERSION` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |

--- a/docs/reference/dependencies-and-llm-providers.md
+++ b/docs/reference/dependencies-and-llm-providers.md
@@ -108,7 +108,8 @@ For OpenAI and OpenAI-compatible custom endpoints, `SKILL_SCANNER_LLM_USER` can 
 | OpenAI-compatible custom endpoint | API key + endpoint | `SKILL_SCANNER_LLM_API_KEY`, `SKILL_SCANNER_LLM_PROVIDER=openai`, `SKILL_SCANNER_LLM_BASE_URL` |
 | AWS Bedrock (API key) | API key | `SKILL_SCANNER_LLM_API_KEY` |
 | AWS Bedrock (IAM) | AWS credentials | `AWS_REGION`, `AWS_PROFILE` (optional: `AWS_SESSION_TOKEN`) |
-| Google Vertex AI | Service account | `GOOGLE_APPLICATION_CREDENTIALS` |
+| Google Vertex AI (service account) | Service account key file | `GOOGLE_APPLICATION_CREDENTIALS` |
+| Google Vertex AI (ambient ADC) | Workload Identity / attached service account | none -- falls back automatically, like Bedrock IAM |
 | Google AI Studio | API key | `SKILL_SCANNER_LLM_API_KEY` (auto-sets `GEMINI_API_KEY`) |
 | Azure OpenAI | API key + endpoint | `SKILL_SCANNER_LLM_API_KEY`, `SKILL_SCANNER_LLM_BASE_URL`, `SKILL_SCANNER_LLM_API_VERSION` |
 | Ollama | None | — |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ dependencies = [
     # Floor pin: avoid compromised PyPI lines in 1.80.16 / 1.82.3 / 1.82.8 (BerriAI/litellm#24512)
     # SSRF fix in 1.83.7 (GHSA-xqmj-j6mv-4862), and CVE-2026-49468 fix in 1.84.0.
     "litellm>=1.84.0,<2",
+    # Floor pin: PYSEC-2026-2132 fixed in 8.3.3. Transitive via litellm/magika/uvicorn/typer.
+    "click>=8.3.3",
 ]
 
 [project.optional-dependencies]
@@ -83,6 +85,9 @@ dependencies = [
 google = [
     "google-genai>=1.60,<2",
     "google-generativeai>=0.8,<1",
+    # Floor pins for transitive CVEs pulled in via google-generativeai -> google-api-python-client / google-auth
+    "httplib2>=0.32.0",  # PYSEC-2026-3444
+    "pyasn1>=0.6.4",  # PYSEC-2026-3455, PYSEC-2026-3456, PYSEC-2026-3457
 ]
 # AWS Bedrock support (requires boto3 for IAM credentials)
 bedrock = [
@@ -91,6 +96,9 @@ bedrock = [
 # Google Vertex AI support
 vertex = [
     "google-cloud-aiplatform>=1.130,<2",
+    # Floor pins for transitive CVEs pulled in via google-cloud-aiplatform -> google-api-core / google-auth
+    "httplib2>=0.32.0",  # PYSEC-2026-3444
+    "pyasn1>=0.6.4",  # PYSEC-2026-3455, PYSEC-2026-3456, PYSEC-2026-3457
 ]
 # Azure OpenAI support (for managed identity auth)
 azure = [
@@ -107,6 +115,8 @@ all = [
     "boto3>=1.40,<2",
     "google-cloud-aiplatform>=1.130,<2",
     "azure-identity>=1.20,<2",
+    "httplib2>=0.32.0",  # PYSEC-2026-3444
+    "pyasn1>=0.6.4",  # PYSEC-2026-3455, PYSEC-2026-3456, PYSEC-2026-3457
 ]
 
 [dependency-groups]

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -392,7 +392,11 @@ def _collect_env_variables() -> dict[str, set[str]]:
 
 def _describe_env_var(var: str) -> str:
     descriptions = {
-        "SKILL_SCANNER_LLM_API_KEY": "Primary API key for LLM analyzer and meta fallback.",
+        "SKILL_SCANNER_LLM_API_KEY": (
+            "Primary API key for LLM analyzer and meta fallback. Required for "
+            "API-key-based providers; not required for Bedrock (IAM), Ollama "
+            "(local), or Vertex AI (ambient Application Default Credentials)."
+        ),
         "SKILL_SCANNER_LLM_MODEL": "Primary model identifier for semantic analysis.",
         "SKILL_SCANNER_LLM_PROVIDER": "Optional provider override, including OpenAI-compatible custom endpoint routing.",
         "SKILL_SCANNER_LLM_BASE_URL": "Optional custom endpoint base URL for provider routing.",
@@ -410,7 +414,12 @@ def _describe_env_var(var: str) -> str:
         "AWS_REGION": "AWS region for Bedrock-backed flows.",
         "AWS_PROFILE": "AWS credential profile for Bedrock IAM auth.",
         "AWS_SESSION_TOKEN": "Optional AWS session token.",
-        "GOOGLE_APPLICATION_CREDENTIALS": "Path to GCP service account credentials.",
+        "GOOGLE_APPLICATION_CREDENTIALS": (
+            "Path to GCP service account credentials. Optional -- if unset, "
+            "`vertex_ai/*` models fall back to ambient Application Default "
+            "Credentials (e.g. a GCE/Cloud Run attached service account or "
+            "Workload Identity), same as Bedrock's IAM role fallback."
+        ),
         "SKILL_SCANNER_ALLOWED_ROOTS": "Colon-delimited API path allowlist for server-side path access.",
         "SKILL_SCANNER_TAXONOMY_PATH": "Path to a custom Cisco AI taxonomy YAML file (overridden by `--taxonomy`).",
         "SKILL_SCANNER_THREAT_MAPPING_PATH": "Path to a custom threat mapping YAML file (overridden by `--threat-mapping`).",
@@ -518,7 +527,7 @@ _ENV_VAR_EXAMPLES: dict[str, str] = {
     "SKILL_SCANNER_THREAT_MAPPING_PATH": "/path/to/threats.yaml",
 }
 
-_ENV_VAR_REQUIRED: set[str] = {"SKILL_SCANNER_LLM_API_KEY"}
+_ENV_VAR_REQUIRED: set[str] = set()
 
 
 def _render_configuration_reference() -> str:

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -84,7 +84,7 @@ def _render_cli_reference() -> str:
         "| `skill-scanner configure-policy` | Interactive TUI policy editor | `skill-scanner configure-policy` |",
         "| `skill-scanner interactive` | Interactive setup wizard | `skill-scanner interactive` |",
         "| `skill-scanner-api` | Start the REST API server | `skill-scanner-api --port 8080` |",
-        "| `skill-scanner-pre-commit` | Git pre-commit hook | `skill-scanner-pre-commit install` |",
+        "| `skill-scanner-pre-commit` | Git pre-commit hook | `skill-scanner-pre-commit --install` |",
         "",
         "## Common Flags",
         "",

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -7,7 +7,7 @@
 # Installation:
 #   1. Copy to .git/hooks/pre-commit
 #   2. Or symlink: ln -s ../../scripts/pre-commit-hook.sh .git/hooks/pre-commit
-#   3. Or run: skill-scanner-pre-commit install
+#   3. Or run: skill-scanner-pre-commit --install
 #
 # Configuration:
 #   Create .skill_scannerrc in your repo root:

--- a/skill_scanner/core/analyzers/llm_provider_config.py
+++ b/skill_scanner/core/analyzers/llm_provider_config.py
@@ -173,7 +173,12 @@ class ProviderConfig:
         Uses SKILL_SCANNER_LLM_API_KEY consistently for all providers.
 
         Special cases:
-        - Vertex AI: Uses GOOGLE_APPLICATION_CREDENTIALS (service account)
+        - Vertex AI: Uses GOOGLE_APPLICATION_CREDENTIALS (service account key
+          file) when set; otherwise ``validate()`` allows a ``None`` result
+          through (like Bedrock's IAM role) so LiteLLM/google-auth can fall
+          back to ambient Application Default Credentials -- e.g. a GCE/Cloud
+          Run attached service account or Workload Identity, with no key file
+          on disk at all.
         - Ollama: No API key needed (local)
         - Azure: Falls back to Entra ID (``az login``) when no API key is set
         """
@@ -269,7 +274,7 @@ class ProviderConfig:
 
     def validate(self) -> None:
         """Validate that configuration is complete."""
-        if not self.is_bedrock and not self.is_ollama and not self.api_key:
+        if not self.is_bedrock and not self.is_ollama and not self.is_vertex and not self.api_key:
             if self.is_azure:
                 raise ValueError(
                     f"No API key or Entra ID credentials found for Azure model {self.model}. "

--- a/skill_scanner/core/analyzers/llm_provider_config.py
+++ b/skill_scanner/core/analyzers/llm_provider_config.py
@@ -187,7 +187,7 @@ class ProviderConfig:
 
         # Special cases with different auth mechanisms
         if self.is_vertex:
-            return os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+            return None
         elif self.is_ollama:
             return None
 

--- a/skill_scanner/core/analyzers/llm_provider_config.py
+++ b/skill_scanner/core/analyzers/llm_provider_config.py
@@ -173,12 +173,12 @@ class ProviderConfig:
         Uses SKILL_SCANNER_LLM_API_KEY consistently for all providers.
 
         Special cases:
-        - Vertex AI: Uses GOOGLE_APPLICATION_CREDENTIALS (service account key
-          file) when set; otherwise ``validate()`` allows a ``None`` result
-          through (like Bedrock's IAM role) so LiteLLM/google-auth can fall
-          back to ambient Application Default Credentials -- e.g. a GCE/Cloud
-          Run attached service account or Workload Identity, with no key file
-          on disk at all.
+        - Vertex AI: Always returns ``None`` -- LiteLLM/google-auth read
+          GOOGLE_APPLICATION_CREDENTIALS directly from the environment when
+          set, or fall back to ambient Application Default Credentials
+          (like Bedrock's IAM role) -- e.g. a GCE/Cloud Run attached
+          service account or Workload Identity, with no key file on disk
+          at all.
         - Ollama: No API key needed (local)
         - Azure: Falls back to Entra ID (``az login``) when no API key is set
         """

--- a/skill_scanner/core/changed_skills.py
+++ b/skill_scanner/core/changed_skills.py
@@ -37,10 +37,10 @@ def _nearest_skill_root(start: Path, skill_file: str, stop: Path | None) -> Path
     """Walk upward from *start* and return the nearest skill root."""
     candidate = start
     while True:
+        if stop is not None and (candidate == stop or not candidate.is_relative_to(stop)):
+            return None
         if (candidate / skill_file).is_file():
             return candidate
-        if stop is not None and candidate == stop:
-            return None
         parent = candidate.parent
         if parent == candidate:
             return None

--- a/skill_scanner/core/changed_skills.py
+++ b/skill_scanner/core/changed_skills.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve changed repository paths to the skill packages they affect."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def _resolve_path(path: Path) -> Path:
+    """Resolve a path without requiring the final entry to exist."""
+    try:
+        return path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        # ``absolute()`` leaves ``..`` segments intact, which can make a
+        # lexical containment check accept a path that escapes the repository.
+        return Path(os.path.abspath(path))
+
+
+def _nearest_skill_root(start: Path, skill_file: str, stop: Path | None) -> Path | None:
+    """Walk upward from *start* and return the nearest skill root."""
+    candidate = start
+    while True:
+        if (candidate / skill_file).is_file():
+            return candidate
+        if stop is not None and candidate == stop:
+            return None
+        parent = candidate.parent
+        if parent == candidate:
+            return None
+        candidate = parent
+
+
+def resolve_affected_skills(
+    changed_files: Iterable[str | Path],
+    *,
+    repo_root: str | Path | None = None,
+    skill_roots: Iterable[str | Path] = (),
+    skill_file: str = "SKILL.md",
+) -> set[Path]:
+    """Map changed file paths to their nearest containing skill directories.
+
+    Paths may be absolute or relative to *repo_root*. When *repo_root* is
+    provided, paths outside that repository are ignored so an untrusted file
+    argument cannot make the hook scan arbitrary directories. Missing paths
+    are supported, allowing deleted files to map to a still-existing skill.
+
+    *skill_roots* provides compatibility with configured skill collections.
+    Each root is used as a fallback for the common ``<root>/<skill>/...``
+    layout; the nearest parent containing *skill_file* always wins.
+    """
+    if not skill_file or Path(skill_file).name != skill_file:
+        raise ValueError("skill_file must be a filename, not a path")
+
+    base = _resolve_path(Path(repo_root) if repo_root is not None else Path.cwd())
+    bounded = repo_root is not None
+
+    configured_roots: list[Path] = []
+    for root in skill_roots:
+        root_path = Path(root)
+        if not root_path.is_absolute():
+            root_path = base / root_path
+        root_path = _resolve_path(root_path)
+        if bounded and not root_path.is_relative_to(base):
+            continue
+        configured_roots.append(root_path)
+
+    affected: set[Path] = set()
+    for changed_file in changed_files:
+        raw_value = str(changed_file)
+        if not raw_value:
+            continue
+
+        changed_path = Path(raw_value)
+        if not changed_path.is_absolute():
+            changed_path = base / changed_path
+        changed_path = _resolve_path(changed_path)
+
+        if bounded and not changed_path.is_relative_to(base):
+            continue
+
+        nearest = _nearest_skill_root(changed_path.parent, skill_file, base if bounded else None)
+        if nearest is not None:
+            affected.add(nearest)
+            continue
+
+        # Preserve the configured ``<skills-root>/<skill>/...`` lookup used by
+        # the original hook. This is mainly useful for callers that provide a
+        # path before its leaf file has been materialized.
+        for configured_root in configured_roots:
+            try:
+                relative = changed_path.relative_to(configured_root)
+            except ValueError:
+                continue
+            if not relative.parts:
+                continue
+            skill_root = configured_root / relative.parts[0]
+            if (skill_root / skill_file).is_file():
+                affected.add(skill_root)
+                break
+
+    return affected

--- a/skill_scanner/hooks/pre_commit.py
+++ b/skill_scanner/hooks/pre_commit.py
@@ -33,7 +33,7 @@ Usage:
              entry: skill-scanner-pre-commit
              language: python
              types: [file]
-             pass_filenames: false
+             pass_filenames: true
 
 Configuration:
     Create a .skill_scannerrc file in your repo root:
@@ -50,6 +50,8 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+
+from ..core.changed_skills import resolve_affected_skills
 
 # Default configuration
 DEFAULT_CONFIG = {
@@ -111,7 +113,7 @@ def get_staged_files() -> list[str]:
     """
     try:
         result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMRD"],
             capture_output=True,
             text=True,
             check=True,
@@ -121,48 +123,35 @@ def get_staged_files() -> list[str]:
         return []
 
 
-def get_affected_skills(staged_files: list[str], skills_path: str) -> set[Path]:
+def get_affected_skills(
+    changed_files: list[str],
+    skills_path: str,
+    *,
+    repo_root: str | Path | None = None,
+    skill_file: str = "SKILL.md",
+) -> set[Path]:
     """
-    Identify skill directories affected by staged changes.
+    Identify skill directories affected by changed files.
 
     Walks up from each staged file to find the nearest parent containing a
     SKILL.md.  Also honours the configured ``skills_path`` prefix so that
     changes inside a known skills tree are always detected.
 
     Args:
-        staged_files: List of staged file paths
+        changed_files: File paths supplied by pre-commit or discovered from the index
         skills_path: Base path for skills
+        repo_root: Optional repository boundary and base for relative paths
+        skill_file: Metadata filename used to identify a skill root
 
     Returns:
         Set of affected skill directory paths
     """
-    affected_skills: set[Path] = set()
-    skills_prefix = skills_path.rstrip("/") + "/"
-
-    for file_path in staged_files:
-        # 1. Check if file is in the configured skills directory
-        if file_path.startswith(skills_prefix) or file_path.startswith(skills_path):
-            relative = file_path[len(skills_path) :].lstrip("/")
-            parts = relative.split("/")
-
-            if parts:
-                skill_dir = Path(skills_path) / parts[0]
-                skill_md = skill_dir / "SKILL.md"
-                if skill_md.exists():
-                    affected_skills.add(skill_dir)
-
-        # 2. Walk up from the staged file to locate the nearest SKILL.md
-        candidate = Path(file_path).parent
-        while str(candidate) not in ("", "."):
-            if (candidate / "SKILL.md").exists():
-                affected_skills.add(candidate)
-                break
-            parent = candidate.parent
-            if parent == candidate:
-                break
-            candidate = parent
-
-    return affected_skills
+    return resolve_affected_skills(
+        changed_files,
+        repo_root=repo_root,
+        skill_roots=(skills_path,),
+        skill_file=skill_file,
+    )
 
 
 def scan_skill(skill_dir: Path, config: dict) -> dict:
@@ -300,15 +289,16 @@ def main(args: list[str] | None = None) -> int:
         help="Tolerate malformed skills instead of failing",
     )
     parser.add_argument(
-        "install",
-        nargs="?",
-        help="Install pre-commit hook",
+        "filenames",
+        nargs="*",
+        metavar="FILE",
+        help="Changed files supplied by pre-commit (falls back to staged files when omitted)",
     )
 
     parsed_args = parser.parse_args(args)
 
     # Handle install command
-    if parsed_args.install == "install":
+    if parsed_args.filenames == ["install"] and not Path("install").exists():
         return install_hook()
 
     # Find repo root
@@ -343,8 +333,12 @@ def main(args: list[str] | None = None) -> int:
         else:
             affected_skills = set()
     else:
-        staged_files = get_staged_files()
-        affected_skills = get_affected_skills(staged_files, config["skills_path"])
+        changed_files = parsed_args.filenames or get_staged_files()
+        affected_skills = get_affected_skills(
+            changed_files,
+            config["skills_path"],
+            repo_root=repo_root,
+        )
 
     if not affected_skills:
         # No skills affected, allow commit

--- a/skill_scanner/hooks/pre_commit.py
+++ b/skill_scanner/hooks/pre_commit.py
@@ -128,17 +128,14 @@ def get_ref_changed_files(from_ref: str, to_ref: str) -> list[str]:
     """Get changed paths between two revisions, including deleted files."""
     changed_files: list[str] = []
     comparison = f"{from_ref}...{to_ref}"
-    try:
-        for diff_filter in ("ACMR", "D"):
-            result = subprocess.run(
-                ["git", "diff", f"--diff-filter={diff_filter}", "--name-only", comparison],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            changed_files.extend(line.strip() for line in result.stdout.splitlines() if line.strip())
-    except subprocess.CalledProcessError:
-        return []
+    for diff_filter in ("ACMR", "D"):
+        result = subprocess.run(
+            ["git", "diff", f"--diff-filter={diff_filter}", "--name-only", comparison],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        changed_files.extend(line.strip() for line in result.stdout.splitlines() if line.strip())
 
     return list(dict.fromkeys(changed_files))
 
@@ -363,7 +360,12 @@ def main(args: list[str] | None = None) -> int:
         from_ref = os.environ.get("PRE_COMMIT_FROM_REF")
         to_ref = os.environ.get("PRE_COMMIT_TO_REF")
         if from_ref and to_ref:
-            changed_files.extend(get_ref_changed_files(from_ref, to_ref))
+            try:
+                changed_files.extend(get_ref_changed_files(from_ref, to_ref))
+            except subprocess.CalledProcessError as exc:
+                detail = exc.stderr.strip() if exc.stderr else str(exc)
+                print(f"Error: Failed to discover changed files: {detail}", file=sys.stderr)
+                return 1
             changed_files = list(dict.fromkeys(changed_files))
         elif not changed_files:
             changed_files = get_staged_files()

--- a/skill_scanner/hooks/pre_commit.py
+++ b/skill_scanner/hooks/pre_commit.py
@@ -23,7 +23,7 @@ and blocks commits that contain HIGH or CRITICAL severity findings.
 
 Usage:
     1. Install as a pre-commit hook:
-       skill-scanner-pre-commit install
+       skill-scanner-pre-commit --install
 
     2. Or add to .pre-commit-config.yaml:
        - repo: local
@@ -32,8 +32,8 @@ Usage:
              name: Skill Scanner
              entry: skill-scanner-pre-commit
              language: python
-             types: [file]
-             pass_filenames: true
+             pass_filenames: false
+             always_run: true
 
 Configuration:
     Create a .skill_scannerrc file in your repo root:
@@ -47,6 +47,7 @@ Configuration:
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -121,6 +122,25 @@ def get_staged_files() -> list[str]:
         return [f.strip() for f in result.stdout.split("\n") if f.strip()]
     except subprocess.CalledProcessError:
         return []
+
+
+def get_ref_changed_files(from_ref: str, to_ref: str) -> list[str]:
+    """Get changed paths between two revisions, including deleted files."""
+    changed_files: list[str] = []
+    comparison = f"{from_ref}...{to_ref}"
+    try:
+        for diff_filter in ("ACMR", "D"):
+            result = subprocess.run(
+                ["git", "diff", f"--diff-filter={diff_filter}", "--name-only", comparison],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            changed_files.extend(line.strip() for line in result.stdout.splitlines() if line.strip())
+    except subprocess.CalledProcessError:
+        return []
+
+    return list(dict.fromkeys(changed_files))
 
 
 def get_affected_skills(
@@ -279,9 +299,15 @@ def main(args: list[str] | None = None) -> int:
         help="Override skills path from config",
     )
     parser.add_argument(
-        "--all",
+        "--scan-all",
         action="store_true",
+        dest="scan_all",
         help="Scan all skills, not just staged ones",
+    )
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="Install the built-in pre-commit hook",
     )
     parser.add_argument(
         "--lenient",
@@ -297,8 +323,8 @@ def main(args: list[str] | None = None) -> int:
 
     parsed_args = parser.parse_args(args)
 
-    # Handle install command
-    if parsed_args.filenames == ["install"] and not Path("install").exists():
+    # Installation is explicit so a changed path named ``install`` remains a filename.
+    if parsed_args.install:
         return install_hook()
 
     # Find repo root
@@ -326,14 +352,21 @@ def main(args: list[str] | None = None) -> int:
         config["lenient"] = True
 
     # Get staged files and affected skills
-    if parsed_args.all:
+    if parsed_args.scan_all:
         skills_dir = repo_root / config["skills_path"]
         if skills_dir.exists():
             affected_skills = {d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()}
         else:
             affected_skills = set()
     else:
-        changed_files = parsed_args.filenames or get_staged_files()
+        changed_files = list(parsed_args.filenames)
+        from_ref = os.environ.get("PRE_COMMIT_FROM_REF")
+        to_ref = os.environ.get("PRE_COMMIT_TO_REF")
+        if from_ref and to_ref:
+            changed_files.extend(get_ref_changed_files(from_ref, to_ref))
+            changed_files = list(dict.fromkeys(changed_files))
+        elif not changed_files:
+            changed_files = get_staged_files()
         affected_skills = get_affected_skills(
             changed_files,
             config["skills_path"],

--- a/skill_scanner/hooks/pre_commit.py
+++ b/skill_scanner/hooks/pre_commit.py
@@ -114,12 +114,12 @@ def get_staged_files() -> list[str]:
     """
     try:
         result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMRD"],
+            ["git", "diff", "--cached", "--name-only", "-z", "--diff-filter=ACMRTD"],
             capture_output=True,
             text=True,
             check=True,
         )
-        return [f.strip() for f in result.stdout.split("\n") if f.strip()]
+        return [path for path in result.stdout.split("\0") if path]
     except subprocess.CalledProcessError:
         return []
 
@@ -128,14 +128,14 @@ def get_ref_changed_files(from_ref: str, to_ref: str) -> list[str]:
     """Get changed paths between two revisions, including deleted files."""
     changed_files: list[str] = []
     comparison = f"{from_ref}...{to_ref}"
-    for diff_filter in ("ACMR", "D"):
+    for diff_filter in ("ACMRT", "D"):
         result = subprocess.run(
-            ["git", "diff", f"--diff-filter={diff_filter}", "--name-only", comparison],
+            ["git", "diff", f"--diff-filter={diff_filter}", "--name-only", "-z", comparison],
             capture_output=True,
             text=True,
             check=True,
         )
-        changed_files.extend(line.strip() for line in result.stdout.splitlines() if line.strip())
+        changed_files.extend(path for path in result.stdout.split("\0") if path)
 
     return list(dict.fromkeys(changed_files))
 

--- a/tests/test_changed_skills.py
+++ b/tests/test_changed_skills.py
@@ -150,7 +150,7 @@ class TestStagedFileDiscovery:
         completed = CompletedProcess(
             args=[],
             returncode=0,
-            stdout="skills/alpha/deleted.py\n",
+            stdout="skills/alpha/deleted.py\0",
             stderr="",
         )
 
@@ -162,7 +162,8 @@ class TestStagedFileDiscovery:
             "diff",
             "--cached",
             "--name-only",
-            "--diff-filter=ACMRD",
+            "-z",
+            "--diff-filter=ACMRTD",
         ]
 
     def test_ref_diff_uses_a_separate_deletion_query(self):
@@ -170,13 +171,13 @@ class TestStagedFileDiscovery:
         non_deleted = CompletedProcess(
             args=[],
             returncode=0,
-            stdout="skills/alpha/changed.py\n",
+            stdout="skills/alpha/changed.py\0",
             stderr="",
         )
         deleted = CompletedProcess(
             args=[],
             returncode=0,
-            stdout="skills/alpha/deleted.py\ninstall\n",
+            stdout="skills/alpha/deleted.py\0install\0",
             stderr="",
         )
 
@@ -193,8 +194,9 @@ class TestStagedFileDiscovery:
         assert run.call_args_list[0].args[0] == [
             "git",
             "diff",
-            "--diff-filter=ACMR",
+            "--diff-filter=ACMRT",
             "--name-only",
+            "-z",
             "base...head",
         ]
         assert run.call_args_list[1].args[0] == [
@@ -202,8 +204,24 @@ class TestStagedFileDiscovery:
             "diff",
             "--diff-filter=D",
             "--name-only",
+            "-z",
             "base...head",
         ]
+
+    def test_preserves_unusual_path_characters(self):
+        """NUL-delimited output preserves whitespace and backslashes verbatim."""
+        completed = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="skills/tab\tname/SKILL.md\0skills/back\\slash/SKILL.md\0",
+            stderr="",
+        )
+
+        with patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=completed):
+            assert get_staged_files() == [
+                "skills/tab\tname/SKILL.md",
+                "skills/back\\slash/SKILL.md",
+            ]
 
     def test_ref_diff_propagates_git_failure(self):
         """Invalid CI refs cannot be mistaken for an empty change set."""

--- a/tests/test_changed_skills.py
+++ b/tests/test_changed_skills.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import patch
@@ -203,6 +204,17 @@ class TestStagedFileDiscovery:
             "--name-only",
             "base...head",
         ]
+
+    def test_ref_diff_propagates_git_failure(self):
+        """Invalid CI refs cannot be mistaken for an empty change set."""
+        with (
+            patch(
+                "skill_scanner.hooks.pre_commit.subprocess.run",
+                side_effect=subprocess.CalledProcessError(128, ["git", "diff"], stderr="bad revision"),
+            ),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            get_ref_changed_files("missing", "head")
 
 
 class TestPreCommitIncrementalFiles:

--- a/tests/test_changed_skills.py
+++ b/tests/test_changed_skills.py
@@ -25,10 +25,11 @@ from unittest.mock import patch
 import pytest
 
 from skill_scanner.core.changed_skills import resolve_affected_skills
-from skill_scanner.hooks.pre_commit import get_staged_files, main
+from skill_scanner.hooks.pre_commit import get_ref_changed_files, get_staged_files, main
 
 
 def _make_skill(skill_dir: Path) -> Path:
+    """Create a minimal skill directory for resolver tests."""
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         "---\nname: test-skill\ndescription: test skill\n---\n# Test\n",
@@ -38,7 +39,10 @@ def _make_skill(skill_dir: Path) -> Path:
 
 
 class TestResolveAffectedSkills:
+    """Cover repository-bounded changed-path resolution."""
+
     def test_resolves_relative_deleted_file(self, tmp_path):
+        """Deleted relative paths resolve through their surviving parents."""
         repo_root = tmp_path / "repo"
         skill_dir = _make_skill(repo_root / ".claude" / "skills" / "alpha")
 
@@ -51,6 +55,7 @@ class TestResolveAffectedSkills:
         assert result == {skill_dir.resolve()}
 
     def test_nearest_nested_skill_wins(self, tmp_path):
+        """The nearest nested skill takes precedence over its outer skill."""
         repo_root = tmp_path / "repo"
         _make_skill(repo_root / "skills" / "outer")
         inner = _make_skill(repo_root / "skills" / "outer" / "nested")
@@ -64,6 +69,7 @@ class TestResolveAffectedSkills:
         assert result == {inner.resolve()}
 
     def test_deduplicates_files_and_supports_spaces(self, tmp_path):
+        """Multiple paths with spaces resolve to one affected skill."""
         repo_root = tmp_path / "repo"
         skill_dir = _make_skill(repo_root / "skills" / " skill with spaces ")
 
@@ -79,6 +85,7 @@ class TestResolveAffectedSkills:
         assert result == {skill_dir.resolve()}
 
     def test_ignores_absolute_path_outside_repo(self, tmp_path):
+        """Absolute paths outside the repository boundary are ignored."""
         repo_root = tmp_path / "repo"
         repo_root.mkdir()
         outside = _make_skill(tmp_path / "outside")
@@ -91,6 +98,7 @@ class TestResolveAffectedSkills:
         assert result == set()
 
     def test_ignores_relative_path_traversal_outside_repo(self, tmp_path):
+        """Relative traversal cannot escape the repository boundary."""
         repo_root = tmp_path / "repo"
         repo_root.mkdir()
         _make_skill(tmp_path / "outside")
@@ -103,6 +111,7 @@ class TestResolveAffectedSkills:
         assert result == set()
 
     def test_ignores_configured_root_outside_repo(self, tmp_path):
+        """Configured skill roots outside the repository are ignored."""
         repo_root = tmp_path / "repo"
         repo_root.mkdir()
         outside = _make_skill(tmp_path / "outside" / "alpha")
@@ -116,12 +125,27 @@ class TestResolveAffectedSkills:
         assert result == set()
 
     def test_rejects_skill_file_paths(self):
+        """The metadata marker must be a filename rather than a path."""
         with pytest.raises(ValueError, match="filename"):
             resolve_affected_skills([], skill_file="metadata/SKILL.md")
 
+    def test_repo_root_is_an_exclusive_search_boundary(self, tmp_path):
+        """A marker at the repository root cannot become an affected skill."""
+        repo_root = _make_skill(tmp_path / "repo")
+
+        result = resolve_affected_skills(
+            ["scripts/run.py"],
+            repo_root=repo_root,
+        )
+
+        assert result == set()
+
 
 class TestStagedFileDiscovery:
+    """Cover Git-based changed-path discovery."""
+
     def test_includes_deleted_paths(self):
+        """The staged fallback asks Git to include deleted paths."""
         completed = CompletedProcess(
             args=[],
             returncode=0,
@@ -140,9 +164,52 @@ class TestStagedFileDiscovery:
             "--diff-filter=ACMRD",
         ]
 
+    def test_ref_diff_uses_a_separate_deletion_query(self):
+        """CI ref discovery obtains deleted paths through an explicit Git diff."""
+        non_deleted = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="skills/alpha/changed.py\n",
+            stderr="",
+        )
+        deleted = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="skills/alpha/deleted.py\ninstall\n",
+            stderr="",
+        )
+
+        with patch(
+            "skill_scanner.hooks.pre_commit.subprocess.run",
+            side_effect=[non_deleted, deleted],
+        ) as run:
+            assert get_ref_changed_files("base", "head") == [
+                "skills/alpha/changed.py",
+                "skills/alpha/deleted.py",
+                "install",
+            ]
+
+        assert run.call_args_list[0].args[0] == [
+            "git",
+            "diff",
+            "--diff-filter=ACMR",
+            "--name-only",
+            "base...head",
+        ]
+        assert run.call_args_list[1].args[0] == [
+            "git",
+            "diff",
+            "--diff-filter=D",
+            "--name-only",
+            "base...head",
+        ]
+
 
 class TestPreCommitIncrementalFiles:
+    """Cover pre-commit argument routing and changed-file selection."""
+
     def test_precommit_filenames_bypass_staged_diff(self, tmp_path, monkeypatch):
+        """Explicit filenames remain supported without reading the staged diff."""
         repo_root = tmp_path / "repo"
         skill_dir = _make_skill(repo_root / ".claude" / "skills" / "alpha")
         monkeypatch.chdir(repo_root)
@@ -179,6 +246,7 @@ class TestPreCommitIncrementalFiles:
         assert scan.call_args.args[0] == skill_dir.resolve()
 
     def test_no_filenames_keeps_staged_fallback(self, tmp_path, monkeypatch):
+        """Direct invocation without filenames retains staged discovery."""
         repo_root = tmp_path / "repo"
         skill_dir = _make_skill(repo_root / ".claude" / "skills" / "alpha")
         monkeypatch.chdir(repo_root)
@@ -209,7 +277,102 @@ class TestPreCommitIncrementalFiles:
         staged.assert_called_once_with()
         scan.assert_called_once()
 
-    def test_install_command_remains_supported(self):
+    def test_install_flag_remains_supported(self):
+        """The explicit install flag routes to hook installation."""
         with patch("skill_scanner.hooks.pre_commit.install_hook", return_value=0) as install:
-            assert main(["install"]) == 0
+            assert main(["--install"]) == 0
         install.assert_called_once_with()
+
+    def test_install_filename_is_not_a_subcommand(self, tmp_path, monkeypatch):
+        """A changed path named install goes through normal skill resolution."""
+        monkeypatch.chdir(tmp_path)
+        rev_parse = CompletedProcess(
+            args=["git", "rev-parse", "--show-toplevel"],
+            returncode=0,
+            stdout=f"{tmp_path}\n",
+            stderr="",
+        )
+
+        with (
+            patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=rev_parse),
+            patch("skill_scanner.hooks.pre_commit.install_hook") as install,
+            patch("skill_scanner.hooks.pre_commit.get_affected_skills", return_value=set()) as affected,
+        ):
+            assert main(["install"]) == 0
+
+        install.assert_not_called()
+        affected.assert_called_once_with(["install"], ".claude/skills", repo_root=tmp_path)
+
+    def test_ci_refs_use_internal_changed_file_discovery(self, tmp_path, monkeypatch):
+        """CI ref environment variables select internal changed-path discovery."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("PRE_COMMIT_FROM_REF", "base")
+        monkeypatch.setenv("PRE_COMMIT_TO_REF", "head")
+        rev_parse = CompletedProcess(
+            args=["git", "rev-parse", "--show-toplevel"],
+            returncode=0,
+            stdout=f"{tmp_path}\n",
+            stderr="",
+        )
+
+        with (
+            patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=rev_parse),
+            patch(
+                "skill_scanner.hooks.pre_commit.get_ref_changed_files",
+                return_value=["skills/alpha/deleted.py", "install"],
+            ) as changed,
+            patch("skill_scanner.hooks.pre_commit.get_staged_files") as staged,
+            patch("skill_scanner.hooks.pre_commit.get_affected_skills", return_value=set()) as affected,
+        ):
+            assert main([]) == 0
+
+        changed.assert_called_once_with("base", "head")
+        staged.assert_not_called()
+        affected.assert_called_once_with(
+            ["skills/alpha/deleted.py", "install"],
+            ".claude/skills",
+            repo_root=tmp_path,
+        )
+
+    def test_legacy_all_filename_cannot_trigger_full_scan(self, tmp_path, monkeypatch):
+        """A path token named --all remains a filename after the option boundary."""
+        monkeypatch.chdir(tmp_path)
+        rev_parse = CompletedProcess(
+            args=["git", "rev-parse", "--show-toplevel"],
+            returncode=0,
+            stdout=f"{tmp_path}\n",
+            stderr="",
+        )
+
+        with (
+            patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=rev_parse),
+            patch("skill_scanner.hooks.pre_commit.get_affected_skills", return_value=set()) as affected,
+        ):
+            assert main(["--", "--all"]) == 0
+
+        affected.assert_called_once_with(["--all"], ".claude/skills", repo_root=tmp_path)
+
+    def test_scan_all_option_scans_every_configured_skill(self, tmp_path, monkeypatch):
+        """The renamed scan-all option selects every configured skill."""
+        skill_dir = _make_skill(tmp_path / ".claude" / "skills" / "alpha")
+        monkeypatch.chdir(tmp_path)
+        rev_parse = CompletedProcess(
+            args=["git", "rev-parse", "--show-toplevel"],
+            returncode=0,
+            stdout=f"{tmp_path}\n",
+            stderr="",
+        )
+        clean_result = {
+            "skill_name": "alpha",
+            "skill_directory": str(skill_dir),
+            "findings": [],
+        }
+
+        with (
+            patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=rev_parse),
+            patch("skill_scanner.hooks.pre_commit.scan_skill", return_value=clean_result) as scan,
+        ):
+            assert main(["--scan-all"]) == 0
+
+        scan.assert_called_once()
+        assert scan.call_args.args[0] == skill_dir

--- a/tests/test_changed_skills.py
+++ b/tests/test_changed_skills.py
@@ -1,0 +1,215 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for incremental pre-commit skill resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from skill_scanner.core.changed_skills import resolve_affected_skills
+from skill_scanner.hooks.pre_commit import get_staged_files, main
+
+
+def _make_skill(skill_dir: Path) -> Path:
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: test-skill\ndescription: test skill\n---\n# Test\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+class TestResolveAffectedSkills:
+    def test_resolves_relative_deleted_file(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        skill_dir = _make_skill(repo_root / ".claude" / "skills" / "alpha")
+
+        result = resolve_affected_skills(
+            [".claude/skills/alpha/scripts/deleted.py"],
+            repo_root=repo_root,
+            skill_roots=(".claude/skills",),
+        )
+
+        assert result == {skill_dir.resolve()}
+
+    def test_nearest_nested_skill_wins(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        _make_skill(repo_root / "skills" / "outer")
+        inner = _make_skill(repo_root / "skills" / "outer" / "nested")
+
+        result = resolve_affected_skills(
+            ["skills/outer/nested/scripts/run.py"],
+            repo_root=repo_root,
+            skill_roots=("skills",),
+        )
+
+        assert result == {inner.resolve()}
+
+    def test_deduplicates_files_and_supports_spaces(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        skill_dir = _make_skill(repo_root / "skills" / " skill with spaces ")
+
+        result = resolve_affected_skills(
+            [
+                "skills/ skill with spaces /SKILL.md",
+                "skills/ skill with spaces /scripts/run.py",
+            ],
+            repo_root=repo_root,
+            skill_roots=("skills",),
+        )
+
+        assert result == {skill_dir.resolve()}
+
+    def test_ignores_absolute_path_outside_repo(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        outside = _make_skill(tmp_path / "outside")
+
+        result = resolve_affected_skills(
+            [outside / "scripts" / "run.py"],
+            repo_root=repo_root,
+        )
+
+        assert result == set()
+
+    def test_ignores_relative_path_traversal_outside_repo(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        _make_skill(tmp_path / "outside")
+
+        result = resolve_affected_skills(
+            ["../outside/scripts/run.py"],
+            repo_root=repo_root,
+        )
+
+        assert result == set()
+
+    def test_ignores_configured_root_outside_repo(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        outside = _make_skill(tmp_path / "outside" / "alpha")
+
+        result = resolve_affected_skills(
+            [repo_root / "unrelated" / "file.py"],
+            repo_root=repo_root,
+            skill_roots=(outside.parent,),
+        )
+
+        assert result == set()
+
+    def test_rejects_skill_file_paths(self):
+        with pytest.raises(ValueError, match="filename"):
+            resolve_affected_skills([], skill_file="metadata/SKILL.md")
+
+
+class TestStagedFileDiscovery:
+    def test_includes_deleted_paths(self):
+        completed = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="skills/alpha/deleted.py\n",
+            stderr="",
+        )
+
+        with patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=completed) as run:
+            assert get_staged_files() == ["skills/alpha/deleted.py"]
+
+        assert run.call_args.args[0] == [
+            "git",
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=ACMRD",
+        ]
+
+
+class TestPreCommitIncrementalFiles:
+    def test_precommit_filenames_bypass_staged_diff(self, tmp_path, monkeypatch):
+        repo_root = tmp_path / "repo"
+        skill_dir = _make_skill(repo_root / ".claude" / "skills" / "alpha")
+        monkeypatch.chdir(repo_root)
+
+        rev_parse = CompletedProcess(
+            args=["git", "rev-parse", "--show-toplevel"],
+            returncode=0,
+            stdout=f"{repo_root}\n",
+            stderr="",
+        )
+        clean_result = {
+            "skill_name": "alpha",
+            "skill_directory": str(skill_dir),
+            "findings": [],
+        }
+
+        with (
+            patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=rev_parse),
+            patch(
+                "skill_scanner.hooks.pre_commit.get_staged_files",
+                side_effect=AssertionError("staged diff must not run when filenames are provided"),
+            ),
+            patch("skill_scanner.hooks.pre_commit.scan_skill", return_value=clean_result) as scan,
+        ):
+            exit_code = main(
+                [
+                    ".claude/skills/alpha/SKILL.md",
+                    ".claude/skills/alpha/scripts/run.py",
+                ]
+            )
+
+        assert exit_code == 0
+        scan.assert_called_once()
+        assert scan.call_args.args[0] == skill_dir.resolve()
+
+    def test_no_filenames_keeps_staged_fallback(self, tmp_path, monkeypatch):
+        repo_root = tmp_path / "repo"
+        skill_dir = _make_skill(repo_root / ".claude" / "skills" / "alpha")
+        monkeypatch.chdir(repo_root)
+
+        rev_parse = CompletedProcess(
+            args=["git", "rev-parse", "--show-toplevel"],
+            returncode=0,
+            stdout=f"{repo_root}\n",
+            stderr="",
+        )
+        clean_result = {
+            "skill_name": "alpha",
+            "skill_directory": str(skill_dir),
+            "findings": [],
+        }
+
+        with (
+            patch("skill_scanner.hooks.pre_commit.subprocess.run", return_value=rev_parse),
+            patch(
+                "skill_scanner.hooks.pre_commit.get_staged_files",
+                return_value=[".claude/skills/alpha/scripts/run.py"],
+            ) as staged,
+            patch("skill_scanner.hooks.pre_commit.scan_skill", return_value=clean_result) as scan,
+        ):
+            exit_code = main([])
+
+        assert exit_code == 0
+        staged.assert_called_once_with()
+        scan.assert_called_once()
+
+    def test_install_command_remains_supported(self):
+        with patch("skill_scanner.hooks.pre_commit.install_hook", return_value=0) as install:
+            assert main(["install"]) == 0
+        install.assert_called_once_with()

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -62,6 +62,16 @@ class TestLLMAnalyzerInitialization:
             with pytest.raises(ValueError, match="API key required"):
                 LLMAnalyzer(model="claude-3-5-sonnet-20241022", api_key=None)
 
+    def test_init_vertex_without_api_key(self):
+        """Test Vertex AI initialization without an API key (should work with
+        ambient Application Default Credentials -- e.g. a GCE/Cloud Run
+        attached service account or Workload Identity), mirroring Bedrock's
+        IAM-role fallback."""
+        with patch.dict("os.environ", {}, clear=True):
+            analyzer = LLMAnalyzer(model="vertex_ai/gemini-1.5-pro", api_key=None)
+        assert analyzer.provider_config.is_vertex
+        assert analyzer.api_key is None
+
     def test_init_gemini_uses_litellm_when_google_genai_missing(self):
         """Test Gemini models can fall back to LiteLLM without google-genai."""
         with (

--- a/tests/test_robustness_features.py
+++ b/tests/test_robustness_features.py
@@ -437,10 +437,10 @@ class TestPrecommitGetAffectedSkills:
     def test_detects_skill_under_configured_path(self):
         from skill_scanner.hooks.pre_commit import get_affected_skills
 
-        # Path.exists is patched so no real filesystem setup is needed;
+        # Path.is_file is patched so no real filesystem setup is needed;
         # this avoids sandbox restrictions on creating ".cursor" directories.
         staged = [".cursor/skills/my-skill/scripts/run.py"]
-        with patch("pathlib.Path.exists", return_value=True):
+        with patch("pathlib.Path.is_file", return_value=True):
             result = get_affected_skills(staged, ".cursor/skills")
         assert len(result) >= 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -539,6 +539,7 @@ name = "cisco-ai-skill-scanner"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "click" },
     { name = "confusable-homoglyphs" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -566,6 +567,8 @@ all = [
     { name = "google-cloud-aiplatform" },
     { name = "google-genai" },
     { name = "google-generativeai" },
+    { name = "httplib2" },
+    { name = "pyasn1" },
 ]
 azure = [
     { name = "azure-identity" },
@@ -576,9 +579,13 @@ bedrock = [
 google = [
     { name = "google-genai" },
     { name = "google-generativeai" },
+    { name = "httplib2" },
+    { name = "pyasn1" },
 ]
 vertex = [
     { name = "google-cloud-aiplatform" },
+    { name = "httplib2" },
+    { name = "pyasn1" },
 ]
 
 [package.dev-dependencies]
@@ -600,6 +607,7 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.20,<2" },
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.40,<2" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.40,<2" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "confusable-homoglyphs", specifier = ">=3.3,<4" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "google-cloud-aiplatform", marker = "extra == 'all'", specifier = ">=1.130,<2" },
@@ -608,12 +616,18 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.60,<2" },
     { name = "google-generativeai", marker = "extra == 'all'", specifier = ">=0.8,<1" },
     { name = "google-generativeai", marker = "extra == 'google'", specifier = ">=0.8,<1" },
+    { name = "httplib2", marker = "extra == 'all'", specifier = ">=0.32.0" },
+    { name = "httplib2", marker = "extra == 'google'", specifier = ">=0.32.0" },
+    { name = "httplib2", marker = "extra == 'vertex'", specifier = ">=0.32.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "litellm", specifier = ">=1.84.0,<2" },
     { name = "magika", specifier = ">=1.0,<2" },
     { name = "oletools", specifier = ">=0.60,<1" },
     { name = "openai", specifier = ">=2.0,<3" },
     { name = "pdfid", specifier = ">=1.1,<2" },
+    { name = "pyasn1", marker = "extra == 'all'", specifier = ">=0.6.4" },
+    { name = "pyasn1", marker = "extra == 'google'", specifier = ">=0.6.4" },
+    { name = "pyasn1", marker = "extra == 'vertex'", specifier = ">=0.6.4" },
     { name = "pydantic", specifier = ">=2.10,<3" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "python-frontmatter", specifier = ">=1.1,<2" },
@@ -641,14 +655,14 @@ dev = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1584,14 +1598,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]
@@ -3050,11 +3064,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR adds incremental CI scanning support for the Skill Scanner pre-commit hook.

Previously, the hook ignored filenames supplied by pre-commit and only inspected
`git diff --cached`. In CI environments, this could result in a successful run
without scanning any changed skills.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test coverage improvement

## Related Issues

Closes #126

## Changes Made

- Added a reusable resolver that maps changed files to the nearest parent containing `SKILL.md`.
- Enabled `pass_filenames` for the pre-commit hook.
- Added serial execution to avoid duplicate scans from parallel hook invocations.
- Preserved the staged-file fallback for direct local invocation.
- Added repository-boundary validation for changed paths.
- Added support for deleted paths in the staged-file fallback.
- Documented incremental CI usage with `--from-ref` and `--to-ref`.

Example:

```bash
pre-commit run skill-scanner \
  --from-ref "$BASE_SHA" \
  --to-ref "$HEAD_SHA"
```

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing

Commands run:

```bash
PYTHONDONTWRITEBYTECODE=1 \
/private/tmp/skill-scanner-min-pytest/bin/python \
-m pytest --noconftest tests/test_changed_skills.py -q

PYTHONDONTWRITEBYTECODE=1 \
/private/tmp/skill-scanner-min-pytest/bin/python \
-m pytest --noconftest \
tests/test_robustness_features.py::TestPrecommitGetAffectedSkills \
tests/test_robustness_features.py::TestPrecommitWalkUpRoot -q
```

Additional checks:

```bash
python3 -c "import ast, pathlib; ..."
git diff --check
```

**Results:**

- Expected: Changed filenames resolve to affected skills, duplicate paths are deduplicated, and direct invocation still uses staged files.
- Actual: 11 new tests and 6 existing pre-commit regression tests passed.
- Full repository tests were not run because the complete development dependency set was not installed.

## Checklist

### Code Quality

- [x] Code follows project style guidelines
- [x] Type hints added where applicable
- [x] Docstrings added/updated for public APIs
- [x] No hardcoded credentials or secrets
- [x] Error handling is comprehensive
- [ ] Logging is appropriate

### Documentation

- [x] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] CHANGELOG updated
- [x] Code comments added for complex logic

### Security

- [x] No new security vulnerabilities introduced
- [x] Input validation added where needed
- [x] Follows security best practices from workspace rules
- [x] No eval/exec on user input without sanitization

### Testing

- [ ] Tests pass: `uv run pre-commit run --all-files`
- [ ] Benchmark passes: `uv run python evals/runners/benchmark_runner.py`
- [x] No regressions in existing functionality
- [x] Edge cases covered

## Performance Impact

- [x] No significant performance regression
- [ ] Performance benchmarks run (if applicable)
- [x] Resource usage is acceptable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-commit scans only skills affected by changed or deleted files, including nested skills.
  * Incremental CI checks can compare two revisions and scan only impacted skills.
  * Added an option to scan all configured skills with `--scan-all`.
* **Bug Fixes**
  * Improved path handling, deduplication, and detection of affected skills.
* **Documentation**
  * Updated installation and usage guidance, including the `--install` command and CI examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->