### PR TITLE
fix: suppress warning for recovered fenced JSON

### DIFF
--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_response_validator.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_response_validator.py
@@ -71,10 +71,13 @@ class AlignmentResponseValidator:
             return data
 
         except json.JSONDecodeError as e:
-            self.logger.warning(f"Invalid JSON response: {e}")
             self.logger.debug(f"Raw response (first 500 chars): {response[:500]}")
-            # Try to extract JSON from markdown code blocks
-            return self._extract_json_from_markdown(response)
+            # Try to extract JSON from markdown code blocks before reporting an error.
+            data = self._extract_json_from_markdown(response)
+            if data is not None:
+                return data
+            self.logger.warning(f"Invalid JSON response: {e}")
+            return None
         except Exception as e:
             self.logger.error(f"Unexpected error validating response: {e}")
             return None

--- a/tests/behavioral/test_alignment_response_validator.py
+++ b/tests/behavioral/test_alignment_response_validator.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for AlignmentResponseValidator."""
+
+import logging
+
+from skill_scanner.core.analyzers.behavioral.alignment.alignment_response_validator import (
+    AlignmentResponseValidator,
+)
+
+
+def test_fenced_json_is_validated_without_invalid_json_warning(caplog):
+    """A successful markdown fallback must not emit a misleading warning."""
+    response = '```json\n{"mismatch_detected": false}\n```'
+
+    with caplog.at_level(logging.WARNING):
+        result = AlignmentResponseValidator().validate(response)
+
+    assert result == {"mismatch_detected": False}
+    assert "Invalid JSON response" not in caplog.text


### PR DESCRIPTION
## Description

Fixes #147.

When a response is valid JSON inside a Markdown fence, the validator now tries the fenced-JSON recovery path before issuing an `Invalid JSON response` warning. A warning is still emitted when neither direct nor fenced parsing succeeds.

## Changes Made

- Defer the invalid-JSON warning until Markdown JSON recovery fails.
- Add a regression test that verifies valid fenced JSON returns the parsed payload without warning noise.

## Testing

- `uv run pytest tests/behavioral/test_alignment_response_validator.py -q` — passed (1 passed)
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (208 files already formatted)
- `uv run pytest tests/ --ignore=tests/test_llm_analyzer.py -v --tb=short` — passed (1401 passed, 5 skipped, 1 xfailed)
- `uv run pre-commit run --all-files` — passed, including gitleaks
- `uv run python evals/runners/benchmark_runner.py` — passed (11/11 evaluation skills; 100% accuracy)

The intentionally excluded `tests/test_llm_analyzer.py` requires LLM-specific execution and was excluded from the full local suite, matching the issue candidate's verification command.

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Unit tests added/updated
- [x] All applicable local tests pass
- [x] No hardcoded credentials or secrets
- [x] No significant performance regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of responses containing JSON enclosed in Markdown code blocks.
  - Valid fenced JSON is now parsed successfully without generating an unnecessary invalid-response warning.
  - Invalid or unrecoverable JSON continues to be reported appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->