### PR TITLE
fix release SBOM attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,16 +62,21 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           uv sync --frozen --only-group sbom
+          # --output-reproducible omits the serialNumber required by actions/attest.
           uv run --no-sync cyclonedx-py requirements \
             release-assets/requirements.txt \
             --pyproject pyproject.toml \
-            --output-reproducible \
             --output-file release-assets/sbom.cdx.json
           jq --arg v "$VERSION" \
             '.metadata.component.version = $v
              | .metadata.component.purl = "pkg:pypi/cisco-ai-skill-scanner@\($v)"' \
             release-assets/sbom.cdx.json > sbom.tmp
           mv sbom.tmp release-assets/sbom.cdx.json
+          jq -e \
+            '.bomFormat == "CycloneDX"
+             and (.serialNumber | type == "string" and length > 0)
+             and (.specVersion | type == "string" and length > 0)' \
+            release-assets/sbom.cdx.json >/dev/null
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
## What changed

- Preserve the CycloneDX `serialNumber` generated by `cyclonedx-py`.
- Validate the SBOM fields required by `actions/attest` before attempting attestation.

## Root cause

The release workflow used `--output-reproducible`, which intentionally omits the CycloneDX `serialNumber`. The pinned GitHub attestation action requires that field to recognize CycloneDX JSON, causing release run 30858915389 to fail before publishing.

## Impact

New release runs can attest the generated SBOM and continue to upload release assets and publish the package.

## Validation

- Generated and stamped a CycloneDX 1.6 SBOM locally.
- Confirmed it contains `bomFormat`, `specVersion`, and a UUID `serialNumber`.
- Parsed the workflow YAML successfully.
- Passed repository pre-commit checks, including GitHub workflow validation.
- Passed `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved software bill of materials validation to ensure required metadata is present.
  * Enhanced release attestations by including the SBOM serial number and verifying its specification version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->