### PR TITLE
docs: improve Skill Scanner search descriptions

### DIFF
--- a/docs-site/api-reference.mdx
+++ b/docs-site/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "API Reference"
-description: "Skill Scanner REST API reference — FastAPI server endpoints for upload-driven scanning, batch processing, health checks, and analyzer listing. Service-to-service integration for AI agent skill security from Cisco AI Defense."
+description: "Skill Scanner REST API reference for FastAPI endpoints that scan uploaded AI agent skills, run batch security jobs, check health, and list analyzers."
 order: 9
 ---
 

--- a/docs-site/architecture.mdx
+++ b/docs-site/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Architecture"
-description: "Skill Scanner architecture — six-stage scanning pipeline, two-phase analysis (load and analyze), core components, rule packs, threat taxonomy, and extension points for custom analyzers. Cisco AI Defense open-source documentation."
+description: "Explore Skill Scanner architecture: its six-stage security pipeline, pluggable analyzers, policy engine, rule packs, threat taxonomy, and extension points."
 order: 6
 ---
 

--- a/docs-site/cli-reference.mdx
+++ b/docs-site/cli-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CLI Reference"
-description: "Skill Scanner CLI reference — scan local skills or GitHub repositories, enable OSV and LLM adjudication, produce multiple reports, manage policies and rule packs, run the API, and configure incremental pre-commit scans."
+description: "Skill Scanner CLI reference for scanning local skills or GitHub repositories, enabling OSV and LLM analysis, applying policies, and exporting reports."
 order: 5
 ---
 

--- a/docs-site/faq.mdx
+++ b/docs-site/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: "FAQ"
-description: "Skill Scanner frequently asked questions — what it scans, supported skill formats, LLM providers, analyzer selection, scan policies, CI/CD integration, Python SDK usage, output formats, and troubleshooting. Cisco AI Defense open-source documentation."
+description: "Answers to common Skill Scanner questions about supported formats, analyzers, LLM providers, scan policies, CI/CD, SDK usage, outputs, and troubleshooting."
 order: 11
 ---
 

--- a/docs-site/features.mdx
+++ b/docs-site/features.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Features"
-description: "Skill Scanner features — deterministic and LLM analyzers, OSV.dev dependency intelligence, per-finding adjudication, 712-rule ATR coverage, file intelligence, policies, and CI-ready reporting."
+description: "Explore Skill Scanner features, including deterministic, behavioral, OSV, YARA, and LLM analysis, adjudication, policies, and CI-ready reports."
 order: 3
 ---
 

--- a/docs-site/github-actions.mdx
+++ b/docs-site/github-actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GitHub Actions"
-description: "Skill Scanner GitHub Actions integration — reusable CI/CD workflow, SARIF upload to GitHub Code Scanning, branch protection rules, configuration tiers (static, LLM, full stack), and pre-commit hooks from Cisco AI Defense."
+description: "Integrate Skill Scanner with GitHub Actions using reusable workflows, SARIF Code Scanning, severity gates, branch protection, and pre-commit hooks."
 order: 10
 ---
 

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "Skill Scanner overview — open-source AI agent skill security scanner from Cisco AI Defense. Detect prompt injection, vulnerable and unpinned dependencies, data exfiltration, malicious code, and hidden Unicode attacks with deterministic, LLM, and behavioral analysis."
+description: "Open-source AI agent skill security scanner from Cisco AI Defense. Detect prompt injection, data exfiltration, malicious code, and vulnerable dependencies."
 order: 1
 ---
 

--- a/docs-site/installation.mdx
+++ b/docs-site/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install Cisco AI Defense Skill Scanner CLI and Python package. Prerequisites, PyPI install, cloud provider extras (AWS Bedrock, Google Vertex, Azure), source build, and environment variable configuration."
+description: "Install Skill Scanner from PyPI or source, configure AWS Bedrock, Google Vertex AI, or Azure OpenAI extras, and set credentials for optional analyzers."
 order: 2
 ---
 

--- a/docs-site/python-sdk.mdx
+++ b/docs-site/python-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Python SDK"
-description: "Skill Scanner Python SDK — embed AI agent skill security scanning in Python applications. SkillScanner class, ScanResult and Finding models, Severity enum, policy support, and programmatic analyzer composition from Cisco AI Defense."
+description: "Use the Skill Scanner Python SDK to scan AI agent skills, configure analyzers and policies, and process typed findings, results, and security reports."
 order: 8
 ---
 

--- a/docs-site/quick-start.mdx
+++ b/docs-site/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quick Start"
-description: "Get Cisco AI Defense Skill Scanner running in under a minute. Install from PyPI, scan your first AI agent skill, review security findings, and configure output formats with step-by-step instructions."
+description: "Install Skill Scanner, scan an AI agent skill, review security findings, and export JSON, SARIF, Markdown, table, or HTML reports in minutes."
 order: 4
 ---
 

--- a/docs-site/scan-policies.mdx
+++ b/docs-site/scan-policies.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Scan Policies"
-description: "Skill Scanner scan policies — built-in presets, custom YAML, adjudication, trusted reference domains, LLM budgets, severity overrides, rule disabling, and interactive configuration."
+description: "Configure Skill Scanner policies with built-in presets, severity overrides, disabled rules, LLM budgets, trusted domains, and adjudication controls."
 order: 7
 ---
 


### PR DESCRIPTION
## Summary

- tighten frontmatter descriptions across all 11 public Skill Scanner MDX pages
- keep each description unique, accurate, and between 141–155 characters
- preserve the documentation body content and links unchanged

## Why

The previous descriptions were 181–266 characters long, which made search and social snippets likely to truncate before the most useful page-specific terms.

## Impact

The daily website sync will pick these descriptions up directly from the Skill Scanner repository after merge, improving metadata for every `/docs/skill-scanner/...` page without duplicating docs in the website repo.

## Validation

- `python3 scripts/validate_docs_site.py`
- all 11 descriptions asserted unique and within 120–160 characters
- `git diff --check`
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation summaries across the API, architecture, CLI, features, installation, SDK, and scanning guides.
  * Clarified supported scanning workflows, analyzers, policies, reports, integrations, and configuration options.
  * Refreshed FAQ, homepage, and Quick Start descriptions for clearer overviews and reporting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->