### PR TITLE
docs(packs/atr): correct benchmark numbers and stop quoting a single precision figure

### DIFF
--- a/skill_scanner/data/packs/atr/README.md
+++ b/skill_scanner/data/packs/atr/README.md
@@ -4,7 +4,17 @@
 **ATR Version:** 3.5.6
 **Rules:** 712 signatures across 10 signature files
 **License:** MIT
-**Benchmarks:** 97.2% recall on NVIDIA garak (650 in-the-wild jailbreaks) · 100% recall on 498 labeled SKILL.md samples · 99.7% precision on 850 PINT adversarial samples · OWASP Agentic Top 10: 10/10
+**Benchmarks:** measured on ATR 3.5.11 (this pack is built from 3.5.6, so treat them as indicative for the
+shipped signatures rather than exact):
+
+- 91.5% recall on NVIDIA garak (650 in-the-wild jailbreaks; 595 detected, 55 missed), re-measured 2026-07-28
+- 100% recall / 97% precision on 498 labeled SKILL.md samples
+- 99.7% precision, 63.6% recall on an 850-sample PINT-format corpus (deepset/prompt-injections + Lakera
+  Gandalf; not Lakera's official PINT benchmark)
+- **False positives are lane-dependent and ATR does not publish a single precision figure.** On the 65K-sample
+  benign gate: ~0.24% FP on the enforce lane (stable, confirm-gated rules) and ~9% FP on the hunt lane, which
+  is the default. A scanner running the full pack should expect the hunt-lane figure.
+- OWASP Agentic Top 10: 10/10 categories mapped
 
 ## Overview
 

--- a/skill_scanner/data/packs/atr/README.md
+++ b/skill_scanner/data/packs/atr/README.md
@@ -7,7 +7,7 @@
 **Benchmarks:** measured on ATR 3.5.11 (this pack is built from 3.5.6, so treat them as indicative for the
 shipped signatures rather than exact):
 
-- 91.5% recall on NVIDIA garak (650 in-the-wild jailbreaks; 595 detected, 55 missed), re-measured 2026-07-28
+- 92.5% recall on NVIDIA garak's in-the-wild jailbreak corpus (601 of 650 detected), measured 2026-08-05 on ATR v3.5.11. This corpus is a single probe family; across garak's full 23-family corpus recall is substantially lower and is reported separately upstream.
 - 100% recall / 97% precision on 498 labeled SKILL.md samples
 - **False positives are lane-dependent and ATR does not publish a single precision figure.** On the 65K-sample
   benign gate: ~0.24% FP on the enforce lane (stable, confirm-gated rules) and ~9% FP on the hunt lane, which

--- a/skill_scanner/data/packs/atr/README.md
+++ b/skill_scanner/data/packs/atr/README.md
@@ -9,8 +9,6 @@ shipped signatures rather than exact):
 
 - 91.5% recall on NVIDIA garak (650 in-the-wild jailbreaks; 595 detected, 55 missed), re-measured 2026-07-28
 - 100% recall / 97% precision on 498 labeled SKILL.md samples
-- 99.7% precision, 63.6% recall on an 850-sample PINT-format corpus (deepset/prompt-injections + Lakera
-  Gandalf; not Lakera's official PINT benchmark)
 - **False positives are lane-dependent and ATR does not publish a single precision figure.** On the 65K-sample
   benign gate: ~0.24% FP on the enforce lane (stable, confirm-gated rules) and ~9% FP on the hunt lane, which
   is the default. A scanner running the full pack should expect the hunt-lane figure.


### PR DESCRIPTION
Two problems with the benchmark line I added in #142, both mine.

**The garak recall was wrong.** It said 97.2%, which is two measurements old. ATR re-measured on 2026-07-28 against the same 650-sample in-the-wild jailbreak corpus and got **91.5%** (595 detected, 55 missed). The drop is an honest re-measure, not an arithmetic correction, and the older figure should not have been carried forward into this pack.

**The bigger issue is "99.7% precision".** ATR moved to lane-keyed false-positive reporting in June, because a single precision figure misleads operators about what they will actually see. On the 65K-sample benign gate it is roughly 0.24% FP on the enforce lane (stable, confirm-gated rules) and roughly 9% on the hunt lane — and hunt is the default. A pack consumer running the full signature set gets hunt-lane behaviour, so quoting a corpus-specific PINT precision without that context sets the wrong expectation. That seems worth being precise about here in particular, given that FP escalations on custom servers are a real operational cost for this scanner.

The replacement also states that the numbers were measured on ATR 3.5.11 while this pack is built from 3.5.6, so they are indicative for the shipped signatures rather than exact.

**Deliberately not touched:** the `Rules: 712` line. That is "signatures in this pack", which is a different quantity from the ATR corpus total; changing it in the same PR would create a new mismatch rather than fix one. If you would like the pack refreshed to 3.5.11 as a follow-up, I am happy to do that as its own PR where the rule count and the version move together.

Docs-only change, one file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark information to reflect ATR 3.5.11 measurements.
  * Added measurement date, recall and precision results, false-positive rates by lane, and sample counts.
  * Clarified that the hunt-lane rate represents the expected full-pack figure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->