### PR TITLE
docs(packs/atr): correct the benchmark figures and their caveats

### DIFF
--- a/skill_scanner/data/packs/atr/README.md
+++ b/skill_scanner/data/packs/atr/README.md
@@ -4,7 +4,39 @@
 **ATR Version:** 3.5.6
 **Rules:** 712 signatures across 10 signature files
 **License:** MIT
-**Benchmarks:** 97.2% recall on NVIDIA garak (650 in-the-wild jailbreaks) · 100% recall on 498 labeled SKILL.md samples · 99.7% precision on 850 PINT adversarial samples · OWASP Agentic Top 10: 10/10
+**Benchmarks:** see the [ATR benchmark table](https://github.com/Agent-Threat-Rule/agent-threat-rules#benchmarks),
+which is version-pinned and regenerated from measurement files rather than
+hand-copied. Selected rows:
+
+| Corpus | Samples | Recall | Precision | ATR version |
+|---|---:|---:|---:|---:|
+| NVIDIA garak, in-the-wild jailbreaks | 650 | 92.5% | 100% | 3.5.11 |
+| NVIDIA garak, all 23 probe families | 3,475 | 57.2% | 100% | 3.5.11 |
+| PINT-format (deepset + Lakera Gandalf) | 850 | 60.3% | 100% | 3.5.11 |
+| Labeled SKILL.md, internal | 498 | 100% (hunt) / 0% (enforce) | 97% | 3.5.0 |
+
+**This pack ships ATR 3.5.6; the rows above were measured on 3.5.11 and 3.5.0.**
+Treat them as indicative of the shipped signatures rather than exact. The
+upstream table is the authority and carries the measurement file behind each
+row.
+
+Three caveats belong next to those numbers.
+
+The PINT-format row is **not** a run of Lakera's official PINT benchmark. That
+corpus is private and roughly five times larger. This is a self-built corpus in
+the same format, and 226 of its 272 detections come from a single rule
+(`ATR-2026-00001`), so it measures one rule family rather than overall coverage.
+
+The SKILL.md split is structural, not a tuning gap. ATR's enforce lane loads
+only `maturity: stable`, and all 38 rules carrying `scan_target: skill` are
+currently `maturity: test` — so an enforce-lane deployment loads no
+skill-scanning rule at all and detects 0 of the 32 malicious samples. This pack
+loads the full static ruleset, which is the configuration the 100% figure
+describes.
+
+OWASP Agentic Top 10 coverage (10/10 categories, 1,179 mappings) is a taxonomy
+mapping, not a detection benchmark, and is listed separately upstream for that
+reason.
 
 ## Overview
 

--- a/skill_scanner/data/packs/atr/pack.yaml
+++ b/skill_scanner/data/packs/atr/pack.yaml
@@ -9,7 +9,7 @@ pack:
   name: ATR Agent Threat Rules
   version: 3.5.6
   description: >-
-    Open-source AI agent security detection rules from the Agent Threat Rules (ATR) project. 712 supported static rules across 10 attack categories: prompt injection, agent manipulation, skill compromise, context exfiltration, tool poisoning, privilege escalation, model abuse, excessive autonomy, data poisoning, and model security. Benchmarks: 97.2% recall on NVIDIA garak 650 in-the-wild jailbreaks, 100% recall on 498 labeled SKILL.md samples, 99.7% precision on 850 PINT adversarial samples. OWASP Agentic Top 10: 10/10. MIT license.
+    Open-source AI agent security detection rules from the Agent Threat Rules (ATR) project. 712 supported static rules across 10 attack categories: prompt injection, agent manipulation, skill compromise, context exfiltration, tool poisoning, privilege escalation, model abuse, excessive autonomy, data poisoning, and model security. Benchmark results are published upstream in the ATR benchmark table, version-pinned per measurement; see the pack README for the figures that apply to this ruleset and their caveats. MIT license.
   author: ATR Community
   license: MIT
   source_url: https://github.com/Agent-Threat-Rule/agent-threat-rules


### PR DESCRIPTION
@vineethsai7 — correcting numbers I wrote, not asking for anything.

The three benchmark figures in this pack's README and in `pack.yaml`'s description were written when the pack was first contributed and never revisited. Upstream has since re-measured, and two of the three overstate the pack.

| figure | as published here | upstream, ATR 3.5.11 |
|---|---|---|
| garak, in-the-wild jailbreaks | 97.2% recall | **92.5%** recall (650 samples) |
| PINT | 99.7% precision on 850 samples | see below |
| SKILL.md | 100% recall | 100%, but only with the lane stated |

**PINT is the one worth reading carefully.** Lakera's official PINT corpus is private and roughly five times larger. Upstream's is a self-built corpus in the same format, and 226 of its 272 detections come from a single rule (`ATR-2026-00001`). Written as "99.7% precision on 850 PINT adversarial samples" it reads as a third-party evaluation that did not happen. Upstream now labels that row `PINT-format (deepset + Lakera Gandalf)` with a footnote saying the same thing.

**SKILL.md 100% is true for this pack** — it loads the full static ruleset, which is the configuration that figure describes. It is not true of an ATR enforce-lane deployment: that lane loads only `maturity: stable`, and all 38 skill-scanning rules are currently `maturity: test`, so it detects 0 of the 32 malicious samples. Stating the lane keeps the number from travelling somewhere it is false.

**OWASP Agentic Top 10 10/10** is a taxonomy mapping, not a detection benchmark, so it moves out of the Benchmarks line.

Rather than swap one set of hand-copied numbers for another, the README now links the [upstream benchmark table](https://github.com/Agent-Threat-Rule/agent-threat-rules#benchmarks) — version-pinned and regenerated from measurement files — and reproduces only the rows that apply here. Upstream added a citation check on 2026-08-04 that fails when a quoted figure has no measurement file behind it, which is the gap that let this drift.

No rule content changes; docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark documentation with version-pinned corpus sizes, recall, and precision results.
  * Added clarifications about corpus provenance, rule concentration, SKILL.md maturity enforcement, shipped-versus-measured versions, and OWASP taxonomy coverage.
  * Updated the ATR pack description to reference upstream benchmark results and the accompanying documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->