### PR TITLE
feat(llm): add OrcaRouter as an LLM provider

### DIFF
--- a/docs-site/faq.mdx
+++ b/docs-site/faq.mdx
@@ -20,7 +20,7 @@ No. Core analyzers (static, bytecode, pipeline) require no API keys and no netwo
 
 ### Which LLM providers are supported?
 
-Skill Scanner uses [LiteLLM](https://github.com/BerriAI/litellm) under the hood, supporting Anthropic, OpenAI, AWS Bedrock, Google Vertex AI, Azure OpenAI, and many other providers. Install optional extras (`[bedrock]`, `[vertex]`, `[azure]`, or `[all]`) for managed cloud services.
+Skill Scanner uses [LiteLLM](https://github.com/BerriAI/litellm) under the hood, supporting Anthropic, OpenAI, AWS Bedrock, Google Vertex AI, Azure OpenAI, OrcaRouter, and many other providers. Install optional extras (`[bedrock]`, `[vertex]`, `[azure]`, or `[all]`) for managed cloud services.
 
 ### How do I choose which analyzers to enable?
 

--- a/docs/reference/dependencies-and-llm-providers.md
+++ b/docs/reference/dependencies-and-llm-providers.md
@@ -96,6 +96,7 @@ Set `SKILL_SCANNER_LLM_MODEL` using the provider prefix convention:
 | Google AI Studio | `gemini/gemini-2.5-flash` | Requires `[google]` extra |
 | Azure OpenAI | `azure/my-deployment-name` | Requires `[azure]` extra |
 | Ollama (local) | `ollama/llama3` | No API key needed |
+| OrcaRouter | `orcarouter/anthropic/claude-sonnet-5` | OpenAI-compatible gateway; default endpoint `https://api.orcarouter.ai/v1` (override with `SKILL_SCANNER_LLM_BASE_URL`) |
 
 For OpenAI and OpenAI-compatible custom endpoints, `SKILL_SCANNER_LLM_USER` can set the raw Chat Completions `user` request field. The value is passed through unchanged and is ignored for non-OpenAI routes.
 
@@ -113,6 +114,7 @@ For OpenAI and OpenAI-compatible custom endpoints, `SKILL_SCANNER_LLM_USER` can 
 | Google AI Studio | API key | `SKILL_SCANNER_LLM_API_KEY` (auto-sets `GEMINI_API_KEY`) |
 | Azure OpenAI | API key + endpoint | `SKILL_SCANNER_LLM_API_KEY`, `SKILL_SCANNER_LLM_BASE_URL`, `SKILL_SCANNER_LLM_API_VERSION` |
 | Ollama | None | — |
+| OrcaRouter | API key | `SKILL_SCANNER_LLM_API_KEY` |
 
 ## Related
 

--- a/skill_scanner/core/analyzers/llm_analyzer.py
+++ b/skill_scanner/core/analyzers/llm_analyzer.py
@@ -83,6 +83,7 @@ class LLMProvider(str, Enum):
     - gcp-vertex: Google Cloud Vertex AI
     - ollama: Local Ollama models
     - openrouter: OpenRouter API
+    - orcarouter: OrcaRouter API
     """
 
     OPENAI = "openai"
@@ -94,6 +95,7 @@ class LLMProvider(str, Enum):
     GCP_VERTEX = "gcp-vertex"
     OLLAMA = "ollama"
     OPENROUTER = "openrouter"
+    ORCAROUTER = "orcarouter"
 
     @classmethod
     def normalize(cls, provider: str) -> str:
@@ -223,6 +225,7 @@ class LLMAnalyzer(BaseAnalyzer):
                 "gcp-vertex": "vertex_ai/gemini-1.5-pro",
                 "ollama": "ollama/llama2",
                 "openrouter": "openrouter/openai/gpt-4",
+                "orcarouter": "orcarouter/anthropic/claude-sonnet-5",
             }
             model = model_mapping.get(provider_str, "claude-3-5-sonnet-20241022")
         elif model is None:

--- a/skill_scanner/core/analyzers/llm_provider_config.py
+++ b/skill_scanner/core/analyzers/llm_provider_config.py
@@ -107,6 +107,9 @@ class ProviderConfig:
         )
         self.is_ollama = not self.is_openai_compatible and model_lower.startswith("ollama/")
         self.is_openrouter = not self.is_openai_compatible and model_lower.startswith("openrouter/")
+        self.is_orcarouter = self.provider == "orcarouter" or (
+            not self.is_openai_compatible and model_lower.startswith("orcarouter/")
+        )
         self.is_gpt5 = "gpt-5" in model_lower
 
         # Determine if we should use Google SDK
@@ -124,6 +127,12 @@ class ProviderConfig:
             if not LITELLM_AVAILABLE:
                 raise ImportError("LiteLLM is required for Vertex AI. Install with: pip install litellm")
             self.model = model  # Keep vertex_ai/ prefix for LiteLLM
+        elif self.is_orcarouter:
+            # OrcaRouter is OpenAI-compatible; route through the OpenAI LiteLLM adapter
+            # with the well-known default endpoint (overridable via base_url).
+            if not LITELLM_AVAILABLE:
+                raise ImportError("LiteLLM is required for OrcaRouter. Install with: pip install litellm")
+            self.model = self._normalize_orcarouter_model_name(model)
         elif self.is_gemini and GOOGLE_GENAI_AVAILABLE:
             # Google AI Studio (uses Google SDK directly)
             self.use_google_sdk = True
@@ -165,6 +174,12 @@ class ProviderConfig:
         """Force LiteLLM's OpenAI adapter for arbitrary OpenAI-compatible model names."""
         if model.lower().startswith("openai/"):
             return model
+        return f"openai/{model}"
+
+    def _normalize_orcarouter_model_name(self, model: str) -> str:
+        """Force LiteLLM's OpenAI adapter for OrcaRouter models (OpenAI-compatible)."""
+        if model.lower().startswith("orcarouter/"):
+            model = model[len("orcarouter/"):]
         return f"openai/{model}"
 
     def _resolve_api_key(self, api_key: str | None) -> str | None:
@@ -301,6 +316,9 @@ class ProviderConfig:
 
         if self.base_url:
             params["api_base"] = self.base_url
+        elif self.is_orcarouter:
+            # Default OrcaRouter endpoint (OpenAI-compatible) when no base_url is given.
+            params["api_base"] = "https://api.orcarouter.ai/v1"
         if self.api_version:
             params["api_version"] = self.api_version
 

--- a/skill_scanner/data/packs/atr/signatures/atr_context_exfiltration.yaml
+++ b/skill_scanner/data/packs/atr/signatures/atr_context_exfiltration.yaml
@@ -795,9 +795,9 @@ signatures:
     severity: CRITICAL
     patterns:
       - >-
-        (?i)"ANTHROPIC_BASE_URL"\s*:\s*"https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/"]|$))[^"]+"
+        (?i)"ANTHROPIC_BASE_URL"\s*:\s*"https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|api\.orcarouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/"]|$))[^"]+"
       - >-
-        (?i)\bANTHROPIC_BASE_URL\s*=\s*["\x27]?https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/\s"\x27]|$))[^\s"\x27]+
+        (?i)\bANTHROPIC_BASE_URL\s*=\s*["\x27]?https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|api\.orcarouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/\s"\x27]|$))[^\s"\x27]+
       - >-
         (?i)"ANTHROPIC_BASE_URL"\s*:\s*"https?://(?!(?:127\.|10\.|0\.0\.0\.0|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.))(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?(?![\d.])
       - >-

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -170,6 +170,46 @@ class TestLLMAnalyzerInitialization:
         assert analyzer.model == "openai/enterprise-model"
         assert analyzer.provider_config.is_openai_compatible
 
+    def test_orcarouter_model_prefix_routes_via_openai_adapter(self):
+        """OrcaRouter model prefix routes through the OpenAI LiteLLM adapter with the default endpoint."""
+        analyzer = LLMAnalyzer(
+            model="orcarouter/anthropic/claude-sonnet-5",
+            api_key="test-key",
+        )
+
+        assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+        assert analyzer.provider_config.is_orcarouter
+        assert analyzer.provider_config.get_request_params() == {
+            "api_key": "test-key",
+            "api_base": "https://api.orcarouter.ai/v1",
+        }
+
+    def test_orcarouter_provider_override_uses_default_endpoint(self):
+        """The explicit orcarouter provider override maps to the OpenAI adapter."""
+        analyzer = LLMAnalyzer(
+            model="anthropic/claude-sonnet-5",
+            provider="orcarouter",
+            api_key="test-key",
+        )
+
+        assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+        assert analyzer.provider_config.is_orcarouter
+        assert analyzer.provider_config.get_request_params()["api_base"] == "https://api.orcarouter.ai/v1"
+
+    def test_orcarouter_custom_base_url_overrides_default_endpoint(self):
+        """An explicit base_url overrides the OrcaRouter default endpoint."""
+        analyzer = LLMAnalyzer(
+            model="orcarouter/anthropic/claude-sonnet-5",
+            api_key="test-key",
+            base_url="https://orca.internal/v1",
+        )
+
+        assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+        assert analyzer.provider_config.get_request_params() == {
+            "api_key": "test-key",
+            "api_base": "https://orca.internal/v1",
+        }
+
 
 class TestPromptLoading:
     """Test prompt loading functionality."""


### PR DESCRIPTION
## Add OrcaRouter as an LLM provider

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a named LLM provider for the LLM analyzer and adjudicator, mirroring how OpenRouter is wired in `LLMProvider`.

OrcaRouter is an AI gateway that fronts many upstream models (`anthropic/claude-*`, `openai/*`, etc.) behind a single OpenAI-compatible Chat Completions endpoint (`https://api.orcarouter.ai/v1/chat/completions`), so it slots into the existing LiteLLM-based routing:

- **`LLMProvider`** enum extended with `ORCAROUTER = "orcarouter"` (`llm_analyzer.py`), including the default-model mapping (`orcarouter/anthropic/claude-sonnet-5`)
- **`ProviderConfig`** (`llm_provider_config.py`): new `is_orcarouter` detection for the `orcarouter/` model prefix or `provider="orcarouter"` override, routed through LiteLLM's OpenAI adapter with the well-known default endpoint `https://api.orcarouter.ai/v1` (overridable via `base_url` / `SKILL_SCANNER_LLM_BASE_URL`); API key stays on the existing `SKILL_SCANNER_LLM_API_KEY` secret
- **ATR signature allowlist** (`atr_context_exfiltration.yaml`): `api.orcarouter.ai` added as a known gateway host so `ANTHROPIC_BASE_URL` pointed at OrcaRouter's Anthropic-compatible endpoint does not trigger the credential-exfiltration rule
- **Docs**: provider and auth tables in `dependencies-and-llm-providers.md` plus the FAQ provider list

The wire format was verified live against `https://api.orcarouter.ai/v1/chat/completions`: a POST with Bearer auth and the namespaced model id `anthropic/claude-sonnet-5` returns `choices[0].message.content` as expected, matching what LiteLLM's OpenAI adapter sends.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported LLM provider.
  * Added support for OrcaRouter models, API-key authentication, default endpoints, and configurable base URLs.
  * Added provider detection for explicit configuration and OrcaRouter model prefixes.

* **Bug Fixes**
  * Updated credential-exfiltration detection to recognize OrcaRouter’s API endpoint as an approved destination.

* **Documentation**
  * Updated the FAQ and LLM provider reference with OrcaRouter setup and model details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->