### PR TITLE
fix(deps): allow Textual 8

### DIFF
--- a/docs/reference/dependencies-and-llm-providers.md
+++ b/docs/reference/dependencies-and-llm-providers.md
@@ -20,7 +20,7 @@ All versions from [`pyproject.toml`](https://github.com/cisco-ai-defense/skill-s
 |---------|---------|---------|
 | `click` | >= 8.1.0 | CLI framework |
 | `rich` | >= 13.0.0 | Terminal formatting |
-| `textual` | >= 1.0.0 | Interactive TUI (policy configurator) |
+| `textual` | >= 7.0, < 9 | Interactive TUI (policy configurator) |
 | `tabulate` | >= 0.9.0 | Table output formatting |
 
 ### Analysis and Detection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,10 @@ dependencies = [
     "PyYAML>=6.0,<7",
     "python-frontmatter>=1.1,<2",
     "rich>=14.0,<15",
-    "textual>=7.0,<8",
+    # Textual 8 remains API-compatible with the policy configurator. Keep the
+    # next-major ceiling while allowing downstream applications that already
+    # use the supported 8.x line to share one runtime environment.
+    "textual>=7.0,<9",
     "tabulate>=0.9,<1",
     "pydantic>=2.10,<3",
     "fastapi>=0.115,<1",

--- a/tests/test_textual_compatibility.py
+++ b/tests/test_textual_compatibility.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Cisco Systems, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for the policy configurator's Textual contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+from skill_scanner.cli.policy_tui import PolicyConfigApp
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_textual_dependency_accepts_supported_seven_and_eight_lines() -> None:
+    """Downstream Textual 8 applications must resolve with Skill Scanner."""
+
+    document = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    textual = next(
+        Requirement(value)
+        for value in document["project"]["dependencies"]
+        if Requirement(value).name == "textual"
+    )
+
+    assert Version("7.0.0") in textual.specifier
+    assert Version("8.2.8") in textual.specifier
+    assert Version("9.0.0") not in textual.specifier
+
+
+@pytest.mark.asyncio
+async def test_policy_configurator_mounts_on_locked_textual() -> None:
+    """Boot the real TUI so dependency-only changes cannot mask API drift."""
+
+    app = PolicyConfigApp(output_path="unused.yaml")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert app.query_one("#policy-name-input").value == app.policy.policy_name == "default"
+        assert app.query_one("#preset-balanced").value is True

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=14.0,<15" },
     { name = "tabulate", specifier = ">=0.9,<1" },
-    { name = "textual", specifier = ">=7.0,<8" },
+    { name = "textual", specifier = ">=7.0,<9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
     { name = "yara-x", specifier = ">=1.10,<2" },
 ]
@@ -3043,11 +3043,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]
@@ -4100,7 +4100,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "7.5.0"
+version = "8.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -4110,9 +4110,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/38/7d169a765993efde5095c70a668bf4f5831bb7ac099e932f2783e9b71abf/textual-7.5.0.tar.gz", hash = "sha256:c730cba1e3d704e8f1ca915b6a3af01451e3bca380114baacf6abf87e9dac8b6", size = 1592319, upload-time = "2026-01-30T13:46:39.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/78/96ddb99933e11d91bc6e05edae23d2687e44213066bcbaca338898c73c47/textual-7.5.0-py3-none-any.whl", hash = "sha256:849dfee9d705eab3b2d07b33152b7bd74fb1f5056e002873cc448bce500c6374", size = 718164, upload-time = "2026-01-30T13:46:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- expand the supported Textual range from `>=7,<8` to `>=7,<9`
- lock Textual 8.2.8 and add a real TUI boot regression test
- document the supported range and refresh the vulnerable pip lock entry required by the audit gate

DefenseClaw uses Textual 8 APIs and embeds skill-scanner in the same Python environment. The previous `<8` upper bound made those otherwise-compatible dependencies impossible to resolve together.

## Validation

- `uv run pytest tests/ -q` — 1,671 passed, 5 skipped, 1 xfailed
- `uv run pre-commit run --all-files` — all hooks passed
- `uv run pip-audit` — no known vulnerabilities (editable project itself skipped because the dev version is not on PyPI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Textual 8.x versions in the CLI and TUI.

- **Bug Fixes**
  - Improved compatibility checks to accept supported Textual versions while rejecting unsupported future versions.
  - Verified that the policy configurator launches correctly and initializes key controls.

- **Tests**
  - Added regression coverage for dependency compatibility and TUI startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->