### PR TITLE
fix(static): reject unreachable loop exits (#160)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@
 # SKILL_SCANNER_LLM_MODEL=claude-3-5-sonnet-20241022
 # Positive integer output budget (default: 8192)
 # SKILL_SCANNER_LLM_MAX_TOKENS=16384
+# Optional: disabled, minimal, low, medium, high, xhigh, or max.
+# Direct Google GenAI SDK requests reject this control; LiteLLM-backed Gemini requests support it.
+# SKILL_SCANNER_LLM_REASONING_EFFORT=low
 
 # OpenAI-compatible custom endpoint
 # SKILL_SCANNER_LLM_API_KEY=your_custom_provider_key
@@ -43,6 +46,8 @@
 # SKILL_SCANNER_META_LLM_BASE_URL=
 # SKILL_SCANNER_META_LLM_API_VERSION=
 # SKILL_SCANNER_META_LLM_MAX_TOKENS=32768
+# Direct Google GenAI SDK requests reject this control; LiteLLM-backed Gemini requests support it.
+# SKILL_SCANNER_META_LLM_REASONING_EFFORT=low
 
 # VirusTotal Configuration (optional)
 # VIRUSTOTAL_API_KEY=your_virustotal_api_key

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ pip install cisco-ai-skill-scanner[all]
 # For LLM analyzer and Meta-analyzer
 export SKILL_SCANNER_LLM_API_KEY="your_api_key"
 export SKILL_SCANNER_LLM_MODEL="claude-3-5-sonnet-20241022"
+# Optional: disabled, minimal, low, medium, high, xhigh, or max
+export SKILL_SCANNER_LLM_REASONING_EFFORT="low"
 
 # For VirusTotal binary scanning
 export VIRUSTOTAL_API_KEY="your_virustotal_api_key"
@@ -254,6 +256,7 @@ if not result.is_safe:
 | `--llm-provider` | LLM provider for CLI routing: `anthropic` or `openai` |
 | `--llm-consensus-runs N` | Run LLM analysis `N` times, keep majority-agreed findings, and retain their highest observed severity |
 | `--llm-max-tokens N` | Maximum output tokens for LLM responses (default: 8192) |
+| `--llm-reasoning-effort LEVEL` | Optional reasoning depth (`disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`); unset preserves the provider default |
 | `--use-virustotal` | Enable VirusTotal binary scanner |
 | `--vt-api-key KEY` | Provide VirusTotal API key directly (optional) |
 | `--vt-upload-files` | Upload unknown binaries to VirusTotal (optional) |

--- a/docs-site/faq.mdx
+++ b/docs-site/faq.mdx
@@ -20,7 +20,7 @@ No. Core analyzers (static, bytecode, pipeline) require no API keys and no netwo
 
 ### Which LLM providers are supported?
 
-Skill Scanner uses [LiteLLM](https://github.com/BerriAI/litellm) under the hood, supporting Anthropic, OpenAI, AWS Bedrock, Google Vertex AI, Azure OpenAI, and many other providers. Install optional extras (`[bedrock]`, `[vertex]`, `[azure]`, or `[all]`) for managed cloud services.
+Skill Scanner uses [LiteLLM](https://github.com/BerriAI/litellm) under the hood, supporting Anthropic, OpenAI, AWS Bedrock, Google Vertex AI, Azure OpenAI, OrcaRouter, and many other providers. Install optional extras (`[bedrock]`, `[vertex]`, `[azure]`, or `[all]`) for managed cloud services.
 
 ### How do I choose which analyzers to enable?
 

--- a/docs/architecture/analyzers/llm-analyzer.md
+++ b/docs/architecture/analyzers/llm-analyzer.md
@@ -306,6 +306,14 @@ export AWS_REGION=us-east-1
 - Applies prompt budget gates from policy (`llm_analysis.*`) and emits `LLM_CONTEXT_BUDGET_EXCEEDED` when content is skipped
 - Output token limit precedence is `--llm-max-tokens` / API `llm_max_tokens` → `SKILL_SCANNER_LLM_MAX_TOKENS` → `llm_analysis.max_output_tokens` in the active policy (default 8192). Every configured value must be a positive integer.
 - Provider-reported output truncation (`finish_reason=length`, `max_tokens`, or the Google `MAX_TOKENS` equivalent) fails with `LLMResponseTruncatedError` before partial JSON is parsed. The resulting `LLM_ANALYSIS_FAILED` diagnostic identifies the model, budget, finish reason, and the knobs that can raise the limit.
+- Reasoning effort is optional and unset by default, so existing provider behavior is unchanged. Configure `--llm-reasoning-effort`, API `llm_reasoning_effort`, or `SKILL_SCANNER_LLM_REASONING_EFFORT` with `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
+
+### Reasoning Provider Semantics
+
+- `disabled` is an explicit scanner-level semantic. Direct Anthropic, Bedrock Claude, and Vertex Claude routes receive `thinking: {type: "disabled"}`. This matters for [Claude Sonnet 5, where omitting `thinking` enables adaptive thinking](https://platform.claude.com/docs/en/docs/about-claude/models/whats-new-sonnet-5).
+- OpenAI and OpenAI-compatible gateway routes receive `reasoning_effort: "none"`. The gateway/provider remains responsible for honoring that OpenAI-style value.
+- Other effort levels use LiteLLM's normalized `reasoning_effort` field. Supported levels vary by model; `xhigh` and `max` are not universal. `drop_params=True` can remove an unsupported parameter, but cannot make a provider accept an unsupported level.
+- The scanner's optional direct Google GenAI SDK path uses different model-specific thinking controls. A configured `llm_reasoning_effort` fails with a configuration error (CLI exit 1 / API HTTP 400) rather than being silently ignored; use a LiteLLM-backed route or leave the setting unset.
 
 ## Error Handling
 

--- a/docs/architecture/analyzers/meta-analyzer.md
+++ b/docs/architecture/analyzers/meta-analyzer.md
@@ -90,6 +90,7 @@ export SKILL_SCANNER_LLM_MODEL="anthropic/claude-sonnet-4-20250514"
 export SKILL_SCANNER_LLM_BASE_URL="https://..."  # For Azure/custom endpoints
 export SKILL_SCANNER_LLM_API_VERSION="2025-01-01-preview"  # For Azure
 export SKILL_SCANNER_LLM_MAX_TOKENS="16384"  # Positive integer
+export SKILL_SCANNER_LLM_REASONING_EFFORT="low"
 ```
 
 **Meta-specific overrides** (optional - use different model/key for meta-analysis):
@@ -99,6 +100,7 @@ export SKILL_SCANNER_META_LLM_MODEL="gpt-4o"
 export SKILL_SCANNER_META_LLM_BASE_URL="https://..."
 export SKILL_SCANNER_META_LLM_API_VERSION="..."
 export SKILL_SCANNER_META_LLM_MAX_TOKENS="32768"
+export SKILL_SCANNER_META_LLM_REASONING_EFFORT="minimal"
 ```
 
 ### Priority Order
@@ -110,6 +112,7 @@ export SKILL_SCANNER_META_LLM_MAX_TOKENS="32768"
 | Base URL | `SKILL_SCANNER_META_LLM_BASE_URL` → `SKILL_SCANNER_LLM_BASE_URL` |
 | API Version | `SKILL_SCANNER_META_LLM_API_VERSION` → `SKILL_SCANNER_LLM_API_VERSION` |
 | Max output tokens | CLI/API explicit value → `SKILL_SCANNER_META_LLM_MAX_TOKENS` → `SKILL_SCANNER_LLM_MAX_TOKENS` → policy/default |
+| Reasoning effort | CLI/API explicit value → `SKILL_SCANNER_META_LLM_REASONING_EFFORT` → `SKILL_SCANNER_LLM_REASONING_EFFORT` → provider default |
 
 ### Auth Behavior
 

--- a/docs/reference/api-endpoint-reference.md
+++ b/docs/reference/api-endpoint-reference.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. DO NOT EDIT DIRECTLY.
-     Regenerate with: uv run python scripts/generate_reference_docs.py -->
+     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->
 
 # API Endpoint Reference
 
@@ -94,6 +94,7 @@ curl -X POST http://localhost:8000/scan-upload \
 | `enable_meta` | `bool` |
 | `llm_consensus_runs` | `int` |
 | `llm_max_tokens` | `int \| None` |
+| `llm_reasoning_effort` | `LLMReasoningEffort \| None` |
 
 ### `ScanResponse`
 
@@ -138,10 +139,12 @@ curl -X POST http://localhost:8000/scan-upload \
 | `enable_meta` | `bool` |
 | `llm_consensus_runs` | `int` |
 | `llm_max_tokens` | `int \| None` |
+| `llm_reasoning_effort` | `LLMReasoningEffort \| None` |
 
 ## Notes
 
 - API behavior is policy-aware and mirrors CLI analyzer selection flags.
 - API keys for VirusTotal and AI Defense are passed via request headers (`X-VirusTotal-Key`, `X-AIDefense-Key`), not in the JSON body.
 - Set `SKILL_SCANNER_ALLOWED_ROOTS` to restrict which directories the API can scan.
+- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default. Direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them.
 - All `POST` endpoints accept JSON bodies. File upload uses `multipart/form-data`.

--- a/docs/reference/cli-command-reference.md
+++ b/docs/reference/cli-command-reference.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. DO NOT EDIT DIRECTLY.
-     Regenerate with: uv run python scripts/generate_reference_docs.py -->
+     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->
 
 # CLI Command Reference
 
@@ -33,6 +33,8 @@ Flags shared by `scan` and `scan-all`:
 | `--use-behavioral` | off | Enable the behavioral analyzer |
 | `--use-virustotal` | off | Enable VirusTotal hash lookups |
 | `--use-aidefense` | off | Enable Cisco AI Defense analyzer |
+| `--use-osv` | off | Enable OSV.dev dependency vulnerability scanning (no API key; requires network) |
+| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. |
 | `--enable-meta` | off | Enable the meta (cross-correlation) analyzer |
 | `--fail-on-findings` | off | Exit non-zero if critical or high findings are reported; equivalent to `--fail-on-severity high` (CI gate) |
 | `--fail-on-severity LEVEL` | off | Exit non-zero if findings at or above LEVEL exist (critical, high, medium, low, info) |
@@ -108,9 +110,9 @@ usage: cli.py scan [-h] [--format {summary,json,markdown,table,sarif,html}]
                    [--aidefense-api-url AIDEFENSE_API_URL] [--use-osv]
                    [--llm-provider {anthropic,openai,openai-compatible}]
                    [--llm-consensus-runs N] [--llm-max-tokens N]
-                   [--use-trigger] [--enable-meta] [--adjudicate]
-                   [--policy PRESET_OR_PATH] [--lenient]
-                   [--skill-file FILENAME] [--custom-rules PATH]
+                   [--llm-reasoning-effort LEVEL] [--use-trigger]
+                   [--enable-meta] [--adjudicate] [--policy PRESET_OR_PATH]
+                   [--lenient] [--skill-file FILENAME] [--custom-rules PATH]
                    [--rule-packs PACK [PACK ...]] [--taxonomy PATH]
                    [--threat-mapping PATH]
                    skill_directory
@@ -173,6 +175,10 @@ options:
                         cost)
   --llm-max-tokens N    Maximum output tokens for LLM responses (default:
                         8192). Raise if scans produce truncated JSON.
+  --llm-reasoning-effort LEVEL
+                        Optional LLM reasoning effort: disabled, minimal, low,
+                        medium, high, xhigh, or max. Unset preserves the
+                        provider default.
   --use-trigger         Enable trigger specificity analysis
   --enable-meta         Enable meta-analysis FP filtering (2+ analyzers)
   --adjudicate          Enable per-finding adjudicator: for each deterministic
@@ -231,7 +237,8 @@ usage: cli.py scan-all [-h] [--recursive] [--check-overlap]
                        [--aidefense-api-url AIDEFENSE_API_URL] [--use-osv]
                        [--llm-provider {anthropic,openai,openai-compatible}]
                        [--llm-consensus-runs N] [--llm-max-tokens N]
-                       [--use-trigger] [--enable-meta] [--adjudicate]
+                       [--llm-reasoning-effort LEVEL] [--use-trigger]
+                       [--enable-meta] [--adjudicate]
                        [--policy PRESET_OR_PATH] [--lenient]
                        [--skill-file FILENAME] [--custom-rules PATH]
                        [--rule-packs PACK [PACK ...]] [--taxonomy PATH]
@@ -298,6 +305,10 @@ options:
                         cost)
   --llm-max-tokens N    Maximum output tokens for LLM responses (default:
                         8192). Raise if scans produce truncated JSON.
+  --llm-reasoning-effort LEVEL
+                        Optional LLM reasoning effort: disabled, minimal, low,
+                        medium, high, xhigh, or max. Unset preserves the
+                        provider default.
   --use-trigger         Enable trigger specificity analysis
   --enable-meta         Enable meta-analysis FP filtering (2+ analyzers)
   --adjudicate          Enable per-finding adjudicator: for each deterministic
@@ -357,7 +368,8 @@ usage: cli.py scan-repo [-h] [--recursive | --no-recursive | -r]
                         [--aidefense-api-url AIDEFENSE_API_URL] [--use-osv]
                         [--llm-provider {anthropic,openai,openai-compatible}]
                         [--llm-consensus-runs N] [--llm-max-tokens N]
-                        [--use-trigger] [--enable-meta] [--adjudicate]
+                        [--llm-reasoning-effort LEVEL] [--use-trigger]
+                        [--enable-meta] [--adjudicate]
                         [--policy PRESET_OR_PATH] [--lenient]
                         [--skill-file FILENAME] [--custom-rules PATH]
                         [--rule-packs PACK [PACK ...]] [--taxonomy PATH]
@@ -427,6 +439,10 @@ options:
                         cost)
   --llm-max-tokens N    Maximum output tokens for LLM responses (default:
                         8192). Raise if scans produce truncated JSON.
+  --llm-reasoning-effort LEVEL
+                        Optional LLM reasoning effort: disabled, minimal, low,
+                        medium, high, xhigh, or max. Unset preserves the
+                        provider default.
   --use-trigger         Enable trigger specificity analysis
   --enable-meta         Enable meta-analysis FP filtering (2+ analyzers)
   --adjudicate          Enable per-finding adjudicator: for each deterministic

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. DO NOT EDIT DIRECTLY.
-     Regenerate with: uv run python scripts/generate_reference_docs.py -->
+     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->
 
 # Configuration Reference
 
@@ -30,6 +30,7 @@ Primary settings for the LLM semantic analyzer.
 | `SKILL_SCANNER_LLM_API_VERSION` | Optional API version for providers that require one. | `2024-02-15-preview` |
 | `SKILL_SCANNER_LLM_USER` | Optional raw Chat Completions user field for OpenAI-compatible routes. | `{"appkey":"your-appkey"}` |
 | `SKILL_SCANNER_LLM_MAX_TOKENS` | Positive integer output-token budget. Overrides the active policy's `llm_analysis.max_output_tokens` value. | `16384` |
+| `SKILL_SCANNER_LLM_REASONING_EFFORT` | Optional reasoning-depth control: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Unset preserves the provider default. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. | `low` |
 | `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` | Skip json_schema and start in plain JSON mode for incompatible proxies. | `true` |
 
 ## Meta Analyzer
@@ -43,6 +44,7 @@ Override LLM settings for the meta (cross-correlation) analyzer. Falls back to t
 | `SKILL_SCANNER_META_LLM_BASE_URL` | Meta-analyzer base URL override. | `(falls back to LLM_BASE_URL)` |
 | `SKILL_SCANNER_META_LLM_API_VERSION` | Meta-analyzer API version override. | `(falls back to LLM_API_VERSION)` |
 | `SKILL_SCANNER_META_LLM_MAX_TOKENS` | Positive integer meta-analysis output budget; falls back to `SKILL_SCANNER_LLM_MAX_TOKENS`. | `32768` |
+| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. | `low` |
 
 ## AWS / Bedrock
 
@@ -106,12 +108,6 @@ Paths, allowlists, and other advanced settings.
 | `SKILL_SCANNER_TAXONOMY_PATH` | Path to a custom Cisco AI taxonomy YAML file (overridden by `--taxonomy`). | `/path/to/taxonomy.yaml` |
 | `SKILL_SCANNER_THREAT_MAPPING_PATH` | Path to a custom threat mapping YAML file (overridden by `--threat-mapping`). | `/path/to/threats.yaml` |
 
-## Other
-
-| Variable | Description | Example |
-|---|---|---|
-| `ANTHROPIC_API_KEY` | Configuration variable discovered in source code. |  |
-
 <details>
 <summary>Source file mapping</summary>
 
@@ -119,7 +115,6 @@ Paths, allowlists, and other advanced settings.
 |---|---|
 | `AI_DEFENSE_API_KEY` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/aidefense_analyzer.py` |
 | `AI_DEFENSE_API_URL` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/aidefense_analyzer.py` |
-| `ANTHROPIC_API_KEY` | `skill_scanner/core/analyzers/behavioral_analyzer.py` |
 | `AWS_PROFILE` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_provider_config.py` |
 | `AWS_REGION` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_provider_config.py` |
 | `AWS_SESSION_TOKEN` | `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_provider_config.py` |
@@ -130,19 +125,21 @@ Paths, allowlists, and other advanced settings.
 | `GEMINI_API_KEY` | `skill_scanner/core/analyzers/llm_provider_config.py` |
 | `GOOGLE_APPLICATION_CREDENTIALS` | `.env.example` |
 | `SKILL_SCANNER_ALLOWED_ROOTS` | `skill_scanner/api/router.py` |
-| `SKILL_SCANNER_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_API_VERSION` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_BASE_URL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` | `.env.example` |
 | `SKILL_SCANNER_LLM_MAX_TOKENS` | `.env.example`, `skill_scanner/llm_token_options.py` |
-| `SKILL_SCANNER_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
-| `SKILL_SCANNER_LLM_PROVIDER` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_PROVIDER` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_REASONING_EFFORT` | `.env.example`, `skill_scanner/llm_reasoning.py` |
 | `SKILL_SCANNER_LLM_USER` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_request_options.py` |
 | `SKILL_SCANNER_META_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_API_VERSION` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_BASE_URL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_MAX_TOKENS` | `.env.example`, `skill_scanner/llm_token_options.py` |
 | `SKILL_SCANNER_META_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | `.env.example`, `skill_scanner/llm_reasoning.py` |
 | `SKILL_SCANNER_TAXONOMY_PATH` | `skill_scanner/threats/cisco_ai_taxonomy.py` |
 | `SKILL_SCANNER_THREAT_MAPPING_PATH` | `skill_scanner/threats/threats.py` |
 | `VIRUSTOTAL_API_KEY` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py` |

--- a/docs/reference/dependencies-and-llm-providers.md
+++ b/docs/reference/dependencies-and-llm-providers.md
@@ -96,6 +96,7 @@ Set `SKILL_SCANNER_LLM_MODEL` using the provider prefix convention:
 | Google AI Studio | `gemini/gemini-2.5-flash` | Requires `[google]` extra |
 | Azure OpenAI | `azure/my-deployment-name` | Requires `[azure]` extra |
 | Ollama (local) | `ollama/llama3` | No API key needed |
+| OrcaRouter | `orcarouter/anthropic/claude-sonnet-5` | OpenAI-compatible gateway; default endpoint `https://api.orcarouter.ai/v1` (override with `SKILL_SCANNER_LLM_BASE_URL`) |
 
 For OpenAI and OpenAI-compatible custom endpoints, `SKILL_SCANNER_LLM_USER` can set the raw Chat Completions `user` request field. The value is passed through unchanged and is ignored for non-OpenAI routes.
 
@@ -113,6 +114,7 @@ For OpenAI and OpenAI-compatible custom endpoints, `SKILL_SCANNER_LLM_USER` can 
 | Google AI Studio | API key | `SKILL_SCANNER_LLM_API_KEY` (auto-sets `GEMINI_API_KEY`) |
 | Azure OpenAI | API key + endpoint | `SKILL_SCANNER_LLM_API_KEY`, `SKILL_SCANNER_LLM_BASE_URL`, `SKILL_SCANNER_LLM_API_VERSION` |
 | Ollama | None | — |
+| OrcaRouter | API key | `SKILL_SCANNER_LLM_API_KEY` |
 
 ## Related
 

--- a/docs/user-guide/installation-and-configuration.md
+++ b/docs/user-guide/installation-and-configuration.md
@@ -56,6 +56,7 @@ You only need to set these if you're using the corresponding features. Click a s
 - `SKILL_SCANNER_LLM_BASE_URL`
 - `SKILL_SCANNER_LLM_API_VERSION`
 - `SKILL_SCANNER_LLM_USER` — optional raw Chat Completions `user` field for OpenAI-compatible routes
+- `SKILL_SCANNER_LLM_REASONING_EFFORT` — optional `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; unset preserves the provider default. Direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them.
 - `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` — start in plain JSON mode for proxies that reject `json_schema`
 
 </details>
@@ -67,6 +68,7 @@ You only need to set these if you're using the corresponding features. Click a s
 - `SKILL_SCANNER_META_LLM_MODEL`
 - `SKILL_SCANNER_META_LLM_BASE_URL`
 - `SKILL_SCANNER_META_LLM_API_VERSION`
+- `SKILL_SCANNER_META_LLM_REASONING_EFFORT` — direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them
 
 </details>
 

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -32,10 +32,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 REFERENCE_DIR = ROOT / "docs" / "reference"
+REFERENCE_PYTHON = (3, 12)
 
 GENERATED_BANNER = (
     "<!-- GENERATED FILE. DO NOT EDIT DIRECTLY.\n"
-    "     Regenerate with: uv run python scripts/generate_reference_docs.py -->\n\n"
+    "     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->\n\n"
 )
 
 
@@ -99,6 +100,8 @@ def _render_cli_reference() -> str:
         "| `--use-behavioral` | off | Enable the behavioral analyzer |",
         "| `--use-virustotal` | off | Enable VirusTotal hash lookups |",
         "| `--use-aidefense` | off | Enable Cisco AI Defense analyzer |",
+        "| `--use-osv` | off | Enable OSV.dev dependency vulnerability scanning (no API key; requires network) |",
+        "| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. |",
         "| `--enable-meta` | off | Enable the meta (cross-correlation) analyzer |",
         "| `--fail-on-findings` | off | Exit non-zero if critical or high findings are reported; equivalent to `--fail-on-severity high` (CI gate) |",
         "| `--fail-on-severity LEVEL` | off | Exit non-zero if findings at or above LEVEL exist (critical, high, medium, low, info) |",
@@ -340,6 +343,7 @@ def _render_api_reference() -> str:
             "- API behavior is policy-aware and mirrors CLI analyzer selection flags.",
             "- API keys for VirusTotal and AI Defense are passed via request headers (`X-VirusTotal-Key`, `X-AIDefense-Key`), not in the JSON body.",
             "- Set `SKILL_SCANNER_ALLOWED_ROOTS` to restrict which directories the API can scan.",
+            "- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default. Direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them.",
             "- All `POST` endpoints accept JSON bodies. File upload uses `multipart/form-data`.",
         ]
     )
@@ -363,6 +367,7 @@ def _collect_env_variables() -> dict[str, set[str]]:
     candidates = [
         ROOT / "skill_scanner" / "config" / "config.py",
         ROOT / "skill_scanner" / "llm_token_options.py",
+        ROOT / "skill_scanner" / "llm_reasoning.py",
         ROOT / "skill_scanner" / "cli" / "cli.py",
         ROOT / "skill_scanner" / "api" / "router.py",
         ROOT / "skill_scanner" / "core" / "analyzers" / "llm_analyzer.py",
@@ -376,24 +381,87 @@ def _collect_env_variables() -> dict[str, set[str]]:
         ROOT / "skill_scanner" / "threats" / "threats.py",
     ]
 
-    env_get_re = re.compile(r'os\.(?:getenv|environ\.get)\(\s*"([A-Z][A-Z0-9_]+)"')
-    env_const_re = re.compile(r'^(_?[A-Z][A-Z0-9_]+)\s*(?::\s*str\s*)?=\s*"([A-Z][A-Z0-9_]+)"', re.MULTILINE)
     for path in candidates:
         if not path.exists():
             continue
         text = path.read_text(encoding="utf-8")
         rel = str(path.relative_to(ROOT))
-        for var in env_get_re.findall(text):
+        for var in _extract_python_env_variables(text):
             add(var, rel)
-        for const_name, var_value in env_const_re.findall(text):
-            if re.search(rf"os\.(?:getenv|environ\.get)\(\s*{const_name}", text):
-                add(var_value, rel)
 
-    token_options_source = "skill_scanner/llm_token_options.py"
-    for var in ("SKILL_SCANNER_LLM_MAX_TOKENS", "SKILL_SCANNER_META_LLM_MAX_TOKENS"):
-        add(var, token_options_source)
+    runtime_env_sources = {
+        "skill_scanner/llm_token_options.py": (
+            "SKILL_SCANNER_LLM_MAX_TOKENS",
+            "SKILL_SCANNER_META_LLM_MAX_TOKENS",
+        ),
+        "skill_scanner/llm_reasoning.py": (
+            "SKILL_SCANNER_LLM_REASONING_EFFORT",
+            "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
+        ),
+    }
+    for source, variables in runtime_env_sources.items():
+        for var in variables:
+            add(var, source)
 
     return dict(sorted(env_map.items()))
+
+
+def _extract_python_env_variables(source: str) -> set[str]:
+    """Return environment names used by executable ``os`` lookup calls.
+
+    Parsing the syntax tree avoids treating examples in comments or docstrings
+    as supported configuration. Module constants passed to the lookup are
+    resolved so helpers such as ``os.getenv(LLM_REASONING_EFFORT_ENV_VAR)``
+    remain discoverable.
+    """
+    tree = ast.parse(source)
+    constants: dict[str, str] = {}
+    env_name_re = re.compile(r"[A-Z][A-Z0-9_]+")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    constants[target.id] = node.value.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            constants[node.target.id] = node.value.value
+
+    variables: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+
+        function = node.func
+        is_getenv = (
+            isinstance(function, ast.Attribute)
+            and function.attr == "getenv"
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "os"
+        )
+        is_environ_get = (
+            isinstance(function, ast.Attribute)
+            and function.attr == "get"
+            and isinstance(function.value, ast.Attribute)
+            and function.value.attr == "environ"
+            and isinstance(function.value.value, ast.Name)
+            and function.value.value.id == "os"
+        )
+        if not (is_getenv or is_environ_get):
+            continue
+
+        argument = node.args[0]
+        value = argument.value if isinstance(argument, ast.Constant) and isinstance(argument.value, str) else None
+        if isinstance(argument, ast.Name):
+            value = constants.get(argument.id)
+        if value and env_name_re.fullmatch(value):
+            variables.add(value)
+
+    return variables
 
 
 def _describe_env_var(var: str) -> str:
@@ -412,6 +480,11 @@ def _describe_env_var(var: str) -> str:
             "Positive integer output-token budget. Overrides the active policy's "
             "`llm_analysis.max_output_tokens` value."
         ),
+        "SKILL_SCANNER_LLM_REASONING_EFFORT": (
+            "Optional reasoning-depth control: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or "
+            "`max`. Unset preserves the provider default. Direct Google GenAI SDK requests reject configured "
+            "controls; LiteLLM-backed Gemini requests support them."
+        ),
         "SKILL_SCANNER_LLM_FORCE_JSON_OBJECT": "Skip json_schema and start in plain JSON mode for incompatible proxies.",
         "SKILL_SCANNER_META_LLM_API_KEY": "Meta-analyzer API key override.",
         "SKILL_SCANNER_META_LLM_MODEL": "Meta-analyzer model override.",
@@ -419,6 +492,10 @@ def _describe_env_var(var: str) -> str:
         "SKILL_SCANNER_META_LLM_API_VERSION": "Meta-analyzer API version override.",
         "SKILL_SCANNER_META_LLM_MAX_TOKENS": (
             "Positive integer meta-analysis output budget; falls back to `SKILL_SCANNER_LLM_MAX_TOKENS`."
+        ),
+        "SKILL_SCANNER_META_LLM_REASONING_EFFORT": (
+            "Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`. "
+            "Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them."
         ),
         "VIRUSTOTAL_API_KEY": "VirusTotal analyzer API key.",
         "VIRUSTOTAL_UPLOAD_FILES": "Enable upload mode for unknown binaries.",
@@ -457,6 +534,7 @@ _ENV_VAR_GROUPS: list[tuple[str, str, list[str]]] = [
             "SKILL_SCANNER_LLM_API_VERSION",
             "SKILL_SCANNER_LLM_USER",
             "SKILL_SCANNER_LLM_MAX_TOKENS",
+            "SKILL_SCANNER_LLM_REASONING_EFFORT",
             "SKILL_SCANNER_LLM_FORCE_JSON_OBJECT",
         ],
     ),
@@ -469,6 +547,7 @@ _ENV_VAR_GROUPS: list[tuple[str, str, list[str]]] = [
             "SKILL_SCANNER_META_LLM_BASE_URL",
             "SKILL_SCANNER_META_LLM_API_VERSION",
             "SKILL_SCANNER_META_LLM_MAX_TOKENS",
+            "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
         ],
     ),
     (
@@ -520,12 +599,14 @@ _ENV_VAR_EXAMPLES: dict[str, str] = {
     "SKILL_SCANNER_LLM_API_VERSION": "2024-02-15-preview",
     "SKILL_SCANNER_LLM_USER": '{"appkey":"your-appkey"}',
     "SKILL_SCANNER_LLM_MAX_TOKENS": "16384",
+    "SKILL_SCANNER_LLM_REASONING_EFFORT": "low",
     "SKILL_SCANNER_LLM_FORCE_JSON_OBJECT": "true",
     "SKILL_SCANNER_META_LLM_API_KEY": "(falls back to LLM_API_KEY)",
     "SKILL_SCANNER_META_LLM_MODEL": "(falls back to LLM_MODEL)",
     "SKILL_SCANNER_META_LLM_BASE_URL": "(falls back to LLM_BASE_URL)",
     "SKILL_SCANNER_META_LLM_API_VERSION": "(falls back to LLM_API_VERSION)",
     "SKILL_SCANNER_META_LLM_MAX_TOKENS": "32768",
+    "SKILL_SCANNER_META_LLM_REASONING_EFFORT": "low",
     "AWS_REGION": "us-east-1",
     "AWS_PROFILE": "my-bedrock-profile",
     "AWS_SESSION_TOKEN": "(temporary STS token)",
@@ -670,6 +751,15 @@ def _write_or_check(outputs: dict[Path, str], check: bool) -> int:
 
 
 def main() -> int:
+    if sys.version_info[:2] != REFERENCE_PYTHON:
+        expected = ".".join(str(part) for part in REFERENCE_PYTHON)
+        actual = f"{sys.version_info.major}.{sys.version_info.minor}"
+        print(
+            f"Reference output depends on argparse formatting; use Python {expected} (running {actual}).",
+            file=sys.stderr,
+        )
+        return 2
+
     parser = argparse.ArgumentParser(description="Generate reference docs from source of truth.")
     parser.add_argument("--check", action="store_true", help="Fail if generated outputs differ from committed files")
     args = parser.parse_args()

--- a/skill_scanner/api/router.py
+++ b/skill_scanner/api/router.py
@@ -47,7 +47,9 @@ from ..core.analyzer_factory import build_analyzers
 from ..core.exceptions import SkillLoadError
 from ..core.scan_policy import ScanPolicy
 from ..core.scanner import SkillScanner
+from ..llm_reasoning import LLMReasoningEffort, ReasoningConfigurationError
 from ..llm_token_options import resolve_llm_max_tokens
+from ..utils.logging_context import scan_log_context
 
 logger = logging.getLogger("skill_scanner.api")
 
@@ -215,6 +217,10 @@ class ScanRequest(BaseModel):
         gt=0,
         description="Maximum output tokens for LLM and meta-analysis responses",
     )
+    llm_reasoning_effort: LLMReasoningEffort | None = Field(
+        None,
+        description="Optional LLM reasoning effort; unset preserves the provider default",
+    )
 
 
 class ScanResponse(BaseModel):
@@ -266,6 +272,10 @@ class BatchScanRequest(BaseModel):
         gt=0,
         description="Maximum output tokens for LLM and meta-analysis responses",
     )
+    llm_reasoning_effort: LLMReasoningEffort | None = Field(
+        None,
+        description="Optional LLM reasoning effort; unset preserves the provider default",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +323,7 @@ def _build_analyzers(
     use_osv: bool = False,
     llm_consensus_runs: int = 1,
     llm_max_tokens: int | None = None,
+    llm_reasoning_effort: str | None = None,
 ):
     """Build the analyzer list — delegates to the centralized factory."""
     return build_analyzers(
@@ -331,6 +342,7 @@ def _build_analyzers(
         use_osv=use_osv,
         llm_consensus_runs=llm_consensus_runs,
         llm_max_tokens=llm_max_tokens,
+        llm_reasoning_effort=llm_reasoning_effort,
     )
 
 
@@ -428,26 +440,32 @@ async def scan_skill(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+    scan_id = str(uuid.uuid4())
+
     def run_scan():
-        analyzers = _build_analyzers(
-            policy,
-            custom_rules=custom_rules_path,
-            use_behavioral=request.use_behavioral,
-            use_llm=request.use_llm,
-            llm_provider=request.llm_provider,
-            use_virustotal=request.use_virustotal,
-            vt_api_key=vt_api_key,
-            vt_upload_files=request.vt_upload_files,
-            use_aidefense=request.use_aidefense,
-            aidefense_api_key=aidefense_api_key,
-            aidefense_api_url=request.aidefense_api_url,
-            use_trigger=request.use_trigger,
-            use_osv=request.use_osv,
-            llm_consensus_runs=request.llm_consensus_runs,
-            llm_max_tokens=request.llm_max_tokens,
-        )
-        scanner = SkillScanner(analyzers=analyzers, policy=policy)
-        return scanner.scan_skill(skill_dir)
+        # Context variables do not automatically cross executor boundaries,
+        # so bind the request id inside the worker thread itself.
+        with scan_log_context(scan_id=scan_id):
+            analyzers = _build_analyzers(
+                policy,
+                custom_rules=custom_rules_path,
+                use_behavioral=request.use_behavioral,
+                use_llm=request.use_llm,
+                llm_provider=request.llm_provider,
+                use_virustotal=request.use_virustotal,
+                vt_api_key=vt_api_key,
+                vt_upload_files=request.vt_upload_files,
+                use_aidefense=request.use_aidefense,
+                aidefense_api_key=aidefense_api_key,
+                aidefense_api_url=request.aidefense_api_url,
+                use_trigger=request.use_trigger,
+                use_osv=request.use_osv,
+                llm_consensus_runs=request.llm_consensus_runs,
+                llm_max_tokens=request.llm_max_tokens,
+                llm_reasoning_effort=request.llm_reasoning_effort,
+            )
+            scanner = SkillScanner(analyzers=analyzers, policy=policy)
+            return scanner.scan_skill(skill_dir)
 
     try:
         loop = asyncio.get_running_loop()
@@ -462,39 +480,47 @@ async def scan_skill(
             and apply_meta_analysis_to_results is not None
             and len(result.findings) > 0
         ):
-            try:
-                from ..core.loader import SkillLoader
+            with scan_log_context(
+                skill_name=result.skill_name,
+                skill_path=str(skill_dir),
+                scan_id=scan_id,
+            ):
+                try:
+                    from ..core.loader import SkillLoader
 
-                meta_analyzer = MetaAnalyzer(
-                    policy=policy,
-                    max_tokens=resolve_llm_max_tokens(
-                        request.llm_max_tokens,
-                        meta=True,
-                        default=policy.llm_analysis.max_output_tokens if policy else 8192,
-                    ),
-                )
-                loader = SkillLoader()
-                skill = loader.load_skill(skill_dir)
+                    meta_analyzer = MetaAnalyzer(
+                        policy=policy,
+                        max_tokens=resolve_llm_max_tokens(
+                            request.llm_max_tokens,
+                            meta=True,
+                            default=policy.llm_analysis.max_output_tokens if policy else 8192,
+                        ),
+                        provider=request.llm_provider,
+                        reasoning_effort=request.llm_reasoning_effort,
+                    )
+                    loader = SkillLoader()
+                    skill = loader.load_skill(skill_dir)
 
-                meta_result = await meta_analyzer.analyze_with_findings(
-                    skill=skill,
-                    findings=result.findings,
-                    analyzers_used=result.analyzers_used,
-                )
+                    meta_result = await meta_analyzer.analyze_with_findings(
+                        skill=skill,
+                        findings=result.findings,
+                        analyzers_used=result.analyzers_used,
+                    )
 
-                filtered_findings = apply_meta_analysis_to_results(
-                    original_findings=result.findings,
-                    meta_result=meta_result,
-                    skill=skill,
-                )
-                result.findings = filtered_findings
-                result.analyzers_used.append("meta_analyzer")
-                if merge_meta_analyzer_usage is not None:
-                    merge_meta_analyzer_usage(result, meta_analyzer)
-            except Exception as meta_error:
-                logger.warning("Meta-analysis failed: %s", meta_error)
+                    filtered_findings = apply_meta_analysis_to_results(
+                        original_findings=result.findings,
+                        meta_result=meta_result,
+                        skill=skill,
+                    )
+                    result.findings = filtered_findings
+                    result.analyzers_used.append("meta_analyzer")
+                    if merge_meta_analyzer_usage is not None:
+                        merge_meta_analyzer_usage(result, meta_analyzer)
+                except ReasoningConfigurationError:
+                    raise
+                except Exception as meta_error:
+                    logger.warning("Meta-analysis failed: %s", meta_error)
 
-        scan_id = str(uuid.uuid4())
         return ScanResponse(
             scan_id=scan_id,
             skill_name=result.skill_name,
@@ -538,6 +564,10 @@ async def scan_uploaded_skill(
         None,
         gt=0,
         description="Maximum output tokens for LLM and meta-analysis responses",
+    ),
+    llm_reasoning_effort: LLMReasoningEffort | None = Form(
+        None,
+        description="Optional LLM reasoning effort; unset preserves the provider default",
     ),
 ):
     """Scan an uploaded skill package (ZIP file)."""
@@ -634,6 +664,7 @@ async def scan_uploaded_skill(
             enable_meta=enable_meta,
             llm_consensus_runs=llm_consensus_runs,
             llm_max_tokens=llm_max_tokens,
+            llm_reasoning_effort=llm_reasoning_effort,
         )
 
         return await scan_skill(request, vt_api_key=vt_api_key, aidefense_api_key=aidefense_api_key)
@@ -698,6 +729,17 @@ def run_batch_scan(
     aidefense_api_key: str | None = None,
 ):
     """Background task to run batch scan."""
+    with scan_log_context(scan_id=scan_id):
+        _run_batch_scan(scan_id, request, vt_api_key, aidefense_api_key)
+
+
+def _run_batch_scan(
+    scan_id: str,
+    request: BatchScanRequest,
+    vt_api_key: str | None = None,
+    aidefense_api_key: str | None = None,
+):
+    """Run a batch scan with its request context already bound."""
     try:
         policy = _resolve_policy(request.policy)
 
@@ -721,6 +763,7 @@ def run_batch_scan(
             use_osv=request.use_osv,
             llm_consensus_runs=request.llm_consensus_runs,
             llm_max_tokens=request.llm_max_tokens,
+            llm_reasoning_effort=request.llm_reasoning_effort,
         )
 
         scanner = SkillScanner(analyzers=analyzers, policy=policy)
@@ -747,31 +790,39 @@ def run_batch_scan(
                         meta=True,
                         default=policy_ref.llm_analysis.max_output_tokens if policy_ref else 8192,
                     ),
+                    provider=request.llm_provider,
+                    reasoning_effort=request.llm_reasoning_effort,
                 )
                 for result in report_ref.scan_results:
                     if result.findings:
-                        try:
-                            skill_dir_path = Path(result.skill_directory)
-                            skill = scanner_ref.loader.load_skill(skill_dir_path)
-                            meta_result = await meta_analyzer.analyze_with_findings(
-                                skill=skill,
-                                findings=result.findings,
-                                analyzers_used=result.analyzers_used,
-                            )
-                            filtered_findings = apply_meta_analysis_to_results(
-                                original_findings=result.findings,
-                                meta_result=meta_result,
-                                skill=skill,
-                            )
-                            result.findings = filtered_findings
-                            result.analyzers_used.append("meta_analyzer")
-                            if merge_meta_analyzer_usage is not None:
-                                merge_meta_analyzer_usage(result, meta_analyzer)
-                        except Exception:
-                            pass
+                        skill_dir_path = Path(result.skill_directory)
+                        with scan_log_context(
+                            skill_name=result.skill_name,
+                            skill_path=str(skill_dir_path.resolve()),
+                        ):
+                            try:
+                                skill = scanner_ref.loader.load_skill(skill_dir_path)
+                                meta_result = await meta_analyzer.analyze_with_findings(
+                                    skill=skill,
+                                    findings=result.findings,
+                                    analyzers_used=result.analyzers_used,
+                                )
+                                filtered_findings = apply_meta_analysis_to_results(
+                                    original_findings=result.findings,
+                                    meta_result=meta_result,
+                                    skill=skill,
+                                )
+                                result.findings = filtered_findings
+                                result.analyzers_used.append("meta_analyzer")
+                                if merge_meta_analyzer_usage is not None:
+                                    merge_meta_analyzer_usage(result, meta_analyzer)
+                            except Exception:
+                                pass
 
             try:
                 asyncio.run(_run_batch_meta(scanner, report, policy))
+            except ReasoningConfigurationError:
+                raise
             except Exception:
                 pass
 

--- a/skill_scanner/cli/cli.py
+++ b/skill_scanner/cli/cli.py
@@ -40,6 +40,7 @@ from ..core.reporters.sarif_reporter import SARIFReporter
 from ..core.reporters.table_reporter import TableReporter
 from ..core.scan_policy import ScanPolicy
 from ..core.scanner import SkillScanner
+from ..llm_reasoning import LLM_REASONING_EFFORT_VALUES, ReasoningConfigurationError
 from ..llm_token_options import resolve_llm_max_tokens
 
 # Optional LLM analyzer (needed only for LLM_AVAILABLE check)
@@ -147,6 +148,7 @@ def _build_analyzers(policy: ScanPolicy, args: argparse.Namespace, status: Calla
         llm_provider=getattr(args, "llm_provider", None),
         llm_consensus_runs=getattr(args, "llm_consensus_runs", 1),
         llm_max_tokens=getattr(args, "llm_max_tokens", None),
+        llm_reasoning_effort=getattr(args, "llm_reasoning_effort", None),
     )
 
     # Emit status messages for the optional analyzers that were activated.
@@ -175,6 +177,7 @@ def _build_meta_analyzer(
     status: Callable[[str], None],
     policy=None,
     max_tokens: int | None = None,
+    reasoning_effort: str | None = None,
 ):
     """Optionally build a MetaAnalyzer if ``--enable-meta`` is set."""
     if not getattr(args, "enable_meta", False):
@@ -199,6 +202,8 @@ def _build_meta_analyzer(
             api_key=meta_api_key,
             base_url=meta_base_url,
             api_version=meta_api_version,
+            provider=getattr(args, "llm_provider", None),
+            reasoning_effort=reasoning_effort,
             policy=policy,
         )
         effective_max_tokens = resolve_llm_max_tokens(
@@ -210,6 +215,8 @@ def _build_meta_analyzer(
         meta = MetaAnalyzer(**kwargs)
         status("Using Meta-Analyzer for false positive filtering and finding prioritization")
         return meta
+    except ReasoningConfigurationError:
+        raise
     except Exception as e:
         logger.warning("Could not initialise Meta-Analyzer: %s", e)
         return None
@@ -405,7 +412,15 @@ def scan_command(args: argparse.Namespace) -> int:
         policy.adjudicator.enabled = True
     analyzers = _build_analyzers(policy, args, status)
     llm_max_tokens = getattr(args, "llm_max_tokens", None)
-    meta_analyzer = _build_meta_analyzer(args, len(analyzers), status, policy=policy, max_tokens=llm_max_tokens)
+    llm_reasoning_effort = getattr(args, "llm_reasoning_effort", None)
+    meta_analyzer = _build_meta_analyzer(
+        args,
+        len(analyzers),
+        status,
+        policy=policy,
+        max_tokens=llm_max_tokens,
+        reasoning_effort=llm_reasoning_effort,
+    )
 
     scanner = SkillScanner(analyzers=analyzers, policy=policy)
     lenient = getattr(args, "lenient", False)
@@ -499,7 +514,15 @@ def scan_all_command(args: argparse.Namespace) -> int:
         policy.adjudicator.enabled = True
     analyzers = _build_analyzers(policy, args, status)
     llm_max_tokens = getattr(args, "llm_max_tokens", None)
-    meta_analyzer = _build_meta_analyzer(args, len(analyzers), status, policy=policy, max_tokens=llm_max_tokens)
+    llm_reasoning_effort = getattr(args, "llm_reasoning_effort", None)
+    meta_analyzer = _build_meta_analyzer(
+        args,
+        len(analyzers),
+        status,
+        policy=policy,
+        max_tokens=llm_max_tokens,
+        reasoning_effort=llm_reasoning_effort,
+    )
 
     scanner = SkillScanner(analyzers=analyzers, policy=policy)
 
@@ -628,7 +651,15 @@ def scan_repo_command(args: argparse.Namespace) -> int:
                 policy.adjudicator.enabled = True
             analyzers = _build_analyzers(policy, args, status)
             llm_max_tokens = getattr(args, "llm_max_tokens", None)
-            meta_analyzer = _build_meta_analyzer(args, len(analyzers), status, policy=policy, max_tokens=llm_max_tokens)
+            llm_reasoning_effort = getattr(args, "llm_reasoning_effort", None)
+            meta_analyzer = _build_meta_analyzer(
+                args,
+                len(analyzers),
+                status,
+                policy=policy,
+                max_tokens=llm_max_tokens,
+                reasoning_effort=llm_reasoning_effort,
+            )
 
             scanner = SkillScanner(analyzers=analyzers, policy=policy)
 
@@ -984,6 +1015,16 @@ def _add_common_scan_flags(parser: argparse.ArgumentParser) -> None:
         metavar="N",
         help="Maximum output tokens for LLM responses (default: 8192). Raise if scans produce truncated JSON.",
     )
+    parser.add_argument(
+        "--llm-reasoning-effort",
+        choices=LLM_REASONING_EFFORT_VALUES,
+        default=None,
+        metavar="LEVEL",
+        help=(
+            "Optional LLM reasoning effort: disabled, minimal, low, medium, high, xhigh, or max. "
+            "Unset preserves the provider default."
+        ),
+    )
     parser.add_argument("--use-trigger", action="store_true", help="Enable trigger specificity analysis")
     parser.add_argument("--enable-meta", action="store_true", help="Enable meta-analysis FP filtering (2+ analyzers)")
     parser.add_argument(
@@ -1148,7 +1189,11 @@ def main() -> int:
     }
     handler = dispatch.get(args.command)
     if handler:
-        return handler(args)
+        try:
+            return handler(args)
+        except ReasoningConfigurationError as exc:
+            print(f"LLM reasoning configuration error: {exc}", file=sys.stderr)
+            return 1
 
     parser.print_help()
     return 1

--- a/skill_scanner/config/config.py
+++ b/skill_scanner/config/config.py
@@ -24,6 +24,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..llm_reasoning import resolve_llm_reasoning_effort
 from ..llm_token_options import resolve_llm_max_tokens
 
 
@@ -46,6 +47,7 @@ class Config:
     llm_rate_limit_delay: float = 2.0
     llm_max_retries: int = 3
     llm_timeout: int = 120
+    llm_reasoning_effort: str | None = None
 
     # AWS Bedrock Configuration
     aws_region_name: str = "us-east-1"
@@ -89,6 +91,10 @@ class Config:
         # Malformed/non-positive environment values are rejected instead of
         # silently producing provider errors or zero-length responses.
         self.llm_max_tokens = resolve_llm_max_tokens(self.llm_max_tokens)
+
+        # Explicit constructor value > scanner-wide environment > unset.
+        # Unset deliberately emits no reasoning/thinking request fields.
+        self.llm_reasoning_effort = resolve_llm_reasoning_effort(self.llm_reasoning_effort)
 
         # Optional raw Chat Completions user field for OpenAI-compatible routes
         if self.llm_user is not None and not self.llm_user.strip():

--- a/skill_scanner/core/analyzer_factory.py
+++ b/skill_scanner/core/analyzer_factory.py
@@ -31,6 +31,7 @@ import logging
 import os
 from pathlib import Path
 
+from ..llm_reasoning import ReasoningConfigurationError
 from ..llm_token_options import resolve_llm_max_tokens
 from .analyzers.base import BaseAnalyzer
 from .analyzers.bytecode_analyzer import BytecodeAnalyzer
@@ -104,6 +105,7 @@ def build_analyzers(
     use_osv: bool = False,
     llm_consensus_runs: int = 1,
     llm_max_tokens: int | None = None,
+    llm_reasoning_effort: str | None = None,
 ) -> list[BaseAnalyzer]:
     """Build the full analyzer list (core + optional).
 
@@ -123,6 +125,9 @@ def build_analyzers(
             policy's ``llm_analysis.max_output_tokens`` value.
         llm_user: Optional raw Chat Completions user field for
             OpenAI-compatible LLM routes.
+        llm_reasoning_effort: Optional reasoning-depth control. When *None*,
+            LLM clients resolve ``SKILL_SCANNER_LLM_REASONING_EFFORT`` and
+            otherwise preserve provider defaults.
 
     Returns:
         A list of analyzer instances ready to be passed to
@@ -140,7 +145,12 @@ def build_analyzers(
         try:
             from .analyzers.behavioral_analyzer import BehavioralAnalyzer
 
-            analyzers.append(BehavioralAnalyzer())
+            analyzers.append(
+                BehavioralAnalyzer(
+                    llm_provider=llm_provider,
+                    llm_reasoning_effort=llm_reasoning_effort,
+                )
+            )
         except (ImportError, ValueError, TypeError) as exc:
             logger.warning("Could not load behavioral analyzer: %s", exc)
 
@@ -167,12 +177,17 @@ def build_analyzers(
                 api_version=api_version,
                 provider=provider,
                 llm_user=llm_user,
+                reasoning_effort=llm_reasoning_effort,
                 policy=policy,
                 **extra_kwargs,
             )
             if llm_consensus_runs > 1:
                 llm.consensus_runs = llm_consensus_runs
             analyzers.append(llm)
+        except ReasoningConfigurationError:
+            # A requested LLM control must never turn ``--use-llm`` into a
+            # successful deterministic-only scan.
+            raise
         except (ImportError, ValueError, TypeError) as exc:
             logger.warning("Could not load LLM analyzer: %s", exc)
 

--- a/skill_scanner/core/analyzers/adjudicator.py
+++ b/skill_scanner/core/analyzers/adjudicator.py
@@ -51,6 +51,7 @@ from typing import Any
 
 from ..models import Finding, Severity, Skill
 from ..rule_registry import PackLoader
+from .llm_provider_config import ProviderConfig
 from .llm_request_handler import (
     LLMTokenUsage,
     _add_token_usage,
@@ -270,7 +271,24 @@ class Adjudicator:
         self.max_retries = max_retries
         self.rate_limit_delay = rate_limit_delay
         self.timeout = timeout
-        self.model = _resolve_model()
+        raw_provider = os.environ.get("SKILL_SCANNER_LLM_PROVIDER")
+        self.provider = raw_provider.strip().lower().replace("_", "-") if raw_provider else None
+        model = _resolve_model()
+        if model is None and self.provider == "orcarouter":
+            model = "orcarouter/anthropic/claude-sonnet-5"
+
+        self.provider_config: ProviderConfig | None = None
+        if model and (self.provider == "orcarouter" or model.lower().startswith("orcarouter/")):
+            self.provider_config = ProviderConfig(
+                model=model,
+                api_key=os.environ.get("SKILL_SCANNER_LLM_API_KEY"),
+                base_url=os.environ.get("SKILL_SCANNER_LLM_BASE_URL"),
+                api_version=os.environ.get("SKILL_SCANNER_LLM_API_VERSION"),
+                provider=self.provider,
+            )
+            self.model = self.provider_config.model
+        else:
+            self.model = model
         self.temperature = _resolve_temperature()
 
         # Lazy-loaded rule registry — only touched if we actually
@@ -354,6 +372,8 @@ class Adjudicator:
         }
         if self.temperature is not None:
             request["temperature"] = self.temperature
+        if self.provider_config is not None:
+            request.update(self.provider_config.get_request_params())
 
         content = ""
         last_exc: Exception | None = None

--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
@@ -31,8 +31,14 @@ import logging
 import os
 from typing import Any
 
+from .....llm_reasoning import build_litellm_reasoning_params, resolve_llm_reasoning_effort
+from ...llm_provider_config import ProviderConfig
 from ...llm_request_handler import _TEMPERATURE_UNSET, _resolve_temperature
-from ...llm_request_options import resolve_llm_user, supports_openai_user_param
+from ...llm_request_options import (
+    normalize_litellm_model_for_provider,
+    resolve_llm_user,
+    supports_openai_user_param,
+)
 
 try:
     from litellm import acompletion
@@ -68,6 +74,9 @@ class AlignmentLLMClient:
         temperature: Any = _TEMPERATURE_UNSET,
         max_tokens: int = 4096,
         timeout: int = 120,
+        *,
+        provider: str | None = None,
+        reasoning_effort: str | None = None,
     ):
         """Initialize the alignment LLM client.
 
@@ -84,6 +93,9 @@ class AlignmentLLMClient:
                 (numeric value or ``"none"``).
             max_tokens: Max tokens for responses
             timeout: Request timeout in seconds
+            provider: Optional provider override used for request semantics
+            reasoning_effort: Optional reasoning-depth control. When omitted,
+                resolves from ``SKILL_SCANNER_LLM_REASONING_EFFORT``.
 
         Raises:
             ImportError: If litellm is not available
@@ -92,17 +104,38 @@ class AlignmentLLMClient:
         if not LITELLM_AVAILABLE:
             raise ImportError("litellm is required for alignment verification. Install with: pip install litellm")
 
-        # Resolve API key from environment if not provided
-        self._api_key = api_key or self._resolve_api_key(model)
-        if not self._api_key and not self._is_bedrock_model(model):
-            raise ValueError("LLM provider API key is required for alignment verification")
-
-        # Store configuration for per-request usage
-        self._model = model
-        self._base_url = base_url
-        self._api_version = api_version
-        self._provider = os.getenv("SKILL_SCANNER_LLM_PROVIDER")
+        # Store configuration for per-request usage. OrcaRouter uses the shared
+        # provider configuration so model normalization, key resolution, and
+        # its default OpenAI-compatible endpoint stay consistent with the main
+        # and meta LLM clients.
+        raw_provider = provider or os.getenv("SKILL_SCANNER_LLM_PROVIDER")
+        self._provider = raw_provider.strip().lower().replace("_", "-") if raw_provider else None
+        self._provider_config: ProviderConfig | None = None
         self._llm_user = resolve_llm_user(llm_user)
+        if self._provider == "orcarouter" or model.lower().startswith("orcarouter/"):
+            self._provider_config = ProviderConfig(
+                model=model,
+                api_key=api_key,
+                base_url=base_url,
+                api_version=api_version,
+                provider=self._provider,
+                llm_user=self._llm_user,
+            )
+            self._provider_config.validate()
+            self._api_key = self._provider_config.api_key
+            self._base_url = self._provider_config.base_url
+            self._api_version = self._provider_config.api_version
+            self._provider = self._provider_config.provider
+            self._model = self._provider_config.model
+            self._llm_user = self._provider_config.llm_user
+        else:
+            self._api_key = api_key or self._resolve_api_key(model)
+            if not self._api_key and not self._is_bedrock_model(model):
+                raise ValueError("LLM provider API key is required for alignment verification")
+            self._base_url = base_url
+            self._api_version = api_version
+            self._model = normalize_litellm_model_for_provider(model, self._provider)
+        self._reasoning_effort = resolve_llm_reasoning_effort(reasoning_effort)
         self._temperature = _resolve_temperature(temperature, "SKILL_SCANNER_LLM_TEMPERATURE", default=0.1)
         self._max_tokens = max_tokens
         self._timeout = timeout
@@ -219,9 +252,17 @@ class AlignmentLLMClient:
             }
             if self._temperature is not None:
                 request_params["temperature"] = self._temperature
+            request_params.update(
+                build_litellm_reasoning_params(
+                    self._reasoning_effort,
+                    model=self._model,
+                    provider=self._provider,
+                )
+            )
 
-            # Add API key if available
-            if self._api_key:
+            if self._provider_config is not None:
+                request_params.update(self._provider_config.get_request_params())
+            elif self._api_key:
                 request_params["api_key"] = self._api_key
 
             # Only enable JSON mode for supported models/providers
@@ -230,9 +271,9 @@ class AlignmentLLMClient:
                 request_params["response_format"] = {"type": "json_object"}
 
             # Add optional parameters if configured
-            if self._base_url:
+            if self._provider_config is None and self._base_url:
                 request_params["api_base"] = self._base_url
-            if self._api_version:
+            if self._provider_config is None and self._api_version:
                 request_params["api_version"] = self._api_version
 
             if self._llm_user and supports_openai_user_param(self._model, self._provider):

--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
@@ -58,6 +58,9 @@ class AlignmentOrchestrator:
         llm_temperature: Any = _TEMPERATURE_UNSET,
         llm_max_tokens: int = 4096,
         llm_timeout: int = 120,
+        *,
+        llm_provider: str | None = None,
+        llm_reasoning_effort: str | None = None,
     ):
         """Initialize alignment orchestrator.
 
@@ -68,6 +71,8 @@ class AlignmentOrchestrator:
             llm_temperature: Temperature for LLM responses
             llm_max_tokens: Max tokens for LLM responses
             llm_timeout: Timeout for LLM requests in seconds
+            llm_provider: Optional provider override used for request semantics
+            llm_reasoning_effort: Optional reasoning-depth control
 
         Raises:
             ValueError: If LLM API key is not provided
@@ -80,7 +85,9 @@ class AlignmentOrchestrator:
             model=llm_model,
             api_key=llm_api_key,
             base_url=llm_base_url,
+            provider=llm_provider,
             temperature=llm_temperature,
+            reasoning_effort=llm_reasoning_effort,
             max_tokens=llm_max_tokens,
             timeout=llm_timeout,
         )
@@ -89,6 +96,8 @@ class AlignmentOrchestrator:
             model=llm_model,
             api_key=llm_api_key,
             base_url=llm_base_url,
+            provider=llm_provider,
+            reasoning_effort=llm_reasoning_effort,
         )
 
         # Track analysis statistics

--- a/skill_scanner/core/analyzers/behavioral/alignment/threat_vulnerability_classifier.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/threat_vulnerability_classifier.py
@@ -46,6 +46,8 @@ class ThreatVulnerabilityClassifier:
         model: str = "gemini/gemini-2.0-flash",
         api_key: str | None = None,
         base_url: str | None = None,
+        provider: str | None = None,
+        reasoning_effort: str | None = None,
     ):
         """Initialize the threat/vulnerability classifier.
 
@@ -53,12 +55,16 @@ class ThreatVulnerabilityClassifier:
             model: LLM model to use
             api_key: API key for the LLM provider
             base_url: Optional base URL for LLM API
+            provider: Optional provider override used for request semantics
+            reasoning_effort: Optional reasoning-depth control
         """
         self.logger = logging.getLogger(__name__)
         self.llm_client = AlignmentLLMClient(
             model=model,
             api_key=api_key,
             base_url=base_url,
+            provider=provider,
+            reasoning_effort=reasoning_effort,
         )
         self._classification_prompt_template = self._get_classification_prompt()
 

--- a/skill_scanner/core/analyzers/behavioral_analyzer.py
+++ b/skill_scanner/core/analyzers/behavioral_analyzer.py
@@ -79,6 +79,8 @@ class BehavioralAnalyzer(BaseAnalyzer):
         use_alignment_verification: bool = False,
         llm_model: str | None = None,
         llm_api_key: str | None = None,
+        llm_provider: str | None = None,
+        llm_reasoning_effort: str | None = None,
     ):
         """
         Initialize behavioral analyzer.
@@ -87,6 +89,8 @@ class BehavioralAnalyzer(BaseAnalyzer):
             use_alignment_verification: Enable LLM-powered alignment verification
             llm_model: LLM model for alignment verification (e.g., "gemini/gemini-2.0-flash")
             llm_api_key: API key for the LLM provider (or resolved from environment)
+            llm_provider: Optional provider override used for request semantics
+            llm_reasoning_effort: Optional reasoning-depth control for alignment calls
 
         Note:
             This analyzer processes Python (.py) files with full AST-based dataflow
@@ -113,6 +117,8 @@ class BehavioralAnalyzer(BaseAnalyzer):
                     self.alignment_orchestrator = AlignmentOrchestrator(
                         llm_model=model,
                         llm_api_key=api_key,
+                        llm_provider=llm_provider,
+                        llm_reasoning_effort=llm_reasoning_effort,
                     )
                     logger.info("Alignment verification enabled with %s", model)
                 else:

--- a/skill_scanner/core/analyzers/llm_analyzer.py
+++ b/skill_scanner/core/analyzers/llm_analyzer.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+import os
 import re
 from enum import Enum
 from pathlib import Path
@@ -83,6 +84,7 @@ class LLMProvider(str, Enum):
     - gcp-vertex: Google Cloud Vertex AI
     - ollama: Local Ollama models
     - openrouter: OpenRouter API
+    - orcarouter: OrcaRouter API
     """
 
     OPENAI = "openai"
@@ -94,6 +96,7 @@ class LLMProvider(str, Enum):
     GCP_VERTEX = "gcp-vertex"
     OLLAMA = "ollama"
     OPENROUTER = "openrouter"
+    ORCAROUTER = "orcarouter"
 
     @classmethod
     def normalize(cls, provider: str) -> str:
@@ -157,6 +160,7 @@ class LLMAnalyzer(BaseAnalyzer):
         # Provider selection (can be enum or string)
         provider: str | None = None,
         llm_user: str | None = None,
+        reasoning_effort: str | None = None,
         # Policy (optional – uses generous defaults when omitted)
         policy: ScanPolicy | None = None,
     ):
@@ -186,6 +190,9 @@ class LLMAnalyzer(BaseAnalyzer):
             provider: LLM provider name (e.g., "openai", "anthropic", "aws-bedrock", etc.)
                 Can be enum or string (e.g., "openai", "anthropic", "aws-bedrock")
             llm_user: Optional raw Chat Completions user field for OpenAI-compatible routes.
+            reasoning_effort: Optional reasoning-depth control. When omitted,
+                resolves from ``SKILL_SCANNER_LLM_REASONING_EFFORT``. Use
+                ``disabled`` for explicit provider-aware thinking disablement.
             policy: Scan policy providing LLM context budget thresholds.
                 When ``None``, generous defaults from ``LLMAnalysisPolicy()``
                 are used.
@@ -200,16 +207,17 @@ class LLMAnalyzer(BaseAnalyzer):
 
             self.llm_policy = LLMAnalysisPolicy()
 
+        provider_value = provider if provider is not None else os.getenv("SKILL_SCANNER_LLM_PROVIDER")
         provider_str: str | None = None
-        if provider is not None:
-            if isinstance(provider, LLMProvider):
-                provider_str = provider.value
+        if provider_value is not None:
+            if isinstance(provider_value, LLMProvider):
+                provider_str = provider_value.value
             else:
-                provider_str = LLMProvider.normalize(str(provider))
+                provider_str = LLMProvider.normalize(str(provider_value))
 
-            if not isinstance(provider, LLMProvider) and not LLMProvider.is_valid_provider(provider_str):
+            if not isinstance(provider_value, LLMProvider) and not LLMProvider.is_valid_provider(provider_str):
                 raise ValueError(
-                    f"Invalid provider '{provider}'. Valid providers: {', '.join([p.value for p in LLMProvider])}"
+                    f"Invalid provider '{provider_value}'. Valid providers: {', '.join([p.value for p in LLMProvider])}"
                 )
 
         # Handle provider selection: if provider is specified, map to default model
@@ -225,6 +233,7 @@ class LLMAnalyzer(BaseAnalyzer):
                 "gcp-vertex": "vertex_ai/gemini-1.5-pro",
                 "ollama": "ollama/llama2",
                 "openrouter": "openrouter/openai/gpt-4",
+                "orcarouter": "orcarouter/anthropic/claude-sonnet-5",
             }
             model = model_mapping.get(provider_str, "claude-3-5-sonnet-20241022")
         elif model is None:
@@ -252,6 +261,7 @@ class LLMAnalyzer(BaseAnalyzer):
             max_retries=max_retries,
             rate_limit_delay=rate_limit_delay,
             timeout=timeout,
+            reasoning_effort=reasoning_effort,
         )
 
         self.prompt_builder = PromptBuilder()
@@ -270,6 +280,7 @@ class LLMAnalyzer(BaseAnalyzer):
         self.max_retries = max_retries
         self.rate_limit_delay = rate_limit_delay
         self.timeout = timeout
+        self.reasoning_effort = self.request_handler.reasoning_effort
 
         # Cumulative token usage across all LLM calls in the most recent analyze() run.
         self._llm_usage: LLMTokenUsage = _empty_token_usage()

--- a/skill_scanner/core/analyzers/llm_provider_config.py
+++ b/skill_scanner/core/analyzers/llm_provider_config.py
@@ -25,7 +25,11 @@ import importlib.util
 import logging
 import os
 
-from .llm_request_options import resolve_llm_user, supports_openai_user_param
+from .llm_request_options import (
+    normalize_litellm_model_for_provider,
+    resolve_llm_user,
+    supports_openai_user_param,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +111,9 @@ class ProviderConfig:
         )
         self.is_ollama = not self.is_openai_compatible and model_lower.startswith("ollama/")
         self.is_openrouter = not self.is_openai_compatible and model_lower.startswith("openrouter/")
+        self.is_orcarouter = self.provider == "orcarouter" or (
+            not self.is_openai_compatible and model_lower.startswith("orcarouter/")
+        )
         self.is_gpt5 = "gpt-5" in model_lower
 
         # Determine if we should use Google SDK
@@ -124,6 +131,12 @@ class ProviderConfig:
             if not LITELLM_AVAILABLE:
                 raise ImportError("LiteLLM is required for Vertex AI. Install with: pip install litellm")
             self.model = model  # Keep vertex_ai/ prefix for LiteLLM
+        elif self.is_orcarouter:
+            # OrcaRouter is OpenAI-compatible; route through the OpenAI LiteLLM adapter
+            # with the well-known default endpoint (overridable via base_url).
+            if not LITELLM_AVAILABLE:
+                raise ImportError("LiteLLM is required for OrcaRouter. Install with: pip install litellm")
+            self.model = self._normalize_orcarouter_model_name(model)
         elif self.is_gemini and GOOGLE_GENAI_AVAILABLE:
             # Google AI Studio (uses Google SDK directly)
             self.use_google_sdk = True
@@ -163,6 +176,12 @@ class ProviderConfig:
 
     def _normalize_openai_compatible_model_name(self, model: str) -> str:
         """Force LiteLLM's OpenAI adapter for arbitrary OpenAI-compatible model names."""
+        return normalize_litellm_model_for_provider(model, "openai-compatible")
+
+    def _normalize_orcarouter_model_name(self, model: str) -> str:
+        """Force LiteLLM's OpenAI adapter for OrcaRouter models (OpenAI-compatible)."""
+        if model.lower().startswith("orcarouter/"):
+            model = model[len("orcarouter/") :]
         if model.lower().startswith("openai/"):
             return model
         return f"openai/{model}"
@@ -301,6 +320,9 @@ class ProviderConfig:
 
         if self.base_url:
             params["api_base"] = self.base_url
+        elif self.is_orcarouter:
+            # Default OrcaRouter endpoint (OpenAI-compatible) when no base_url is given.
+            params["api_base"] = "https://api.orcarouter.ai/v1"
         if self.api_version:
             params["api_version"] = self.api_version
 

--- a/skill_scanner/core/analyzers/llm_request_handler.py
+++ b/skill_scanner/core/analyzers/llm_request_handler.py
@@ -30,6 +30,11 @@ import warnings
 from pathlib import Path
 from typing import Any, TypedDict
 
+from ...llm_reasoning import (
+    build_litellm_reasoning_params,
+    ensure_google_sdk_reasoning_supported,
+    resolve_llm_reasoning_effort,
+)
 from ...llm_token_options import resolve_llm_max_tokens
 from .llm_provider_config import ProviderConfig
 
@@ -243,6 +248,7 @@ class LLMRequestHandler:
         max_retries: int = 3,
         rate_limit_delay: float = 2.0,
         timeout: int = 120,
+        reasoning_effort: str | None = None,
     ):
         """
         Initialize request handler.
@@ -260,6 +266,9 @@ class LLMRequestHandler:
             max_retries: Max retry attempts on rate limits
             rate_limit_delay: Base delay for exponential backoff
             timeout: Request timeout in seconds
+            reasoning_effort: Optional reasoning-depth control. Resolves from
+                ``SKILL_SCANNER_LLM_REASONING_EFFORT`` when omitted. The
+                ``disabled`` value uses provider-aware request semantics.
         """
         self.provider_config = provider_config
         self.max_tokens = resolve_llm_max_tokens(max_tokens)
@@ -267,6 +276,12 @@ class LLMRequestHandler:
         self.max_retries = max_retries
         self.rate_limit_delay = rate_limit_delay
         self.timeout = timeout
+        self.reasoning_effort = resolve_llm_reasoning_effort(reasoning_effort)
+        if self.provider_config.use_google_sdk:
+            ensure_google_sdk_reasoning_supported(
+                self.reasoning_effort,
+                model=self.provider_config.model,
+            )
 
         # Load JSON schema for structured outputs
         self.response_schema = self._load_response_schema()
@@ -445,6 +460,13 @@ class LLMRequestHandler:
                 }
                 if self.temperature is not None:
                     request_params["temperature"] = self.temperature
+                request_params.update(
+                    build_litellm_reasoning_params(
+                        self.reasoning_effort,
+                        model=self.provider_config.model,
+                        provider=getattr(self.provider_config, "provider", None),
+                    )
+                )
 
                 response_format = self._build_response_format()
                 if response_format:

--- a/skill_scanner/core/analyzers/llm_request_options.py
+++ b/skill_scanner/core/analyzers/llm_request_options.py
@@ -22,7 +22,7 @@ import os
 
 LLM_USER_ENV_VAR = "SKILL_SCANNER_LLM_USER"
 
-_OPENAI_USER_PROVIDERS = {"openai", "openai-compatible", "custom-openai"}
+_OPENAI_COMPATIBLE_PROVIDERS = {"openai", "openai-compatible", "custom-openai"}
 _NON_OPENAI_MODEL_PREFIXES = (
     "anthropic/",
     "bedrock/",
@@ -45,6 +45,22 @@ def resolve_llm_user(llm_user: str | None = None) -> str | None:
     return raw_value
 
 
+def normalize_litellm_model_for_provider(model: str, provider: str | None) -> str:
+    """Force OpenAI-compatible routes through LiteLLM's OpenAI adapter.
+
+    A bare downstream model name can otherwise cause LiteLLM to infer a
+    different provider from the name itself. In particular, a gateway model
+    named ``claude-sonnet-5`` would be inferred as native Anthropic, defeating
+    OpenAI-style request semantics such as ``reasoning_effort='none'``.
+    """
+    provider_normalized = (provider or "").strip().lower().replace("_", "-")
+    if provider_normalized not in _OPENAI_COMPATIBLE_PROVIDERS:
+        return model
+    if model.strip().lower().startswith("openai/"):
+        return model
+    return f"openai/{model}"
+
+
 def supports_openai_user_param(model: str | None, provider: str | None = None) -> bool:
     """Return True when the LiteLLM route should receive the OpenAI `user` parameter."""
     model_lower = (model or "").strip().lower()
@@ -52,7 +68,7 @@ def supports_openai_user_param(model: str | None, provider: str | None = None) -
         return False
 
     provider_normalized = (provider or "").strip().lower().replace("_", "-")
-    if provider_normalized in _OPENAI_USER_PROVIDERS:
+    if provider_normalized in _OPENAI_COMPATIBLE_PROVIDERS:
         return True
 
     return model_lower.startswith(("azure/", "openai/", "gpt-"))

--- a/skill_scanner/core/analyzers/meta_analyzer.py
+++ b/skill_scanner/core/analyzers/meta_analyzer.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ...llm_reasoning import build_litellm_reasoning_params, resolve_llm_reasoning_effort
 from ...llm_token_options import resolve_llm_max_tokens
 from ...threats.threats import ThreatMapping
 from ..models import Finding, ScanResult, Severity, Skill, ThreatCategory
@@ -60,7 +61,11 @@ from .llm_request_handler import (
     _resolve_temperature,
     get_truncation_finish_reason,
 )
-from .llm_request_options import resolve_llm_user, supports_openai_user_param
+from .llm_request_options import (
+    normalize_litellm_model_for_provider,
+    resolve_llm_user,
+    supports_openai_user_param,
+)
 
 if TYPE_CHECKING:
     from ...core.scan_policy import LLMAnalysisPolicy, ScanPolicy
@@ -293,6 +298,8 @@ class MetaAnalyzer(BaseAnalyzer):
         aws_profile: str | None = None,
         aws_session_token: str | None = None,
         llm_user: str | None = None,
+        provider: str | None = None,
+        reasoning_effort: str | None = None,
         # Policy (optional – uses generous defaults × meta multiplier)
         policy: ScanPolicy | None = None,
     ):
@@ -319,6 +326,11 @@ class MetaAnalyzer(BaseAnalyzer):
             aws_profile: AWS profile name (for Bedrock)
             aws_session_token: AWS session token (for Bedrock)
             llm_user: Optional raw Chat Completions user field for OpenAI-compatible routes.
+            provider: Optional provider override used for request semantics.
+            reasoning_effort: Optional reasoning-depth control. When omitted,
+                resolves from ``SKILL_SCANNER_META_LLM_REASONING_EFFORT``,
+                then ``SKILL_SCANNER_LLM_REASONING_EFFORT``. Use ``disabled``
+                for explicit provider-aware thinking disablement.
             policy: Scan policy providing LLM context budget thresholds.
                 The meta analyzer applies ``meta_budget_multiplier`` on top of
                 the base limits.  When ``None``, generous defaults are used.
@@ -338,17 +350,20 @@ class MetaAnalyzer(BaseAnalyzer):
 
         # Use SKILL_SCANNER_* env vars only (no provider-specific fallbacks)
         # Priority: meta-specific > scanner-wide
+        raw_provider = provider or os.getenv("SKILL_SCANNER_LLM_PROVIDER")
+        self.provider = raw_provider.strip().lower().replace("_", "-") if raw_provider else None
         self.api_key = (
             api_key
             or os.getenv("SKILL_SCANNER_META_LLM_API_KEY")  # Meta-specific
             or os.getenv("SKILL_SCANNER_LLM_API_KEY")  # Scanner-wide
         )
-        self.model = (
-            model
-            or os.getenv("SKILL_SCANNER_META_LLM_MODEL")  # Meta-specific
-            or os.getenv("SKILL_SCANNER_LLM_MODEL")  # Scanner-wide
-            or "claude-3-5-sonnet-20241022"
-        )
+        self.model = model or os.getenv("SKILL_SCANNER_META_LLM_MODEL") or os.getenv("SKILL_SCANNER_LLM_MODEL")
+        if self.model is None:
+            self.model = (
+                "orcarouter/anthropic/claude-sonnet-5"
+                if self.provider == "orcarouter"
+                else "claude-3-5-sonnet-20241022"
+            )
         self.base_url = (
             base_url
             or os.getenv("SKILL_SCANNER_META_LLM_BASE_URL")  # Meta-specific
@@ -359,14 +374,36 @@ class MetaAnalyzer(BaseAnalyzer):
             or os.getenv("SKILL_SCANNER_META_LLM_API_VERSION")  # Meta-specific
             or os.getenv("SKILL_SCANNER_LLM_API_VERSION")  # Scanner-wide
         )
-        self.provider = os.getenv("SKILL_SCANNER_LLM_PROVIDER")
+        self.model = normalize_litellm_model_for_provider(self.model, self.provider)
         self.llm_user = resolve_llm_user(llm_user)
+        self.reasoning_effort = resolve_llm_reasoning_effort(reasoning_effort, meta=True)
 
         # AWS Bedrock settings
         self.aws_region = aws_region
         self.aws_profile = aws_profile
         self.aws_session_token = aws_session_token
-        self.is_bedrock = self.model and "bedrock/" in self.model
+
+        # OrcaRouter uses LiteLLM's OpenAI adapter. Reuse the primary
+        # analyzer's normalization and request-parameter handling so the meta
+        # analyzer receives the same key and default endpoint.
+        self.provider_config: ProviderConfig | None = None
+        if self.provider == "orcarouter" or self.model.lower().startswith("orcarouter/"):
+            self.provider_config = ProviderConfig(
+                model=self.model,
+                api_key=self.api_key,
+                base_url=self.base_url,
+                api_version=self.api_version,
+                provider=self.provider,
+                aws_region=aws_region,
+                aws_profile=aws_profile,
+                aws_session_token=aws_session_token,
+                llm_user=self.llm_user,
+            )
+            self.model = self.provider_config.model
+            self.api_key = self.provider_config.api_key
+            self.provider = self.provider_config.provider
+
+        self.is_bedrock = "bedrock/" in self.model
 
         # Validate configuration
         if not self.api_key and not self.is_bedrock:
@@ -681,12 +718,16 @@ Respond with JSON containing your analysis following the required schema."""
                 details.append(f"ignored {invalid_entries} invalid or duplicate classification(s)")
             if missing:
                 details.append(f"retained {len(missing)} unclassified finding(s)")
-            result.analysis_warnings.append(
+            # Classification completeness is the primary batch integrity
+            # warning; keep it ahead of assessment-schema warnings that may
+            # already have been recorded while parsing the same response.
+            result.analysis_warnings.insert(
+                0,
                 self._batch_warning(
                     code="META_BATCH_INCOMPLETE",
                     message="; ".join(details),
                     indices=expected_indices,
-                )
+                ),
             )
             logger.error(
                 "Meta-analysis batch %d-%d was incomplete: %s",
@@ -1087,15 +1128,23 @@ Respond with a JSON object following the schema in the system prompt."""
         }
         if self.temperature is not None:
             api_params["temperature"] = self.temperature
+        api_params.update(
+            build_litellm_reasoning_params(
+                self.reasoning_effort,
+                model=self.model,
+                provider=self.provider,
+            )
+        )
 
-        if self.api_key:
-            api_params["api_key"] = self.api_key
-
-        if self.base_url:
-            api_params["api_base"] = self.base_url
-
-        if self.api_version:
-            api_params["api_version"] = self.api_version
+        if self.provider_config is not None:
+            api_params.update(self.provider_config.get_request_params())
+        else:
+            if self.api_key:
+                api_params["api_key"] = self.api_key
+            if self.base_url:
+                api_params["api_base"] = self.base_url
+            if self.api_version:
+                api_params["api_version"] = self.api_version
 
         if self.llm_user and supports_openai_user_param(self.model, self.provider):
             api_params["user"] = self.llm_user
@@ -1204,6 +1253,14 @@ Respond with a JSON object following the schema in the system prompt."""
             if not isinstance(json_data.get("overall_risk_assessment", {}), dict):
                 raise ValueError("overall_risk_assessment must be a JSON object")
 
+            raw_assessment = json_data.get("overall_risk_assessment", {})
+            missing_assessment_fields = [
+                field_name for field_name in ("risk_level", "skill_verdict") if field_name not in raw_assessment
+            ]
+            normalized_assessment = self._normalize_overall_risk_assessment(raw_assessment)
+            for field_name in missing_assessment_fields:
+                normalized_assessment[field_name] = "UNKNOWN"
+
             result = MetaAnalysisResult(
                 validated_findings=json_data.get("validated_findings", []),
                 false_positives=json_data.get("false_positives", []),
@@ -1211,10 +1268,21 @@ Respond with a JSON object following the schema in the system prompt."""
                 priority_order=json_data.get("priority_order", []),
                 correlations=json_data.get("correlations", []),
                 recommendations=json_data.get("recommendations", []),
-                overall_risk_assessment=self._normalize_overall_risk_assessment(
-                    json_data.get("overall_risk_assessment", {})
-                ),
+                overall_risk_assessment=normalized_assessment,
             )
+
+            if missing_assessment_fields:
+                missing_fields = ", ".join(missing_assessment_fields)
+                result.analysis_warnings.append(
+                    self._batch_warning(
+                        code="META_RESPONSE_SCHEMA_INCOMPLETE",
+                        message=(
+                            "Meta-analysis response omitted required overall_risk_assessment "
+                            f"field(s): {missing_fields}; missing values were set to UNKNOWN."
+                        ),
+                        indices=original_indices,
+                    )
+                )
 
             # Enrich validated findings with original data
             self._enrich_findings(result, original_findings, original_indices=original_indices)

--- a/skill_scanner/core/analyzers/static.py
+++ b/skill_scanner/core/analyzers/static.py
@@ -82,15 +82,6 @@ _GLOB_PATTERNS = [
     re.compile(r"fnmatch\."),
 ]
 
-_EXCEPTION_PATTERNS = [
-    re.compile(r"except\s+(EOFError|StopIteration|KeyboardInterrupt|Exception|BaseException)"),
-    re.compile(r"except\s*:"),
-    re.compile(r"break\s*$", re.MULTILINE),
-    re.compile(r"return\s*$", re.MULTILINE),
-    re.compile(r"sys\.exit\s*\("),
-    re.compile(r"raise\s+StopIteration"),
-]
-
 _COMMENT_LINE_RE = re.compile(r"^\s*(?:#|//|/\*|\*|<!--)")
 _NEGATED_EXFILTRATION_RE = re.compile(
     r"\b(?:do\s+not|don't|never|avoid|prevent|block|reject|refus(?:e|es|ed|ing)|rather\s+than)\b"
@@ -100,45 +91,166 @@ _NEGATED_EXFILTRATION_RE = re.compile(
 _NEGATABLE_EXFIL_IDENTIFIERS = {"$explicit_exfil", "$leak_param", "$credential_theft_actions"}
 
 
-class _LoopExitVisitor(ast.NodeVisitor):
-    """Find exits belonging to one enclosing loop, ignoring nested scopes."""
+def _constant_truth_value(node: ast.expr) -> bool | None:
+    """Evaluate side-effect-free literal conditions, or return ``None``.
 
-    def __init__(self) -> None:
-        self.has_exit = False
-        self._nested_loop_depth = 0
+    This deliberately handles only syntax whose value can be established
+    without executing user-controlled code. It keeps unreachable exits such
+    as ``if False: break`` from disguising an infinite loop.
+    """
+    try:
+        return bool(ast.literal_eval(node))
+    except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+        pass
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
-        return
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        operand = _constant_truth_value(node.operand)
+        return None if operand is None else not operand
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
-        return
+    if isinstance(node, ast.BoolOp):
+        values = [_constant_truth_value(value) for value in node.values]
+        if isinstance(node.op, ast.And):
+            if False in values:
+                return False
+            return True if all(value is True for value in values) else None
+        if isinstance(node.op, ast.Or):
+            if True in values:
+                return True
+            return False if all(value is False for value in values) else None
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
-        return
+    if isinstance(node, ast.Compare):
+        try:
+            operands = [ast.literal_eval(node.left), *(ast.literal_eval(item) for item in node.comparators)]
+            comparisons: list[bool] = []
+            for left, operator_node, right in zip(operands[:-1], node.ops, operands[1:], strict=True):
+                if isinstance(operator_node, ast.Eq):
+                    comparisons.append(left == right)
+                elif isinstance(operator_node, ast.NotEq):
+                    comparisons.append(left != right)
+                elif isinstance(operator_node, ast.Lt):
+                    comparisons.append(left < right)
+                elif isinstance(operator_node, ast.LtE):
+                    comparisons.append(left <= right)
+                elif isinstance(operator_node, ast.Gt):
+                    comparisons.append(left > right)
+                elif isinstance(operator_node, ast.GtE):
+                    comparisons.append(left >= right)
+                elif isinstance(operator_node, ast.Is):
+                    comparisons.append(left is right)
+                elif isinstance(operator_node, ast.IsNot):
+                    comparisons.append(left is not right)
+                elif isinstance(operator_node, ast.In):
+                    comparisons.append(left in right)
+                elif isinstance(operator_node, ast.NotIn):
+                    comparisons.append(left not in right)
+                else:
+                    return None
+            return all(comparisons)
+        except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+            return None
 
-    def visit_Return(self, node: ast.Return) -> None:  # noqa: N802
-        self.has_exit = True
+    return None
 
-    def visit_Raise(self, node: ast.Raise) -> None:  # noqa: N802
-        self.has_exit = True
 
-    def visit_Break(self, node: ast.Break) -> None:  # noqa: N802
-        if self._nested_loop_depth == 0:
-            self.has_exit = True
+class _LoopExitVisitor:
+    """Find potentially reachable exits belonging to one enclosing loop."""
 
-    def _visit_nested_loop(self, node: ast.For | ast.AsyncFor | ast.While) -> None:
-        self._nested_loop_depth += 1
-        self.generic_visit(node)
-        self._nested_loop_depth -= 1
+    def block_has_exit(self, statements: list[ast.stmt], *, nested_loop_depth: int = 0) -> bool:
+        """Return whether a reachable path through *statements* exits the loop."""
+        has_exit, _ = self._block_flow(statements, nested_loop_depth=nested_loop_depth)
+        return has_exit
 
-    def visit_For(self, node: ast.For) -> None:  # noqa: N802
-        self._visit_nested_loop(node)
+    def _block_flow(self, statements: list[ast.stmt], *, nested_loop_depth: int) -> tuple[bool, bool]:
+        has_exit = False
+        falls_through = True
+        for statement in statements:
+            if not falls_through:
+                break
+            statement_exit, falls_through = self._statement_flow(
+                statement,
+                nested_loop_depth=nested_loop_depth,
+            )
+            has_exit = has_exit or statement_exit
+        return has_exit, falls_through
 
-    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:  # noqa: N802
-        self._visit_nested_loop(node)
+    def _statement_flow(self, node: ast.stmt, *, nested_loop_depth: int) -> tuple[bool, bool]:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return False, True
+        if isinstance(node, (ast.Return, ast.Raise)):
+            return True, False
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and isinstance(node.value.func.value, ast.Name)
+            and node.value.func.value.id == "sys"
+            and node.value.func.attr == "exit"
+        ):
+            return True, False
+        if isinstance(node, ast.Break):
+            return nested_loop_depth == 0, False
+        if isinstance(node, ast.Continue):
+            return False, False
 
-    def visit_While(self, node: ast.While) -> None:  # noqa: N802
-        self._visit_nested_loop(node)
+        if isinstance(node, ast.If):
+            truth_value = _constant_truth_value(node.test)
+            if truth_value is True:
+                return self._block_flow(node.body, nested_loop_depth=nested_loop_depth)
+            if truth_value is False:
+                return self._block_flow(node.orelse, nested_loop_depth=nested_loop_depth)
+
+            body_exit, body_falls_through = self._block_flow(
+                node.body,
+                nested_loop_depth=nested_loop_depth,
+            )
+            if node.orelse:
+                else_exit, else_falls_through = self._block_flow(
+                    node.orelse,
+                    nested_loop_depth=nested_loop_depth,
+                )
+            else:
+                else_exit, else_falls_through = False, True
+            return body_exit or else_exit, body_falls_through or else_falls_through
+
+        if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+            if isinstance(node, ast.While) and _constant_truth_value(node.test) is False:
+                return self._block_flow(node.orelse, nested_loop_depth=nested_loop_depth + 1)
+            body_exit, _ = self._block_flow(node.body, nested_loop_depth=nested_loop_depth + 1)
+            else_exit, _ = self._block_flow(node.orelse, nested_loop_depth=nested_loop_depth + 1)
+            # A nested loop may complete or break, so the enclosing block can
+            # continue even when one path through its body does not.
+            return body_exit or else_exit, True
+
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            return self._block_flow(node.body, nested_loop_depth=nested_loop_depth)
+
+        if isinstance(node, (ast.Try, getattr(ast, "TryStar", ast.Try))):
+            protected_blocks = [node.body, node.orelse, *(handler.body for handler in node.handlers)]
+            protected_exit = any(
+                self._block_flow(block, nested_loop_depth=nested_loop_depth)[0] for block in protected_blocks if block
+            )
+            if not node.finalbody:
+                return protected_exit, True
+
+            final_exit, final_falls_through = self._block_flow(
+                node.finalbody,
+                nested_loop_depth=nested_loop_depth,
+            )
+            if not final_falls_through:
+                # An unconditional continue/exit in finally overrides control
+                # flow from the protected block.
+                return final_exit, False
+            return protected_exit or final_exit, True
+
+        if isinstance(node, ast.Match):
+            case_flows = [
+                self._block_flow(case.body, nested_loop_depth=nested_loop_depth)
+                for case in node.cases
+                if case.guard is None or _constant_truth_value(case.guard) is not False
+            ]
+            return any(flow[0] for flow in case_flows), True
+
+        return False, True
 
 
 _SKILL_NAME_PATTERN = re.compile(r"[a-z0-9-]+")
@@ -587,8 +699,6 @@ class StaticAnalyzer(BaseAnalyzer):
                     if rule.id == "RESOURCE_ABUSE_INFINITE_LOOP" and skill_file.file_type == "python":
                         if self._python_loop_has_exit(content, match["line_number"]):
                             continue
-                        if self._is_loop_with_exception_handler(content, match["line_number"]):
-                            continue
                     findings.append(self._create_finding_from_match(rule, match))
 
         return findings
@@ -614,25 +724,7 @@ class StaticAnalyzer(BaseAnalyzer):
             if not isinstance(node.test, ast.Constant) or node.test.value not in (True, 1):
                 continue
 
-            visitor = _LoopExitVisitor()
-            for statement in node.body:
-                visitor.visit(statement)
-                if visitor.has_exit:
-                    return True
-            return False
-
-        return False
-
-    def _is_loop_with_exception_handler(self, content: str, loop_line_num: int) -> bool:
-        """Check if a while True loop has an exception handler in surrounding context."""
-        context_size = self.policy.analysis_thresholds.exception_handler_context_lines
-        lines = content.split("\n")
-        context_lines = lines[loop_line_num - 1 : min(loop_line_num + context_size, len(lines))]
-        context_text = "\n".join(context_lines)
-
-        for pattern in _EXCEPTION_PATTERNS:
-            if pattern.search(context_text):
-                return True
+            return _LoopExitVisitor().block_has_exit(node.body)
 
         return False
 

--- a/skill_scanner/core/analyzers/static.py
+++ b/skill_scanner/core/analyzers/static.py
@@ -214,9 +214,9 @@ class _LoopExitVisitor:
 
         if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
             if isinstance(node, ast.While) and _constant_truth_value(node.test) is False:
-                return self._block_flow(node.orelse, nested_loop_depth=nested_loop_depth + 1)
+                return self._block_flow(node.orelse, nested_loop_depth=nested_loop_depth)
             body_exit, _ = self._block_flow(node.body, nested_loop_depth=nested_loop_depth + 1)
-            else_exit, _ = self._block_flow(node.orelse, nested_loop_depth=nested_loop_depth + 1)
+            else_exit, _ = self._block_flow(node.orelse, nested_loop_depth=nested_loop_depth)
             # A nested loop may complete or break, so the enclosing block can
             # continue even when one path through its body does not.
             return body_exit or else_exit, True

--- a/skill_scanner/core/scanner.py
+++ b/skill_scanner/core/scanner.py
@@ -30,6 +30,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from ..utils.logging_context import scan_log_context
 from .analyzability import AnalyzabilityReport, compute_analyzability
 from .analyzer_factory import build_core_analyzers
 from .analyzers.base import BaseAnalyzer
@@ -200,6 +201,14 @@ class SkillScanner:
     # ------------------------------------------------------------------
 
     def _scan_single_skill(self, skill: Skill, skill_directory: Path) -> ScanResult:
+        """Run one scan with skill-scoped logging context."""
+        with scan_log_context(
+            skill_name=skill.name,
+            skill_path=str(skill_directory.resolve()),
+        ):
+            return self._scan_single_skill_with_context(skill, skill_directory)
+
+    def _scan_single_skill_with_context(self, skill: Skill, skill_directory: Path) -> ScanResult:
         """Run the full analysis pipeline on a loaded skill.
 
         This is the shared implementation that both ``scan_skill`` and

--- a/skill_scanner/data/packs/atr/signatures/atr_context_exfiltration.yaml
+++ b/skill_scanner/data/packs/atr/signatures/atr_context_exfiltration.yaml
@@ -795,15 +795,15 @@ signatures:
     severity: CRITICAL
     patterns:
       - >-
-        (?i)"ANTHROPIC_BASE_URL"\s*:\s*"https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/"]|$))[^"]+"
+        (?i)"ANTHROPIC_BASE_URL"\s*:\s*"(?!https://api\.orcarouter\.ai(?::443)?(?:[/"]|$))https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/"]|$))[^"]+"
       - >-
-        (?i)\bANTHROPIC_BASE_URL\s*=\s*["\x27]?https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/\s"\x27]|$))[^\s"\x27]+
+        (?i)\bANTHROPIC_BASE_URL\s*=\s*["\x27]?(?!https://api\.orcarouter\.ai(?::443)?(?:[/\s"\x27]|$))https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|ai-gateway\.vercel\.sh|gateway\.portkey\.ai|api\.openrouter\.ai|[a-z0-9\-]+\.helicone\.ai)(?:[:/\s"\x27]|$))[^\s"\x27]+
       - >-
         (?i)"ANTHROPIC_BASE_URL"\s*:\s*"https?://(?!(?:127\.|10\.|0\.0\.0\.0|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.))(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?(?![\d.])
       - >-
         (?i)"ANTHROPIC_BASE_URL"\s*:\s*"http://(?!(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?:[:/"]|$))[^"]+"
       - >-
-        (?i)\.claude[/\\]settings(?:\.local)?\.json[\s\S]{0,400}"ANTHROPIC_BASE_URL"\s*:\s*"https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1)(?:[:/"]|$))
+        (?i)\.claude[/\\]settings(?:\.local)?\.json[\s\S]{0,400}"ANTHROPIC_BASE_URL"\s*:\s*"(?!https://api\.orcarouter\.ai(?::443)?(?:[/"]|$))https?://(?!(?:api\.anthropic\.com|[a-z0-9\-]+\.googleapis\.com|(?:bedrock|bedrock-runtime|bedrock-agent|bedrock-agent-runtime)\.[a-z0-9\-]+\.amazonaws\.com|localhost|127\.0\.0\.1)(?:[:/"]|$))
       - >-
         (?i)(?:pre[_\s\-]?trust|before\s+(?:the\s+)?trust\s+(?:dialog|prompt))[^\n]{0,160}(?:ANTHROPIC_BASE_URL|api\s+request|authorization\s+header|api\s+key)
       - >-

--- a/skill_scanner/data/packs/core/python/external_tool_checks.py
+++ b/skill_scanner/data/packs/core/python/external_tool_checks.py
@@ -13,6 +13,7 @@ import re
 from typing import TYPE_CHECKING
 
 from skill_scanner.core.models import Finding, Severity, ThreatCategory
+from skill_scanner.core.static_analysis.comment_stripping import comment_stripped_lines
 
 from ._helpers import generate_finding_id
 
@@ -268,10 +269,12 @@ def check_homoglyph_attacks(skill: Skill, policy: ScanPolicy) -> list[Finding]:
             continue
 
         dangerous_lines: list[tuple[int, str, list[dict]]] = []
+        original_lines = content.split("\n")
+        analysis_lines = comment_stripped_lines(content, sf.file_type)
 
-        for line_num, line in enumerate(content.split("\n"), 1):
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#") or stripped.startswith("//"):
+        for line_num, (line, analysis_line) in enumerate(zip(original_lines, analysis_lines, strict=True), 1):
+            stripped = analysis_line.strip()
+            if not stripped or stripped.startswith("//"):
                 continue
             if stripped.isascii():
                 continue
@@ -280,7 +283,7 @@ def check_homoglyph_attacks(skill: Skill, policy: ScanPolicy) -> list[Finding]:
 
             result = confusables.is_dangerous(stripped, preferred_aliases=["LATIN"])
             if result:
-                dangerous_lines.append((line_num, stripped, result))
+                dangerous_lines.append((line_num, line.strip(), result))
 
         min_dangerous_lines = policy.analysis_thresholds.min_dangerous_lines
         if len(dangerous_lines) < min_dangerous_lines:

--- a/skill_scanner/llm_reasoning.py
+++ b/skill_scanner/llm_reasoning.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validated, provider-aware controls for optional LLM reasoning effort."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, TypeAlias
+
+LLM_REASONING_EFFORT_ENV_VAR = "SKILL_SCANNER_LLM_REASONING_EFFORT"
+META_LLM_REASONING_EFFORT_ENV_VAR = "SKILL_SCANNER_META_LLM_REASONING_EFFORT"
+
+LLMReasoningEffort: TypeAlias = Literal[
+    "disabled",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+]
+LLM_REASONING_EFFORT_VALUES: tuple[str, ...] = (
+    "disabled",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
+
+
+class ReasoningConfigurationError(ValueError):
+    """Raised when a requested reasoning control is invalid or unsafe."""
+
+
+class ReasoningControlUnsupportedError(ReasoningConfigurationError):
+    """Raised when a configured control cannot be represented safely."""
+
+
+def normalize_llm_reasoning_effort(
+    value: str | None,
+    *,
+    source: str = "reasoning_effort",
+) -> LLMReasoningEffort | None:
+    """Validate and normalize one user-facing reasoning-effort value."""
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        raise ReasoningConfigurationError(f"{source} must be one of: {', '.join(LLM_REASONING_EFFORT_VALUES)}")
+    if normalized not in LLM_REASONING_EFFORT_VALUES:
+        raise ReasoningConfigurationError(
+            f"{source} must be one of: {', '.join(LLM_REASONING_EFFORT_VALUES)}; got {value!r}"
+        )
+    return normalized  # type: ignore[return-value]
+
+
+def resolve_llm_reasoning_effort(
+    explicit: str | None = None,
+    *,
+    meta: bool = False,
+) -> LLMReasoningEffort | None:
+    """Resolve explicit, analyzer-specific, then scanner-wide configuration."""
+    if explicit is not None:
+        return normalize_llm_reasoning_effort(explicit)
+
+    env_vars = (
+        (META_LLM_REASONING_EFFORT_ENV_VAR, LLM_REASONING_EFFORT_ENV_VAR) if meta else (LLM_REASONING_EFFORT_ENV_VAR,)
+    )
+    for env_var in env_vars:
+        raw_value = os.getenv(env_var)
+        if raw_value is not None and raw_value.strip():
+            return normalize_llm_reasoning_effort(raw_value, source=env_var)
+    return None
+
+
+def _uses_anthropic_native_api(model: str | None, provider: str | None) -> bool:
+    """Return whether LiteLLM routes directly to an Anthropic-native API."""
+    model_lower = (model or "").strip().lower()
+    provider_normalized = (provider or "").strip().lower().replace("_", "-")
+
+    # Explicit gateway adapters expose OpenAI-compatible semantics even when
+    # their downstream model name contains "claude".
+    if provider_normalized in {
+        "openai",
+        "openai-compatible",
+        "custom-openai",
+        "azure-openai",
+        "azure-ai",
+        "openrouter",
+        "orcarouter",
+    }:
+        return False
+    if model_lower.startswith(("openai/", "azure/", "openrouter/", "orcarouter/")):
+        return False
+
+    if model_lower.startswith("anthropic/"):
+        return True
+    if model_lower.startswith(("bedrock/", "bedrock-converse/", "bedrock_converse/")):
+        return "claude" in model_lower
+    if model_lower.startswith(("vertex_ai/claude", "vertex/claude")):
+        return True
+    if model_lower.startswith("claude-"):
+        return provider_normalized in {"", "anthropic"}
+
+    return (
+        provider_normalized
+        in {
+            "anthropic",
+            "aws-bedrock",
+            "bedrock",
+            "bedrock-converse",
+            "gcp-vertex",
+            "vertex",
+            "vertex-ai",
+        }
+        and "claude" in model_lower
+    )
+
+
+def build_litellm_reasoning_params(
+    reasoning_effort: str | None,
+    *,
+    model: str | None,
+    provider: str | None = None,
+) -> dict[str, object]:
+    """Translate the user-facing setting into safe LiteLLM request fields.
+
+    ``disabled`` is intentionally not passed as ``reasoning_effort='none'``
+    on Anthropic-native routes. LiteLLM currently maps that value to omission,
+    while Claude Sonnet 5 interprets an omitted ``thinking`` field as adaptive
+    thinking. The native explicit disable field is required there.
+    """
+    normalized = normalize_llm_reasoning_effort(reasoning_effort)
+    if normalized is None:
+        return {}
+    if normalized == "disabled":
+        if _uses_anthropic_native_api(model, provider):
+            return {"thinking": {"type": "disabled"}}
+        return {"reasoning_effort": "none"}
+    return {"reasoning_effort": normalized}
+
+
+def ensure_google_sdk_reasoning_supported(reasoning_effort: str | None, *, model: str) -> None:
+    """Reject a control the direct Google SDK path cannot translate safely.
+
+    LiteLLM normalizes ``reasoning_effort`` for provider adapters, but the
+    direct Google SDK uses model-specific thinking levels or numeric budgets.
+    Silently dropping the configured control would violate the user's intent.
+    """
+    normalized = normalize_llm_reasoning_effort(reasoning_effort)
+    if normalized is not None:
+        raise ReasoningControlUnsupportedError(
+            "llm_reasoning_effort is not supported by the direct Google GenAI SDK "
+            f"path for model {model!r}; use a LiteLLM-backed route or leave it unset"
+        )

--- a/skill_scanner/utils/logging_context.py
+++ b/skill_scanner/utils/logging_context.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scan-scoped context for Skill Scanner log records.
+
+The scanner is used from synchronous CLI code, asyncio tasks, and worker
+threads.  A :class:`contextvars.ContextVar` keeps those concurrent scans
+isolated without relying on mutable process-wide "current skill" state.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScanLogContext:
+    """Identifiers attached to log records emitted during a scan."""
+
+    skill_name: str | None = None
+    skill_path: str | None = None
+    scan_id: str | None = None
+
+
+_current_scan_context: ContextVar[ScanLogContext | None] = ContextVar(
+    "skill_scanner_log_context",
+    default=None,
+)
+_factory_lock = threading.Lock()
+
+
+def _safe_label(value: str) -> str:
+    """Render an identifier without allowing terminal/log-line injection."""
+    escaped: list[str] = []
+    for char in value:
+        if char == "\\":
+            escaped.append("\\\\")
+        elif char.isprintable():
+            escaped.append(char)
+        else:
+            escaped.append(char.encode("unicode_escape").decode("ascii"))
+    return "".join(escaped)
+
+
+def _install_context_record_factory() -> None:
+    """Install a cooperative record factory that prefixes package logs."""
+
+    with _factory_lock:
+        previous_factory = logging.getLogRecordFactory()
+        if getattr(previous_factory, "_skill_scanner_context_factory", False):
+            return
+
+        def context_record_factory(*args, **kwargs):
+            record = previous_factory(*args, **kwargs)
+            context = _current_scan_context.get()
+
+            safe_skill_name = _safe_label(context.skill_name) if context and context.skill_name is not None else None
+            safe_skill_path = _safe_label(context.skill_path) if context and context.skill_path is not None else None
+            safe_scan_id = _safe_label(context.scan_id) if context and context.scan_id is not None else None
+            # Logger.makeRecord applies caller-supplied ``extra`` only after the
+            # record factory returns.  Do not reserve these public names when no
+            # scan is active, or otherwise-valid ``extra={"skill_name": ...}``
+            # calls would fail with a KeyError.
+            if context:
+                record.skill_name = safe_skill_name
+                record.skill_path = safe_skill_path
+                record.scan_id = safe_scan_id
+
+            if (
+                context
+                and record.name.startswith("skill_scanner")
+                and not getattr(record, "_skill_scanner_context_applied", False)
+            ):
+                labels = []
+                if safe_skill_name:
+                    labels.append(f"skill={safe_skill_name}")
+                if safe_skill_path:
+                    labels.append(f"path={safe_skill_path}")
+                if safe_scan_id:
+                    labels.append(f"scan_id={safe_scan_id}")
+                if labels:
+                    prefix = " ".join(labels)
+                    if record.args:
+                        # LogRecord.getMessage() applies %-formatting to the
+                        # entire message.  Escape untrusted percent signs in the
+                        # injected prefix while leaving structured fields intact.
+                        prefix = prefix.replace("%", "%%")
+                    record.msg = f"[{prefix}] {record.msg}"
+                    record._skill_scanner_context_applied = True
+
+            return record
+
+        context_record_factory._skill_scanner_context_factory = True
+        logging.setLogRecordFactory(context_record_factory)
+
+
+def get_scan_log_context() -> ScanLogContext | None:
+    """Return the context bound to the current task or thread."""
+
+    return _current_scan_context.get()
+
+
+@contextmanager
+def scan_log_context(
+    *,
+    skill_name: str | None = None,
+    skill_path: str | None = None,
+    scan_id: str | None = None,
+) -> Iterator[ScanLogContext]:
+    """Bind scan identifiers for the duration of a scanner operation.
+
+    Nested scopes inherit identifiers they do not explicitly replace.  This
+    lets an API request bind ``scan_id`` in its worker thread while the core
+    scanner adds the concrete skill name and path for each package.
+    """
+
+    _install_context_record_factory()
+    parent = _current_scan_context.get()
+    context = ScanLogContext(
+        skill_name=skill_name if skill_name is not None else (parent.skill_name if parent else None),
+        skill_path=skill_path if skill_path is not None else (parent.skill_path if parent else None),
+        scan_id=scan_id if scan_id is not None else (parent.scan_id if parent else None),
+    )
+    token = _current_scan_context.set(context)
+    try:
+        yield context
+    finally:
+        _current_scan_context.reset(token)

--- a/tests/test_external_tool_checks.py
+++ b/tests/test_external_tool_checks.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct regression tests for extracted external-tool checks."""
+
+from pathlib import Path
+
+import pytest
+
+from skill_scanner.core.models import Skill, SkillFile, SkillManifest
+from skill_scanner.core.scan_policy import ScanPolicy
+from skill_scanner.data.packs.core.python.external_tool_checks import check_homoglyph_attacks
+
+
+def _script_skill(content: str, file_type: str) -> Skill:
+    suffix = ".py" if file_type == "python" else ".sh"
+    path = Path(f"/nonexistent/issue-165/script{suffix}")
+    return Skill(
+        directory=path.parent,
+        manifest=SkillManifest(name="issue-165", description="Regression fixture"),
+        skill_md_path=path.parent / "SKILL.md",
+        instruction_body="# Issue 165 regression fixture",
+        files=[
+            SkillFile(
+                path=path,
+                relative_path=path.name,
+                file_type=file_type,
+                content=content,
+                size_bytes=len(content.encode()),
+            )
+        ],
+    )
+
+
+def _homoglyph_findings(content: str, file_type: str):
+    findings = check_homoglyph_attacks(_script_skill(content, file_type), ScanPolicy.default())
+    return [finding for finding in findings if finding.rule_id == "HOMOGLYPH_ATTACK"]
+
+
+@pytest.mark.parametrize(
+    ("file_type", "content"),
+    [
+        (
+            "python",
+            "COLUMNS = [\n"
+            '    ("calendar_uid", "TEXT"),  # идентификатор календаря в своём источнике\n'
+            '    ("calendar_account", "TEXT"),  # аккаунт Outlook (у Apple пуст)\n'
+            '    ("event_uid", "TEXT"),  # UID из iCalendar; общий для всей серии\n'
+            '    ("recurrence_id", "TEXT"),  # RECURRENCE-ID вхождения; переживает перенос\n'
+            '    ("all_day", "INTEGER"),  # NULL = неизвестно, 0/1 = знание\n'
+            "]\n",
+        ),
+        (
+            "bash",
+            'one=("value")  # описание первого значения\n'
+            'two=("value")  # описание второго значения\n'
+            'three=("value")  # описание третьего значения\n'
+            'four=("value")  # описание четвёртого значения\n'
+            'five=("value")  # описание пятого значения\n',
+        ),
+    ],
+)
+def test_trailing_comments_do_not_trigger_modular_homoglyph_check(file_type: str, content: str) -> None:
+    assert not _homoglyph_findings(content, file_type)
+
+
+@pytest.mark.parametrize("file_type", ["python", "bash"])
+def test_quoted_hash_does_not_hide_spoofed_identifier(file_type: str) -> None:
+    """A quoted hash stays code while the genuine trailing comment is removed."""
+    cyrillic_a = "\u0430"
+    if file_type == "python":
+        content = "".join(
+            f'marker = "# value"; p{cyrillic_a}yload_{index} = read_input()  # обычный комментарий\n'
+            for index in range(5)
+        )
+    else:
+        content = "".join(
+            f'echo "# value"; p{cyrillic_a}yload_{index}=input  # обычный комментарий\n' for index in range(5)
+        )
+
+    assert _homoglyph_findings(content, file_type)
+
+
+def test_ansi_c_hash_does_not_hide_spoofed_identifier() -> None:
+    """ANSI-C escaped quotes keep literal hashes inside the quoted token."""
+    cyrillic_a = "\u0430"
+    content = "".join(
+        f"label=$'can\\'t # literal'; p{cyrillic_a}yload_{index}=input  # комментарий\n" for index in range(5)
+    )
+
+    assert _homoglyph_findings(content, "bash")
+
+
+def test_multiline_bash_quote_hash_does_not_hide_spoofed_identifier() -> None:
+    """Bash quote state is shared across physical lines in modular checks."""
+    cyrillic_a = "\u0430"
+    content = "".join(
+        f'message_{index}="first line\n# literal"; p{cyrillic_a}yload_{index}=input  # комментарий\n'
+        for index in range(5)
+    )
+
+    assert _homoglyph_findings(content, "bash")

--- a/tests/test_issue_160_false_positives.py
+++ b/tests/test_issue_160_false_positives.py
@@ -173,6 +173,34 @@ def poll(client):
     assert "RESOURCE_ABUSE_INFINITE_LOOP" not in _rule_ids(findings)
 
 
+def test_nested_for_else_break_exits_enclosing_infinite_loop() -> None:
+    code = """\
+def consume_all(items):
+    while True:
+        for item in items:
+            consume(item)
+        else:
+            break
+"""
+
+    findings = StaticAnalyzer(use_yara=False).analyze(_python_skill(code))
+    assert "RESOURCE_ABUSE_INFINITE_LOOP" not in _rule_ids(findings)
+
+
+def test_false_nested_while_else_break_exits_enclosing_infinite_loop() -> None:
+    code = """\
+def finish_immediately():
+    while True:
+        while False:
+            perform_work()
+        else:
+            break
+"""
+
+    findings = StaticAnalyzer(use_yara=False).analyze(_python_skill(code))
+    assert "RESOURCE_ABUSE_INFINITE_LOOP" not in _rule_ids(findings)
+
+
 def test_targeted_environment_lookups_are_not_harvesting() -> None:
     code = """\
 import os

--- a/tests/test_issue_160_false_positives.py
+++ b/tests/test_issue_160_false_positives.py
@@ -107,6 +107,59 @@ def spin():
     assert "RESOURCE_ABUSE_INFINITE_LOOP" in _rule_ids(findings)
 
 
+def test_unreachable_break_does_not_disguise_infinite_loop() -> None:
+    code = """\
+def spin():
+    while True:
+        if False:
+            break
+        perform_work()
+"""
+
+    findings = StaticAnalyzer(use_yara=False).analyze(_python_skill(code))
+    assert "RESOURCE_ABUSE_INFINITE_LOOP" in _rule_ids(findings)
+
+
+def test_false_literal_comparison_does_not_disguise_infinite_loop() -> None:
+    code = """\
+def spin():
+    while True:
+        if 1 == 2:
+            return
+        perform_work()
+"""
+
+    findings = StaticAnalyzer(use_yara=False).analyze(_python_skill(code))
+    assert "RESOURCE_ABUSE_INFINITE_LOOP" in _rule_ids(findings)
+
+
+def test_exit_after_unconditional_continue_is_unreachable() -> None:
+    code = """\
+def spin():
+    while True:
+        perform_work()
+        continue
+        break
+"""
+
+    findings = StaticAnalyzer(use_yara=False).analyze(_python_skill(code))
+    assert "RESOURCE_ABUSE_INFINITE_LOOP" in _rule_ids(findings)
+
+
+def test_finally_continue_overrides_break() -> None:
+    code = """\
+def spin():
+    while True:
+        try:
+            break
+        finally:
+            continue
+"""
+
+    findings = StaticAnalyzer(use_yara=False).analyze(_python_skill(code))
+    assert "RESOURCE_ABUSE_INFINITE_LOOP" in _rule_ids(findings)
+
+
 def test_loop_with_raise_exit_is_not_reported_as_infinite() -> None:
     code = """\
 def poll(client):

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -170,6 +170,46 @@ class TestLLMAnalyzerInitialization:
         assert analyzer.model == "openai/enterprise-model"
         assert analyzer.provider_config.is_openai_compatible
 
+    def test_orcarouter_model_prefix_routes_via_openai_adapter(self):
+        """OrcaRouter model prefix routes through the OpenAI LiteLLM adapter with the default endpoint."""
+        analyzer = LLMAnalyzer(
+            model="orcarouter/anthropic/claude-sonnet-5",
+            api_key="test-key",
+        )
+
+        assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+        assert analyzer.provider_config.is_orcarouter
+        assert analyzer.provider_config.get_request_params() == {
+            "api_key": "test-key",
+            "api_base": "https://api.orcarouter.ai/v1",
+        }
+
+    def test_orcarouter_provider_override_uses_default_endpoint(self):
+        """The explicit orcarouter provider override maps to the OpenAI adapter."""
+        analyzer = LLMAnalyzer(
+            model="anthropic/claude-sonnet-5",
+            provider="orcarouter",
+            api_key="test-key",
+        )
+
+        assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+        assert analyzer.provider_config.is_orcarouter
+        assert analyzer.provider_config.get_request_params()["api_base"] == "https://api.orcarouter.ai/v1"
+
+    def test_orcarouter_custom_base_url_overrides_default_endpoint(self):
+        """An explicit base_url overrides the OrcaRouter default endpoint."""
+        analyzer = LLMAnalyzer(
+            model="orcarouter/anthropic/claude-sonnet-5",
+            api_key="test-key",
+            base_url="https://orca.internal/v1",
+        )
+
+        assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+        assert analyzer.provider_config.get_request_params() == {
+            "api_key": "test-key",
+            "api_base": "https://orca.internal/v1",
+        }
+
 
 class TestPromptLoading:
     """Test prompt loading functionality."""

--- a/tests/test_llm_reasoning_controls.py
+++ b/tests/test_llm_reasoning_controls.py
@@ -1,0 +1,568 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for optional, provider-aware LLM reasoning controls."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from skill_scanner.config.config import Config
+from skill_scanner.core.analyzers.llm_request_handler import LLMRequestHandler
+from skill_scanner.core.scan_policy import ScanPolicy
+from skill_scanner.llm_reasoning import (
+    ReasoningConfigurationError,
+    ReasoningControlUnsupportedError,
+    build_litellm_reasoning_params,
+    ensure_google_sdk_reasoning_supported,
+    resolve_llm_reasoning_effort,
+)
+
+
+def _provider(model: str, provider: str | None = None) -> MagicMock:
+    config = MagicMock()
+    config.model = model
+    config.provider = provider
+    config.use_google_sdk = False
+    config.get_request_params.return_value = {"api_key": "test-key"}
+    return config
+
+
+def _response(content: str = '{"result":"ok"}') -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    choice.provider_specific_fields = {}
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    return response
+
+
+class TestReasoningResolution:
+    def test_unset_preserves_provider_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        monkeypatch.delenv("SKILL_SCANNER_META_LLM_REASONING_EFFORT", raising=False)
+        assert resolve_llm_reasoning_effort() is None
+        assert resolve_llm_reasoning_effort(meta=True) is None
+
+    def test_scanner_wide_environment_is_validated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", " LoW ")
+        assert resolve_llm_reasoning_effort() == "low"
+
+    def test_meta_specific_environment_precedes_scanner_wide(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "medium")
+        monkeypatch.setenv("SKILL_SCANNER_META_LLM_REASONING_EFFORT", "minimal")
+        assert resolve_llm_reasoning_effort(meta=True) == "minimal"
+
+    def test_explicit_value_precedes_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "high")
+        assert resolve_llm_reasoning_effort("disabled") == "disabled"
+
+    @pytest.mark.parametrize("value", ["", "none", "off", "extreme"])
+    def test_invalid_or_ambiguous_values_are_rejected(
+        self,
+        value: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", value)
+        if value == "":
+            assert resolve_llm_reasoning_effort() is None
+        else:
+            with pytest.raises(ValueError, match="SKILL_SCANNER_LLM_REASONING_EFFORT must be one of"):
+                resolve_llm_reasoning_effort()
+
+    def test_config_resolves_environment_without_changing_unset_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        assert Config().llm_reasoning_effort is None
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "medium")
+        assert Config().llm_reasoning_effort == "medium"
+
+
+class TestProviderAwareParams:
+    def test_unset_emits_no_request_fields(self) -> None:
+        assert build_litellm_reasoning_params(None, model="anthropic/claude-sonnet-5") == {}
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh", "max"])
+    def test_configured_effort_uses_litellm_normalized_field(self, effort: str) -> None:
+        assert build_litellm_reasoning_params(
+            effort,
+            model="anthropic/claude-sonnet-5",
+            provider="anthropic",
+        ) == {"reasoning_effort": effort}
+
+    @pytest.mark.parametrize(
+        "model,provider",
+        [
+            ("anthropic/claude-sonnet-5", "anthropic"),
+            ("claude-sonnet-5", None),
+            ("bedrock/anthropic.claude-sonnet-5-v1:0", "aws-bedrock"),
+            ("vertex_ai/claude-sonnet-5@default", "gcp-vertex"),
+        ],
+    )
+    def test_disabled_uses_native_thinking_field_on_anthropic_routes(
+        self,
+        model: str,
+        provider: str | None,
+    ) -> None:
+        params = build_litellm_reasoning_params("disabled", model=model, provider=provider)
+        assert params == {"thinking": {"type": "disabled"}}
+        assert "reasoning_effort" not in params
+
+    @pytest.mark.parametrize(
+        "model,provider",
+        [
+            ("gpt-5", "openai"),
+            ("openai/claude-sonnet-5", "openai-compatible"),
+            ("openrouter/anthropic/claude-sonnet-5", "openrouter"),
+            ("anthropic/claude-sonnet-5", "orcarouter"),
+            ("orcarouter/anthropic/claude-sonnet-5", ""),
+            ("bedrock/amazon.nova-pro-v1:0", "aws-bedrock"),
+        ],
+    )
+    def test_disabled_uses_openai_semantics_on_gateway_routes(
+        self,
+        model: str,
+        provider: str,
+    ) -> None:
+        assert build_litellm_reasoning_params("disabled", model=model, provider=provider) == {
+            "reasoning_effort": "none"
+        }
+
+    def test_direct_google_sdk_rejects_configured_control_instead_of_dropping_it(self) -> None:
+        ensure_google_sdk_reasoning_supported(None, model="models/gemini-3.1-pro")
+        with pytest.raises(ReasoningControlUnsupportedError, match="direct Google GenAI SDK"):
+            ensure_google_sdk_reasoning_supported("low", model="models/gemini-3.1-pro")
+
+
+class TestMainLLMRequestPath:
+    @pytest.mark.asyncio
+    async def test_unset_preserves_outgoing_request_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        handler = LLMRequestHandler(_provider("gpt-5", "openai"), max_retries=0)
+        handler.response_schema = None
+        with patch(
+            "skill_scanner.core.analyzers.llm_request_handler.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await handler.make_request([{"role": "user", "content": "test"}])
+
+        kwargs = completion.await_args.kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "thinking" not in kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model,provider,effort,expected",
+        [
+            ("gpt-5", "openai", "low", {"reasoning_effort": "low"}),
+            (
+                "anthropic/claude-sonnet-5",
+                "anthropic",
+                "disabled",
+                {"thinking": {"type": "disabled"}},
+            ),
+            (
+                "openai/claude-sonnet-5",
+                "openai-compatible",
+                "disabled",
+                {"reasoning_effort": "none"},
+            ),
+        ],
+    )
+    async def test_configured_control_reaches_litellm(
+        self,
+        model: str,
+        provider: str,
+        effort: str,
+        expected: dict[str, object],
+    ) -> None:
+        handler = LLMRequestHandler(
+            _provider(model, provider),
+            reasoning_effort=effort,
+            max_retries=0,
+        )
+        handler.response_schema = None
+        with patch(
+            "skill_scanner.core.analyzers.llm_request_handler.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await handler.make_request([{"role": "user", "content": "test"}])
+
+        kwargs = completion.await_args.kwargs
+        for key, value in expected.items():
+            assert kwargs[key] == value
+        unexpected = "thinking" if "reasoning_effort" in expected else "reasoning_effort"
+        assert unexpected not in kwargs
+
+    def test_direct_google_handler_fails_loudly_when_control_is_set(self) -> None:
+        provider = _provider("models/gemini-3.1-pro")
+        provider.use_google_sdk = True
+        with pytest.raises(ReasoningControlUnsupportedError, match="direct Google GenAI SDK"):
+            LLMRequestHandler(provider, reasoning_effort="low")
+
+
+class TestMetaAndAlignmentPaths:
+    def test_alignment_client_preserves_legacy_positional_arguments(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+
+        monkeypatch.delenv("SKILL_SCANNER_LLM_PROVIDER", raising=False)
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        client = AlignmentLLMClient(
+            "gpt-4o",
+            "test-key",
+            "https://llm.example/v1",
+            "2026-01-01",
+            '{"appkey":"legacy"}',
+            0.25,
+            2048,
+            45,
+        )
+
+        assert client._base_url == "https://llm.example/v1"
+        assert client._api_version == "2026-01-01"
+        assert client._llm_user == '{"appkey":"legacy"}'
+        assert client._temperature == 0.25
+        assert client._max_tokens == 2048
+        assert client._timeout == 45
+
+    def test_alignment_orchestrator_preserves_legacy_positional_arguments(self) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_orchestrator import (
+            AlignmentOrchestrator,
+        )
+
+        with (
+            patch(
+                "skill_scanner.core.analyzers.behavioral.alignment.alignment_orchestrator.AlignmentLLMClient"
+            ) as client_type,
+            patch(
+                "skill_scanner.core.analyzers.behavioral.alignment.alignment_orchestrator.ThreatVulnerabilityClassifier"
+            ),
+        ):
+            AlignmentOrchestrator(
+                "gpt-4o",
+                "test-key",
+                "https://llm.example/v1",
+                0.25,
+                2048,
+                45,
+            )
+
+        assert client_type.call_args.kwargs["temperature"] == 0.25
+        assert client_type.call_args.kwargs["max_tokens"] == 2048
+        assert client_type.call_args.kwargs["timeout"] == 45
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model,provider,effort,expected",
+        [
+            ("gpt-5", "openai", None, {}),
+            ("gpt-5", "openai", "medium", {"reasoning_effort": "medium"}),
+            (
+                "anthropic/claude-sonnet-5",
+                "anthropic",
+                "disabled",
+                {"thinking": {"type": "disabled"}},
+            ),
+        ],
+    )
+    async def test_meta_request_uses_shared_provider_mapping(
+        self,
+        model: str,
+        provider: str,
+        effort: str | None,
+        expected: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        monkeypatch.delenv("SKILL_SCANNER_META_LLM_REASONING_EFFORT", raising=False)
+        analyzer = MetaAnalyzer(
+            model=model,
+            api_key="test-key",
+            provider=provider,
+            reasoning_effort=effort,
+            max_retries=1,
+        )
+        with patch(
+            "skill_scanner.core.analyzers.meta_analyzer.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await analyzer._make_llm_request("system", "user")
+
+        kwargs = completion.await_args.kwargs
+        if not expected:
+            assert "reasoning_effort" not in kwargs
+            assert "thinking" not in kwargs
+        for key, value in expected.items():
+            assert kwargs[key] == value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model,provider,effort,expected",
+        [
+            ("gpt-5", "openai", None, {}),
+            ("gpt-5", "openai", "low", {"reasoning_effort": "low"}),
+            (
+                "bedrock/anthropic.claude-sonnet-5-v1:0",
+                "aws-bedrock",
+                "disabled",
+                {"thinking": {"type": "disabled"}},
+            ),
+        ],
+    )
+    async def test_alignment_request_uses_shared_provider_mapping(
+        self,
+        model: str,
+        provider: str,
+        effort: str | None,
+        expected: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        client = AlignmentLLMClient(
+            model=model,
+            api_key="test-key",
+            provider=provider,
+            reasoning_effort=effort,
+        )
+        with patch(
+            "skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await client._make_llm_request("prompt")
+
+        kwargs = completion.await_args.kwargs
+        if not expected:
+            assert "reasoning_effort" not in kwargs
+            assert "thinking" not in kwargs
+        for key, value in expected.items():
+            assert kwargs[key] == value
+
+    @pytest.mark.asyncio
+    async def test_openai_compatible_bare_claude_models_are_normalized(self) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+        from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+        bare_model = "claude-sonnet-5"
+        expected_model = "openai/claude-sonnet-5"
+        meta = MetaAnalyzer(
+            model=bare_model,
+            api_key="test-key",
+            provider="openai-compatible",
+            reasoning_effort="disabled",
+            max_retries=1,
+        )
+        alignment = AlignmentLLMClient(
+            model=bare_model,
+            api_key="test-key",
+            provider="openai-compatible",
+            reasoning_effort="disabled",
+        )
+
+        with patch(
+            "skill_scanner.core.analyzers.meta_analyzer.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as meta_completion:
+            await meta._make_llm_request("system", "user")
+        with patch(
+            "skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as alignment_completion:
+            await alignment._make_llm_request("prompt")
+
+        for completion in (meta_completion, alignment_completion):
+            assert completion.await_args.kwargs["model"] == expected_model
+            assert completion.await_args.kwargs["reasoning_effort"] == "none"
+            assert "thinking" not in completion.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_orcarouter_meta_default_and_alignment_share_gateway_semantics(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+        from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+        for variable in (
+            "SKILL_SCANNER_LLM_MODEL",
+            "SKILL_SCANNER_META_LLM_MODEL",
+            "SKILL_SCANNER_LLM_PROVIDER",
+            "SKILL_SCANNER_LLM_REASONING_EFFORT",
+            "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
+        ):
+            monkeypatch.delenv(variable, raising=False)
+
+        meta = MetaAnalyzer(
+            api_key="test-key",
+            provider="orcarouter",
+            reasoning_effort="disabled",
+            max_retries=1,
+        )
+        alignment = AlignmentLLMClient(
+            model="orcarouter/anthropic/claude-sonnet-5",
+            api_key="test-key",
+            provider="orcarouter",
+            reasoning_effort="disabled",
+        )
+
+        with patch(
+            "skill_scanner.core.analyzers.meta_analyzer.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as meta_completion:
+            await meta._make_llm_request("system", "user")
+        with patch(
+            "skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as alignment_completion:
+            await alignment._make_llm_request("prompt")
+
+        for completion in (meta_completion, alignment_completion):
+            kwargs = completion.await_args.kwargs
+            assert kwargs["model"] == "openai/anthropic/claude-sonnet-5"
+            assert kwargs["api_base"] == "https://api.orcarouter.ai/v1"
+            assert kwargs["reasoning_effort"] == "none"
+            assert "thinking" not in kwargs
+
+
+class TestEntryPointPlumbing:
+    def test_cli_parser_accepts_canonical_values_and_rejects_none(self) -> None:
+        from skill_scanner.cli.cli import build_parser
+
+        args = build_parser().parse_args(["scan", "/tmp/skill", "--llm-reasoning-effort", "disabled"])
+        assert args.llm_reasoning_effort == "disabled"
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["scan", "/tmp/skill", "--llm-reasoning-effort", "none"])
+
+    def test_cli_forwards_setting_to_main_and_meta_factories(self) -> None:
+        from skill_scanner.cli.cli import _build_analyzers, _build_meta_analyzer
+
+        policy = ScanPolicy.default()
+        args = argparse.Namespace(
+            enable_meta=True,
+            llm_provider="anthropic",
+            llm_reasoning_effort="disabled",
+        )
+        with patch("skill_scanner.cli.cli.build_analyzers", return_value=[]) as factory:
+            _build_analyzers(policy, args, lambda _message: None)
+        assert factory.call_args.kwargs["llm_reasoning_effort"] == "disabled"
+
+        with patch("skill_scanner.cli.cli.MetaAnalyzer", return_value=MagicMock()) as meta_type:
+            _build_meta_analyzer(
+                args,
+                2,
+                lambda _message: None,
+                policy=policy,
+                reasoning_effort="disabled",
+            )
+        assert meta_type.call_args.kwargs["reasoning_effort"] == "disabled"
+        assert meta_type.call_args.kwargs["provider"] == "anthropic"
+
+    def test_core_factory_forwards_setting_to_main_and_behavioral_analyzers(self) -> None:
+        from skill_scanner.core.analyzer_factory import build_analyzers
+
+        with (
+            patch("skill_scanner.core.analyzers.llm_analyzer.LLMAnalyzer", return_value=MagicMock()) as llm_type,
+            patch(
+                "skill_scanner.core.analyzers.behavioral_analyzer.BehavioralAnalyzer",
+                return_value=MagicMock(),
+            ) as behavioral_type,
+        ):
+            build_analyzers(
+                ScanPolicy.default(),
+                use_llm=True,
+                use_behavioral=True,
+                llm_provider="anthropic",
+                llm_reasoning_effort="low",
+            )
+
+        assert llm_type.call_args.kwargs["reasoning_effort"] == "low"
+        assert behavioral_type.call_args.kwargs["llm_reasoning_effort"] == "low"
+        assert behavioral_type.call_args.kwargs["llm_provider"] == "anthropic"
+
+    def test_core_factory_does_not_swallow_invalid_reasoning_environment(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzer_factory import build_analyzers
+
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "turbo")
+        monkeypatch.delenv("SKILL_SCANNER_LLM_PROVIDER", raising=False)
+        with pytest.raises(ReasoningConfigurationError, match="SKILL_SCANNER_LLM_REASONING_EFFORT"):
+            build_analyzers(
+                ScanPolicy.default(),
+                use_llm=True,
+                llm_model="gpt-5",
+                llm_api_key="test-key",
+            )
+
+    def test_cli_main_reports_reasoning_configuration_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from skill_scanner.cli.cli import main
+
+        monkeypatch.setattr("sys.argv", ["skill-scanner", "list-analyzers"])
+        with patch(
+            "skill_scanner.cli.cli.list_analyzers_command",
+            side_effect=ReasoningConfigurationError("unsupported direct Google reasoning control"),
+        ):
+            assert main() == 1
+        assert "LLM reasoning configuration error" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_api_returns_400_for_reasoning_configuration_error(self, tmp_path) -> None:
+        from skill_scanner.api.router import ScanRequest, scan_skill
+
+        (tmp_path / "SKILL.md").write_text("---\nname: test\ndescription: test\n---\n", encoding="utf-8")
+        request = ScanRequest(
+            skill_directory=str(tmp_path),
+            use_llm=True,
+            llm_reasoning_effort="low",
+        )
+        with patch(
+            "skill_scanner.api.router._build_analyzers",
+            side_effect=ReasoningConfigurationError("unsupported direct Google reasoning control"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await scan_skill(request)
+        assert exc_info.value.status_code == 400
+        assert "unsupported direct Google reasoning control" in exc_info.value.detail
+
+    def test_api_models_validate_and_router_forwards_setting(self) -> None:
+        from skill_scanner.api.router import BatchScanRequest, ScanRequest, _build_analyzers
+
+        scan_request = ScanRequest(skill_directory="/tmp/skill", llm_reasoning_effort="minimal")
+        batch_request = BatchScanRequest(skills_directory="/tmp/skills", llm_reasoning_effort="disabled")
+        assert scan_request.llm_reasoning_effort == "minimal"
+        assert batch_request.llm_reasoning_effort == "disabled"
+        assert ScanRequest(skill_directory="/tmp/skill").llm_reasoning_effort is None
+        with pytest.raises(ValidationError):
+            ScanRequest(skill_directory="/tmp/skill", llm_reasoning_effort="none")
+
+        with patch("skill_scanner.api.router.build_analyzers", return_value=[]) as factory:
+            _build_analyzers(ScanPolicy.default(), llm_reasoning_effort="high")
+        assert factory.call_args.kwargs["llm_reasoning_effort"] == "high"

--- a/tests/test_logging_context.py
+++ b/tests/test_logging_context.py
@@ -1,0 +1,192 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for scan-scoped logging context (issue #149)."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+from skill_scanner.core.scanner import SkillScanner
+from skill_scanner.utils.logging_context import get_scan_log_context, scan_log_context
+
+
+def test_scan_context_prefixes_package_logs_and_restores(caplog) -> None:
+    logger = logging.getLogger("skill_scanner.tests.context")
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with scan_log_context(skill_name="alpha", skill_path="/skills/alpha", scan_id="scan-1"):
+            logger.warning("Invalid JSON response")
+        logger.warning("Outside scan")
+
+    contextual, outside = caplog.records[-2:]
+    assert contextual.getMessage() == ("[skill=alpha path=/skills/alpha scan_id=scan-1] Invalid JSON response")
+    assert contextual.skill_name == "alpha"
+    assert contextual.skill_path == "/skills/alpha"
+    assert contextual.scan_id == "scan-1"
+    assert outside.getMessage() == "Outside scan"
+    assert getattr(outside, "skill_name", None) is None
+
+
+def test_nested_context_inherits_request_id_and_restores_parent() -> None:
+    assert get_scan_log_context() is None
+
+    with scan_log_context(scan_id="batch-1"):
+        with scan_log_context(skill_name="nested", skill_path="/skills/nested") as nested:
+            assert nested.scan_id == "batch-1"
+            assert nested.skill_name == "nested"
+
+        restored = get_scan_log_context()
+        assert restored is not None
+        assert restored.scan_id == "batch-1"
+        assert restored.skill_name is None
+
+    assert get_scan_log_context() is None
+
+
+def test_context_escapes_control_characters(caplog) -> None:
+    logger = logging.getLogger("skill_scanner.tests.untrusted_context")
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with scan_log_context(
+            skill_name="line-one\nforged-warning",
+            skill_path="/skills/\x1b[31mred",
+            scan_id="id\x00\tend",
+        ):
+            logger.warning("real warning")
+
+    record = caplog.records[-1]
+    assert record.skill_name == "line-one\\nforged-warning"
+    assert record.skill_path == "/skills/\\x1b[31mred"
+    assert record.scan_id == "id\\x00\\tend"
+    assert record.getMessage() == (
+        "[skill=line-one\\nforged-warning path=/skills/\\x1b[31mred scan_id=id\\x00\\tend] real warning"
+    )
+
+    formatted = logging.Formatter("%(skill_name)s|%(skill_path)s|%(scan_id)s|%(message)s").format(record)
+    assert "\n" not in formatted
+    assert "\x1b" not in formatted
+    assert "\x00" not in formatted
+
+
+def test_context_preserves_printable_unicode(caplog) -> None:
+    logger = logging.getLogger("skill_scanner.tests.unicode_context")
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with scan_log_context(skill_name="café-技能"):
+            logger.warning("ready")
+
+    record = caplog.records[-1]
+    assert record.skill_name == "café-技能"
+    assert record.getMessage() == "[skill=café-技能] ready"
+
+
+def test_context_percent_signs_preserve_parameterized_logging(caplog) -> None:
+    """Untrusted percent signs do not become message-format placeholders."""
+    logger = logging.getLogger("skill_scanner.tests.percent_context")
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with scan_log_context(skill_name="progress%s", skill_path=r"C:\Users\%USERNAME%\demo"):
+            logger.warning("failed for %s", "payload")
+
+    record = caplog.records[-1]
+    assert record.skill_name == "progress%s"
+    assert record.skill_path == r"C:\\Users\\%USERNAME%\\demo"
+    assert record.getMessage() == (r"[skill=progress%s path=C:\\Users\\%USERNAME%\\demo] failed for payload")
+
+
+def test_context_factory_does_not_reserve_caller_extra_fields() -> None:
+    """Installing the factory does not break conventional caller-supplied fields."""
+    with scan_log_context(skill_name="factory-install"):
+        pass
+
+    logger = logging.getLogger("skill_scanner.tests.caller_extra")
+    record = logger.makeRecord(
+        logger.name,
+        logging.WARNING,
+        __file__,
+        1,
+        "caller-owned",
+        (),
+        None,
+        extra={"skill_name": "caller", "skill_path": "/caller", "scan_id": "caller-id"},
+    )
+
+    assert record.skill_name == "caller"
+    assert record.skill_path == "/caller"
+    assert record.scan_id == "caller-id"
+
+
+def test_parallel_thread_contexts_do_not_bleed() -> None:
+    logger = logging.getLogger("skill_scanner.tests.parallel")
+    barrier = threading.Barrier(2)
+    records: list[logging.LogRecord] = []
+    records_lock = threading.Lock()
+
+    class RecordingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            with records_lock:
+                records.append(record)
+
+    handler = RecordingHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    logger.propagate = False
+
+    def emit_for(skill_name: str) -> None:
+        with scan_log_context(skill_name=skill_name):
+            barrier.wait(timeout=5)
+            logger.warning("timed out")
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(emit_for, name) for name in ("alpha", "beta")]
+            for future in futures:
+                future.result(timeout=10)
+    finally:
+        logger.removeHandler(handler)
+        logger.propagate = True
+
+    by_skill = {record.skill_name: record.getMessage() for record in records}
+    assert by_skill == {
+        "alpha": "[skill=alpha] timed out",
+        "beta": "[skill=beta] timed out",
+    }
+
+
+def test_scanner_binds_skill_name_and_canonical_path(monkeypatch, tmp_path: Path) -> None:
+    scanner = SkillScanner(analyzers=[])
+    skill = SimpleNamespace(name="bound-skill")
+    captured = None
+
+    def run_with_context(_skill, _path):
+        nonlocal captured
+        captured = get_scan_log_context()
+        return "scan-result"
+
+    monkeypatch.setattr(scanner, "_scan_single_skill_with_context", run_with_context)
+
+    result = scanner._scan_single_skill(skill, tmp_path / "bound-skill")
+
+    assert result == "scan-result"
+    assert captured is not None
+    assert captured.skill_name == "bound-skill"
+    assert captured.skill_path == str((tmp_path / "bound-skill").resolve())
+    assert get_scan_log_context() is None

--- a/tests/test_meta_analyzer.py
+++ b/tests/test_meta_analyzer.py
@@ -235,6 +235,46 @@ class TestOverallRiskAssessmentNormalization:
         assert result.overall_risk_assessment["raw_risk_level"] == "none"
         assert result.overall_risk_assessment["skill_verdict"] == "SUSPICIOUS"
 
+    @pytest.mark.parametrize(
+        ("assessment", "missing_fields"),
+        [
+            ({"risk_level": "LOW", "summary": "missing verdict"}, ("skill_verdict",)),
+            ({"skill_verdict": "SAFE", "summary": "missing risk"}, ("risk_level",)),
+            ({"summary": "missing both"}, ("risk_level", "skill_verdict")),
+        ],
+    )
+    def test_parse_response_degrades_missing_required_assessment_fields(self, assessment, missing_fields):
+        from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+        analyzer = MetaAnalyzer(model="test-model", api_key="test-key")
+        response = json.dumps(
+            {
+                "overall_risk_assessment": assessment,
+                "validated_findings": [],
+                "false_positives": [],
+                "missed_threats": [],
+                "priority_order": [],
+                "correlations": [],
+                "recommendations": [],
+            }
+        )
+
+        original_finding = Finding(
+            id="finding-0",
+            rule_id="RULE_0",
+            category=ThreatCategory.PROMPT_INJECTION,
+            severity=Severity.HIGH,
+            title="Original finding",
+            description="Retained during schema degradation",
+            analyzer="static",
+        )
+        result = analyzer._parse_response(response, [original_finding], original_indices=[0])
+
+        assert result.analysis_warnings[0]["code"] == "META_RESPONSE_SCHEMA_INCOMPLETE"
+        for missing_field in missing_fields:
+            assert result.overall_risk_assessment[missing_field] == "UNKNOWN"
+            assert missing_field in result.analysis_warnings[0]["message"]
+
 
 class TestMetaAnalyzerInit:
     """Tests for MetaAnalyzer initialization."""

--- a/tests/test_orcarouter_provider.py
+++ b/tests/test_orcarouter_provider.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end regression tests for OrcaRouter provider integration."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skill_scanner.core.analyzers.adjudicator import Adjudicator
+from skill_scanner.core.analyzers.llm_analyzer import LLMAnalyzer
+from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+from skill_scanner.core.rules.patterns import RuleLoader, SecurityRule
+from skill_scanner.data import DATA_DIR
+
+
+def test_environment_provider_selects_orcarouter_default_model() -> None:
+    """An environment-only provider must select the OrcaRouter default."""
+    with patch.dict(
+        os.environ,
+        {
+            "SKILL_SCANNER_LLM_PROVIDER": "orcarouter",
+            "SKILL_SCANNER_LLM_API_KEY": "test-key",
+        },
+        clear=True,
+    ):
+        analyzer = LLMAnalyzer()
+
+    assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+    assert analyzer.provider_config.get_request_params() == {
+        "api_key": "test-key",
+        "api_base": "https://api.orcarouter.ai/v1",
+    }
+
+
+def test_orcarouter_preserves_existing_openai_adapter_prefix() -> None:
+    """An already-normalized model must not become ``openai/openai/...``."""
+    analyzer = LLMAnalyzer(
+        model="openai/anthropic/claude-sonnet-5",
+        provider="orcarouter",
+        api_key="test-key",
+    )
+
+    assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+
+
+@pytest.mark.asyncio
+async def test_meta_analyzer_uses_orcarouter_adapter_and_endpoint() -> None:
+    """Meta-analysis must use the same normalized route as primary analysis."""
+    with patch.dict(
+        os.environ,
+        {
+            "SKILL_SCANNER_LLM_PROVIDER": "orcarouter",
+            "SKILL_SCANNER_LLM_API_KEY": "test-key",
+        },
+        clear=True,
+    ):
+        analyzer = MetaAnalyzer()
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = "{}"
+    with patch(
+        "skill_scanner.core.analyzers.meta_analyzer.acompletion",
+        new_callable=AsyncMock,
+        return_value=response,
+    ) as mock_acompletion:
+        await analyzer._make_llm_request("system", "user")
+
+    assert analyzer.model == "openai/anthropic/claude-sonnet-5"
+    kwargs = mock_acompletion.call_args.kwargs
+    assert kwargs["model"] == "openai/anthropic/claude-sonnet-5"
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["api_base"] == "https://api.orcarouter.ai/v1"
+
+
+def test_adjudicator_uses_orcarouter_adapter_and_endpoint() -> None:
+    """Adjudication must not send LiteLLM the unrecognized OrcaRouter prefix."""
+    with patch.dict(
+        os.environ,
+        {
+            "SKILL_SCANNER_LLM_PROVIDER": "orcarouter",
+            "SKILL_SCANNER_LLM_API_KEY": "test-key",
+        },
+        clear=True,
+    ):
+        adjudicator = Adjudicator(max_retries=0)
+
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "content": '{"verdict":"real","confidence":5,"reason":"test"}',
+                }
+            }
+        ]
+    }
+    with patch("litellm.completion", return_value=response) as mock_completion:
+        result = adjudicator._call_llm("test prompt")
+
+    assert result == {"verdict": "real", "confidence": 5, "reason": "test"}
+    kwargs = mock_completion.call_args.kwargs
+    assert kwargs["model"] == "openai/anthropic/claude-sonnet-5"
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["api_base"] == "https://api.orcarouter.ai/v1"
+
+
+@pytest.fixture(scope="module")
+def anthropic_base_url_rule() -> SecurityRule:
+    """Load the ATR endpoint-exfiltration rule from the shipped pack."""
+    signatures = DATA_DIR / "packs" / "atr" / "signatures"
+    loader = RuleLoader(rules_file=signatures)
+    loader.load_rules()
+    rule = loader.get_rule("ATR_2026_00524")
+    assert rule is not None
+    return rule
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        '"ANTHROPIC_BASE_URL": "https://api.orcarouter.ai/v1"',
+        '"ANTHROPIC_BASE_URL": "https://api.orcarouter.ai:443/v1"',
+        'ANTHROPIC_BASE_URL="https://api.orcarouter.ai/v1"',
+        '.claude/settings.json {"ANTHROPIC_BASE_URL": "https://api.orcarouter.ai/v1"}',
+    ],
+)
+def test_https_orcarouter_endpoint_is_trusted(
+    anthropic_base_url_rule: SecurityRule,
+    content: str,
+) -> None:
+    assert anthropic_base_url_rule.scan_content(content, "SKILL.md") == []
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        '"ANTHROPIC_BASE_URL": "http://api.orcarouter.ai/v1"',
+        'ANTHROPIC_BASE_URL="http://api.orcarouter.ai/v1"',
+        '.claude/settings.json {"ANTHROPIC_BASE_URL": "http://api.orcarouter.ai/v1"}',
+        '"ANTHROPIC_BASE_URL": "https://api.orcarouter.ai.evil.example/v1"',
+        '"ANTHROPIC_BASE_URL": "https://api.orcarouter.ai:443.evil.example/v1"',
+    ],
+)
+def test_insecure_or_spoofed_orcarouter_endpoint_is_detected(
+    anthropic_base_url_rule: SecurityRule,
+    content: str,
+) -> None:
+    assert anthropic_base_url_rule.scan_content(content, "SKILL.md")

--- a/tests/test_reference_docs_generator.py
+++ b/tests/test_reference_docs_generator.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for reference-document source discovery."""
+
+from scripts.generate_reference_docs import (
+    _collect_env_variables,
+    _extract_python_env_variables,
+    _render_api_reference,
+    _render_cli_reference,
+    _render_configuration_reference,
+)
+
+
+def test_environment_discovery_ignores_comments_and_docstrings() -> None:
+    source = '''
+import os
+
+ENV_NAME = "CONSTANT_ENV"
+"""Example only: os.getenv("DOCSTRING_ENV")"""
+# Example only: os.environ.get("COMMENT_ENV")
+direct = os.getenv("DIRECT_ENV")
+constant = os.environ.get(ENV_NAME)
+'''
+
+    assert _extract_python_env_variables(source) == {"CONSTANT_ENV", "DIRECT_ENV"}
+
+
+def test_reasoning_environment_variables_map_to_runtime_resolver() -> None:
+    env_map = _collect_env_variables()
+
+    for variable in (
+        "SKILL_SCANNER_LLM_REASONING_EFFORT",
+        "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
+    ):
+        assert "skill_scanner/llm_reasoning.py" in env_map[variable]
+
+
+def test_generated_references_document_google_reasoning_limitation() -> None:
+    expected = "Direct Google GenAI SDK requests reject configured controls"
+
+    assert expected in _render_cli_reference()
+    assert expected in _render_api_reference()
+    assert expected in _render_configuration_reference()


### PR DESCRIPTION
## Summary

- replace regex-context suppression with AST-based reachable control-flow analysis
- ignore statically false exit branches and statements after an unconditional continue
- preserve valid break, return, raise, and sys.exit exits while respecting nested loops and finally overrides

This is the integration-audit hardening follow-up to #180 for issue #160.

## Stack

Layer 11 of gh-stack #182, based on #183. Merge the stack from the bottom upward.

## Verification

- `uv run pytest tests/test_issue_160_false_positives.py -q --tb=short` (13 passed)
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infinite-loop detection for complex control-flow scenarios, reducing false positives.
  * Correctly handles nested loops, unreachable statements, unconditional `continue`, and `finally` blocks that override loop exits.
  * Improved detection of homoglyphs by ignoring comments while preserving reported source context.
  * Prevents certain credential-harvesting and tool-chaining alerts when explicitly negated in exfiltration comments.

* **Tests**
  * Added regression coverage for loop-control and comment-related detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->