### PR TITLE
feat(llm): add provider-aware reasoning controls (#166)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@
 # SKILL_SCANNER_LLM_MODEL=claude-3-5-sonnet-20241022
 # Positive integer output budget (default: 8192)
 # SKILL_SCANNER_LLM_MAX_TOKENS=16384
+# Optional: disabled, minimal, low, medium, high, xhigh, or max
+# SKILL_SCANNER_LLM_REASONING_EFFORT=low
 
 # OpenAI-compatible custom endpoint
 # SKILL_SCANNER_LLM_API_KEY=your_custom_provider_key
@@ -43,6 +45,7 @@
 # SKILL_SCANNER_META_LLM_BASE_URL=
 # SKILL_SCANNER_META_LLM_API_VERSION=
 # SKILL_SCANNER_META_LLM_MAX_TOKENS=32768
+# SKILL_SCANNER_META_LLM_REASONING_EFFORT=low
 
 # VirusTotal Configuration (optional)
 # VIRUSTOTAL_API_KEY=your_virustotal_api_key

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@
 # SKILL_SCANNER_LLM_MODEL=claude-3-5-sonnet-20241022
 # Positive integer output budget (default: 8192)
 # SKILL_SCANNER_LLM_MAX_TOKENS=16384
-# Optional: disabled, minimal, low, medium, high, xhigh, or max
+# Optional: disabled, minimal, low, medium, high, xhigh, or max.
+# Direct Google GenAI SDK requests reject this control; LiteLLM-backed Gemini requests support it.
 # SKILL_SCANNER_LLM_REASONING_EFFORT=low
 
 # OpenAI-compatible custom endpoint
@@ -45,6 +46,7 @@
 # SKILL_SCANNER_META_LLM_BASE_URL=
 # SKILL_SCANNER_META_LLM_API_VERSION=
 # SKILL_SCANNER_META_LLM_MAX_TOKENS=32768
+# Direct Google GenAI SDK requests reject this control; LiteLLM-backed Gemini requests support it.
 # SKILL_SCANNER_META_LLM_REASONING_EFFORT=low
 
 # VirusTotal Configuration (optional)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ pip install cisco-ai-skill-scanner[all]
 # For LLM analyzer and Meta-analyzer
 export SKILL_SCANNER_LLM_API_KEY="your_api_key"
 export SKILL_SCANNER_LLM_MODEL="claude-3-5-sonnet-20241022"
+# Optional: disabled, minimal, low, medium, high, xhigh, or max
+export SKILL_SCANNER_LLM_REASONING_EFFORT="low"
 
 # For VirusTotal binary scanning
 export VIRUSTOTAL_API_KEY="your_virustotal_api_key"
@@ -254,6 +256,7 @@ if not result.is_safe:
 | `--llm-provider` | LLM provider for CLI routing: `anthropic` or `openai` |
 | `--llm-consensus-runs N` | Run LLM analysis `N` times, keep majority-agreed findings, and retain their highest observed severity |
 | `--llm-max-tokens N` | Maximum output tokens for LLM responses (default: 8192) |
+| `--llm-reasoning-effort LEVEL` | Optional reasoning depth (`disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`); unset preserves the provider default |
 | `--use-virustotal` | Enable VirusTotal binary scanner |
 | `--vt-api-key KEY` | Provide VirusTotal API key directly (optional) |
 | `--vt-upload-files` | Upload unknown binaries to VirusTotal (optional) |

--- a/docs/architecture/analyzers/llm-analyzer.md
+++ b/docs/architecture/analyzers/llm-analyzer.md
@@ -306,6 +306,14 @@ export AWS_REGION=us-east-1
 - Applies prompt budget gates from policy (`llm_analysis.*`) and emits `LLM_CONTEXT_BUDGET_EXCEEDED` when content is skipped
 - Output token limit precedence is `--llm-max-tokens` / API `llm_max_tokens` → `SKILL_SCANNER_LLM_MAX_TOKENS` → `llm_analysis.max_output_tokens` in the active policy (default 8192). Every configured value must be a positive integer.
 - Provider-reported output truncation (`finish_reason=length`, `max_tokens`, or the Google `MAX_TOKENS` equivalent) fails with `LLMResponseTruncatedError` before partial JSON is parsed. The resulting `LLM_ANALYSIS_FAILED` diagnostic identifies the model, budget, finish reason, and the knobs that can raise the limit.
+- Reasoning effort is optional and unset by default, so existing provider behavior is unchanged. Configure `--llm-reasoning-effort`, API `llm_reasoning_effort`, or `SKILL_SCANNER_LLM_REASONING_EFFORT` with `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
+
+### Reasoning Provider Semantics
+
+- `disabled` is an explicit scanner-level semantic. Direct Anthropic, Bedrock Claude, and Vertex Claude routes receive `thinking: {type: "disabled"}`. This matters for [Claude Sonnet 5, where omitting `thinking` enables adaptive thinking](https://platform.claude.com/docs/en/docs/about-claude/models/whats-new-sonnet-5).
+- OpenAI and OpenAI-compatible gateway routes receive `reasoning_effort: "none"`. The gateway/provider remains responsible for honoring that OpenAI-style value.
+- Other effort levels use LiteLLM's normalized `reasoning_effort` field. Supported levels vary by model; `xhigh` and `max` are not universal. `drop_params=True` can remove an unsupported parameter, but cannot make a provider accept an unsupported level.
+- The scanner's optional direct Google GenAI SDK path uses different model-specific thinking controls. A configured `llm_reasoning_effort` fails with a configuration error (CLI exit 1 / API HTTP 400) rather than being silently ignored; use a LiteLLM-backed route or leave the setting unset.
 
 ## Error Handling
 

--- a/docs/architecture/analyzers/meta-analyzer.md
+++ b/docs/architecture/analyzers/meta-analyzer.md
@@ -90,6 +90,7 @@ export SKILL_SCANNER_LLM_MODEL="anthropic/claude-sonnet-4-20250514"
 export SKILL_SCANNER_LLM_BASE_URL="https://..."  # For Azure/custom endpoints
 export SKILL_SCANNER_LLM_API_VERSION="2025-01-01-preview"  # For Azure
 export SKILL_SCANNER_LLM_MAX_TOKENS="16384"  # Positive integer
+export SKILL_SCANNER_LLM_REASONING_EFFORT="low"
 ```
 
 **Meta-specific overrides** (optional - use different model/key for meta-analysis):
@@ -99,6 +100,7 @@ export SKILL_SCANNER_META_LLM_MODEL="gpt-4o"
 export SKILL_SCANNER_META_LLM_BASE_URL="https://..."
 export SKILL_SCANNER_META_LLM_API_VERSION="..."
 export SKILL_SCANNER_META_LLM_MAX_TOKENS="32768"
+export SKILL_SCANNER_META_LLM_REASONING_EFFORT="minimal"
 ```
 
 ### Priority Order
@@ -110,6 +112,7 @@ export SKILL_SCANNER_META_LLM_MAX_TOKENS="32768"
 | Base URL | `SKILL_SCANNER_META_LLM_BASE_URL` → `SKILL_SCANNER_LLM_BASE_URL` |
 | API Version | `SKILL_SCANNER_META_LLM_API_VERSION` → `SKILL_SCANNER_LLM_API_VERSION` |
 | Max output tokens | CLI/API explicit value → `SKILL_SCANNER_META_LLM_MAX_TOKENS` → `SKILL_SCANNER_LLM_MAX_TOKENS` → policy/default |
+| Reasoning effort | CLI/API explicit value → `SKILL_SCANNER_META_LLM_REASONING_EFFORT` → `SKILL_SCANNER_LLM_REASONING_EFFORT` → provider default |
 
 ### Auth Behavior
 

--- a/docs/reference/api-endpoint-reference.md
+++ b/docs/reference/api-endpoint-reference.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. DO NOT EDIT DIRECTLY.
-     Regenerate with: uv run python scripts/generate_reference_docs.py -->
+     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->
 
 # API Endpoint Reference
 

--- a/docs/reference/api-endpoint-reference.md
+++ b/docs/reference/api-endpoint-reference.md
@@ -146,5 +146,5 @@ curl -X POST http://localhost:8000/scan-upload \
 - API behavior is policy-aware and mirrors CLI analyzer selection flags.
 - API keys for VirusTotal and AI Defense are passed via request headers (`X-VirusTotal-Key`, `X-AIDefense-Key`), not in the JSON body.
 - Set `SKILL_SCANNER_ALLOWED_ROOTS` to restrict which directories the API can scan.
-- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default.
+- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default. Direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them.
 - All `POST` endpoints accept JSON bodies. File upload uses `multipart/form-data`.

--- a/docs/reference/api-endpoint-reference.md
+++ b/docs/reference/api-endpoint-reference.md
@@ -94,6 +94,7 @@ curl -X POST http://localhost:8000/scan-upload \
 | `enable_meta` | `bool` |
 | `llm_consensus_runs` | `int` |
 | `llm_max_tokens` | `int \| None` |
+| `llm_reasoning_effort` | `LLMReasoningEffort \| None` |
 
 ### `ScanResponse`
 
@@ -138,10 +139,12 @@ curl -X POST http://localhost:8000/scan-upload \
 | `enable_meta` | `bool` |
 | `llm_consensus_runs` | `int` |
 | `llm_max_tokens` | `int \| None` |
+| `llm_reasoning_effort` | `LLMReasoningEffort \| None` |
 
 ## Notes
 
 - API behavior is policy-aware and mirrors CLI analyzer selection flags.
 - API keys for VirusTotal and AI Defense are passed via request headers (`X-VirusTotal-Key`, `X-AIDefense-Key`), not in the JSON body.
 - Set `SKILL_SCANNER_ALLOWED_ROOTS` to restrict which directories the API can scan.
+- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default.
 - All `POST` endpoints accept JSON bodies. File upload uses `multipart/form-data`.

--- a/docs/reference/cli-command-reference.md
+++ b/docs/reference/cli-command-reference.md
@@ -34,7 +34,7 @@ Flags shared by `scan` and `scan-all`:
 | `--use-virustotal` | off | Enable VirusTotal hash lookups |
 | `--use-aidefense` | off | Enable Cisco AI Defense analyzer |
 | `--use-osv` | off | Enable OSV.dev dependency vulnerability scanning (no API key; requires network) |
-| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |
+| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. |
 | `--enable-meta` | off | Enable the meta (cross-correlation) analyzer |
 | `--fail-on-findings` | off | Exit non-zero if critical or high findings are reported; equivalent to `--fail-on-severity high` (CI gate) |
 | `--fail-on-severity LEVEL` | off | Exit non-zero if findings at or above LEVEL exist (critical, high, medium, low, info) |

--- a/docs/reference/cli-command-reference.md
+++ b/docs/reference/cli-command-reference.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. DO NOT EDIT DIRECTLY.
-     Regenerate with: uv run python scripts/generate_reference_docs.py -->
+     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->
 
 # CLI Command Reference
 

--- a/docs/reference/cli-command-reference.md
+++ b/docs/reference/cli-command-reference.md
@@ -33,6 +33,8 @@ Flags shared by `scan` and `scan-all`:
 | `--use-behavioral` | off | Enable the behavioral analyzer |
 | `--use-virustotal` | off | Enable VirusTotal hash lookups |
 | `--use-aidefense` | off | Enable Cisco AI Defense analyzer |
+| `--use-osv` | off | Enable OSV.dev dependency vulnerability scanning (no API key; requires network) |
+| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |
 | `--enable-meta` | off | Enable the meta (cross-correlation) analyzer |
 | `--fail-on-findings` | off | Exit non-zero if critical or high findings are reported; equivalent to `--fail-on-severity high` (CI gate) |
 | `--fail-on-severity LEVEL` | off | Exit non-zero if findings at or above LEVEL exist (critical, high, medium, low, info) |
@@ -108,9 +110,9 @@ usage: cli.py scan [-h] [--format {summary,json,markdown,table,sarif,html}]
                    [--aidefense-api-url AIDEFENSE_API_URL] [--use-osv]
                    [--llm-provider {anthropic,openai,openai-compatible}]
                    [--llm-consensus-runs N] [--llm-max-tokens N]
-                   [--use-trigger] [--enable-meta] [--adjudicate]
-                   [--policy PRESET_OR_PATH] [--lenient]
-                   [--skill-file FILENAME] [--custom-rules PATH]
+                   [--llm-reasoning-effort LEVEL] [--use-trigger]
+                   [--enable-meta] [--adjudicate] [--policy PRESET_OR_PATH]
+                   [--lenient] [--skill-file FILENAME] [--custom-rules PATH]
                    [--rule-packs PACK [PACK ...]] [--taxonomy PATH]
                    [--threat-mapping PATH]
                    skill_directory
@@ -173,6 +175,10 @@ options:
                         cost)
   --llm-max-tokens N    Maximum output tokens for LLM responses (default:
                         8192). Raise if scans produce truncated JSON.
+  --llm-reasoning-effort LEVEL
+                        Optional LLM reasoning effort: disabled, minimal, low,
+                        medium, high, xhigh, or max. Unset preserves the
+                        provider default.
   --use-trigger         Enable trigger specificity analysis
   --enable-meta         Enable meta-analysis FP filtering (2+ analyzers)
   --adjudicate          Enable per-finding adjudicator: for each deterministic
@@ -231,7 +237,8 @@ usage: cli.py scan-all [-h] [--recursive] [--check-overlap]
                        [--aidefense-api-url AIDEFENSE_API_URL] [--use-osv]
                        [--llm-provider {anthropic,openai,openai-compatible}]
                        [--llm-consensus-runs N] [--llm-max-tokens N]
-                       [--use-trigger] [--enable-meta] [--adjudicate]
+                       [--llm-reasoning-effort LEVEL] [--use-trigger]
+                       [--enable-meta] [--adjudicate]
                        [--policy PRESET_OR_PATH] [--lenient]
                        [--skill-file FILENAME] [--custom-rules PATH]
                        [--rule-packs PACK [PACK ...]] [--taxonomy PATH]
@@ -298,6 +305,10 @@ options:
                         cost)
   --llm-max-tokens N    Maximum output tokens for LLM responses (default:
                         8192). Raise if scans produce truncated JSON.
+  --llm-reasoning-effort LEVEL
+                        Optional LLM reasoning effort: disabled, minimal, low,
+                        medium, high, xhigh, or max. Unset preserves the
+                        provider default.
   --use-trigger         Enable trigger specificity analysis
   --enable-meta         Enable meta-analysis FP filtering (2+ analyzers)
   --adjudicate          Enable per-finding adjudicator: for each deterministic
@@ -357,7 +368,8 @@ usage: cli.py scan-repo [-h] [--recursive | --no-recursive | -r]
                         [--aidefense-api-url AIDEFENSE_API_URL] [--use-osv]
                         [--llm-provider {anthropic,openai,openai-compatible}]
                         [--llm-consensus-runs N] [--llm-max-tokens N]
-                        [--use-trigger] [--enable-meta] [--adjudicate]
+                        [--llm-reasoning-effort LEVEL] [--use-trigger]
+                        [--enable-meta] [--adjudicate]
                         [--policy PRESET_OR_PATH] [--lenient]
                         [--skill-file FILENAME] [--custom-rules PATH]
                         [--rule-packs PACK [PACK ...]] [--taxonomy PATH]
@@ -427,6 +439,10 @@ options:
                         cost)
   --llm-max-tokens N    Maximum output tokens for LLM responses (default:
                         8192). Raise if scans produce truncated JSON.
+  --llm-reasoning-effort LEVEL
+                        Optional LLM reasoning effort: disabled, minimal, low,
+                        medium, high, xhigh, or max. Unset preserves the
+                        provider default.
   --use-trigger         Enable trigger specificity analysis
   --enable-meta         Enable meta-analysis FP filtering (2+ analyzers)
   --adjudicate          Enable per-finding adjudicator: for each deterministic

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -30,7 +30,7 @@ Primary settings for the LLM semantic analyzer.
 | `SKILL_SCANNER_LLM_API_VERSION` | Optional API version for providers that require one. | `2024-02-15-preview` |
 | `SKILL_SCANNER_LLM_USER` | Optional raw Chat Completions user field for OpenAI-compatible routes. | `{"appkey":"your-appkey"}` |
 | `SKILL_SCANNER_LLM_MAX_TOKENS` | Positive integer output-token budget. Overrides the active policy's `llm_analysis.max_output_tokens` value. | `16384` |
-| `SKILL_SCANNER_LLM_REASONING_EFFORT` | Optional reasoning-depth control: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Unset preserves the provider default. | `low` |
+| `SKILL_SCANNER_LLM_REASONING_EFFORT` | Optional reasoning-depth control: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Unset preserves the provider default. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. | `low` |
 | `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` | Skip json_schema and start in plain JSON mode for incompatible proxies. | `true` |
 
 ## Meta Analyzer
@@ -44,7 +44,7 @@ Override LLM settings for the meta (cross-correlation) analyzer. Falls back to t
 | `SKILL_SCANNER_META_LLM_BASE_URL` | Meta-analyzer base URL override. | `(falls back to LLM_BASE_URL)` |
 | `SKILL_SCANNER_META_LLM_API_VERSION` | Meta-analyzer API version override. | `(falls back to LLM_API_VERSION)` |
 | `SKILL_SCANNER_META_LLM_MAX_TOKENS` | Positive integer meta-analysis output budget; falls back to `SKILL_SCANNER_LLM_MAX_TOKENS`. | `32768` |
-| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`. | `low` |
+| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. | `low` |
 
 ## AWS / Bedrock
 
@@ -132,14 +132,14 @@ Paths, allowlists, and other advanced settings.
 | `SKILL_SCANNER_LLM_MAX_TOKENS` | `.env.example`, `skill_scanner/llm_token_options.py` |
 | `SKILL_SCANNER_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_PROVIDER` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
-| `SKILL_SCANNER_LLM_REASONING_EFFORT` | `.env.example` |
+| `SKILL_SCANNER_LLM_REASONING_EFFORT` | `.env.example`, `skill_scanner/llm_reasoning.py` |
 | `SKILL_SCANNER_LLM_USER` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_request_options.py` |
 | `SKILL_SCANNER_META_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_API_VERSION` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_BASE_URL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_MAX_TOKENS` | `.env.example`, `skill_scanner/llm_token_options.py` |
 | `SKILL_SCANNER_META_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
-| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | `.env.example` |
+| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | `.env.example`, `skill_scanner/llm_reasoning.py` |
 | `SKILL_SCANNER_TAXONOMY_PATH` | `skill_scanner/threats/cisco_ai_taxonomy.py` |
 | `SKILL_SCANNER_THREAT_MAPPING_PATH` | `skill_scanner/threats/threats.py` |
 | `VIRUSTOTAL_API_KEY` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py` |

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -108,12 +108,6 @@ Paths, allowlists, and other advanced settings.
 | `SKILL_SCANNER_TAXONOMY_PATH` | Path to a custom Cisco AI taxonomy YAML file (overridden by `--taxonomy`). | `/path/to/taxonomy.yaml` |
 | `SKILL_SCANNER_THREAT_MAPPING_PATH` | Path to a custom threat mapping YAML file (overridden by `--threat-mapping`). | `/path/to/threats.yaml` |
 
-## Other
-
-| Variable | Description | Example |
-|---|---|---|
-| `ANTHROPIC_API_KEY` | Configuration variable discovered in source code. |  |
-
 <details>
 <summary>Source file mapping</summary>
 
@@ -121,7 +115,6 @@ Paths, allowlists, and other advanced settings.
 |---|---|
 | `AI_DEFENSE_API_KEY` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/aidefense_analyzer.py` |
 | `AI_DEFENSE_API_URL` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/aidefense_analyzer.py` |
-| `ANTHROPIC_API_KEY` | `skill_scanner/core/analyzers/behavioral_analyzer.py` |
 | `AWS_PROFILE` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_provider_config.py` |
 | `AWS_REGION` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_provider_config.py` |
 | `AWS_SESSION_TOKEN` | `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_provider_config.py` |
@@ -132,12 +125,12 @@ Paths, allowlists, and other advanced settings.
 | `GEMINI_API_KEY` | `skill_scanner/core/analyzers/llm_provider_config.py` |
 | `GOOGLE_APPLICATION_CREDENTIALS` | `.env.example` |
 | `SKILL_SCANNER_ALLOWED_ROOTS` | `skill_scanner/api/router.py` |
-| `SKILL_SCANNER_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_API_VERSION` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_BASE_URL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` | `.env.example` |
 | `SKILL_SCANNER_LLM_MAX_TOKENS` | `.env.example`, `skill_scanner/llm_token_options.py` |
-| `SKILL_SCANNER_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_PROVIDER` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_LLM_REASONING_EFFORT` | `.env.example` |
 | `SKILL_SCANNER_LLM_USER` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_request_options.py` |

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -30,6 +30,7 @@ Primary settings for the LLM semantic analyzer.
 | `SKILL_SCANNER_LLM_API_VERSION` | Optional API version for providers that require one. | `2024-02-15-preview` |
 | `SKILL_SCANNER_LLM_USER` | Optional raw Chat Completions user field for OpenAI-compatible routes. | `{"appkey":"your-appkey"}` |
 | `SKILL_SCANNER_LLM_MAX_TOKENS` | Positive integer output-token budget. Overrides the active policy's `llm_analysis.max_output_tokens` value. | `16384` |
+| `SKILL_SCANNER_LLM_REASONING_EFFORT` | Optional reasoning-depth control: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Unset preserves the provider default. | `low` |
 | `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` | Skip json_schema and start in plain JSON mode for incompatible proxies. | `true` |
 
 ## Meta Analyzer
@@ -43,6 +44,7 @@ Override LLM settings for the meta (cross-correlation) analyzer. Falls back to t
 | `SKILL_SCANNER_META_LLM_BASE_URL` | Meta-analyzer base URL override. | `(falls back to LLM_BASE_URL)` |
 | `SKILL_SCANNER_META_LLM_API_VERSION` | Meta-analyzer API version override. | `(falls back to LLM_API_VERSION)` |
 | `SKILL_SCANNER_META_LLM_MAX_TOKENS` | Positive integer meta-analysis output budget; falls back to `SKILL_SCANNER_LLM_MAX_TOKENS`. | `32768` |
+| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`. | `low` |
 
 ## AWS / Bedrock
 
@@ -136,13 +138,15 @@ Paths, allowlists, and other advanced settings.
 | `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` | `.env.example` |
 | `SKILL_SCANNER_LLM_MAX_TOKENS` | `.env.example`, `skill_scanner/llm_token_options.py` |
 | `SKILL_SCANNER_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/behavioral_analyzer.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
-| `SKILL_SCANNER_LLM_PROVIDER` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_PROVIDER` | `.env.example`, `skill_scanner/core/analyzer_factory.py`, `skill_scanner/core/analyzers/llm_analyzer.py`, `skill_scanner/core/analyzers/llm_provider_config.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_LLM_REASONING_EFFORT` | `.env.example` |
 | `SKILL_SCANNER_LLM_USER` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzers/llm_request_options.py` |
 | `SKILL_SCANNER_META_LLM_API_KEY` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_API_VERSION` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_BASE_URL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
 | `SKILL_SCANNER_META_LLM_MAX_TOKENS` | `.env.example`, `skill_scanner/llm_token_options.py` |
 | `SKILL_SCANNER_META_LLM_MODEL` | `.env.example`, `skill_scanner/cli/cli.py`, `skill_scanner/core/analyzers/meta_analyzer.py` |
+| `SKILL_SCANNER_META_LLM_REASONING_EFFORT` | `.env.example` |
 | `SKILL_SCANNER_TAXONOMY_PATH` | `skill_scanner/threats/cisco_ai_taxonomy.py` |
 | `SKILL_SCANNER_THREAT_MAPPING_PATH` | `skill_scanner/threats/threats.py` |
 | `VIRUSTOTAL_API_KEY` | `.env.example`, `skill_scanner/config/config.py`, `skill_scanner/core/analyzer_factory.py` |

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. DO NOT EDIT DIRECTLY.
-     Regenerate with: uv run python scripts/generate_reference_docs.py -->
+     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->
 
 # Configuration Reference
 

--- a/docs/user-guide/installation-and-configuration.md
+++ b/docs/user-guide/installation-and-configuration.md
@@ -56,7 +56,7 @@ You only need to set these if you're using the corresponding features. Click a s
 - `SKILL_SCANNER_LLM_BASE_URL`
 - `SKILL_SCANNER_LLM_API_VERSION`
 - `SKILL_SCANNER_LLM_USER` — optional raw Chat Completions `user` field for OpenAI-compatible routes
-- `SKILL_SCANNER_LLM_REASONING_EFFORT` — optional `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; unset preserves the provider default
+- `SKILL_SCANNER_LLM_REASONING_EFFORT` — optional `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; unset preserves the provider default. Direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them.
 - `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` — start in plain JSON mode for proxies that reject `json_schema`
 
 </details>
@@ -68,7 +68,7 @@ You only need to set these if you're using the corresponding features. Click a s
 - `SKILL_SCANNER_META_LLM_MODEL`
 - `SKILL_SCANNER_META_LLM_BASE_URL`
 - `SKILL_SCANNER_META_LLM_API_VERSION`
-- `SKILL_SCANNER_META_LLM_REASONING_EFFORT`
+- `SKILL_SCANNER_META_LLM_REASONING_EFFORT` — direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them
 
 </details>
 

--- a/docs/user-guide/installation-and-configuration.md
+++ b/docs/user-guide/installation-and-configuration.md
@@ -56,6 +56,7 @@ You only need to set these if you're using the corresponding features. Click a s
 - `SKILL_SCANNER_LLM_BASE_URL`
 - `SKILL_SCANNER_LLM_API_VERSION`
 - `SKILL_SCANNER_LLM_USER` — optional raw Chat Completions `user` field for OpenAI-compatible routes
+- `SKILL_SCANNER_LLM_REASONING_EFFORT` — optional `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; unset preserves the provider default
 - `SKILL_SCANNER_LLM_FORCE_JSON_OBJECT` — start in plain JSON mode for proxies that reject `json_schema`
 
 </details>
@@ -67,6 +68,7 @@ You only need to set these if you're using the corresponding features. Click a s
 - `SKILL_SCANNER_META_LLM_MODEL`
 - `SKILL_SCANNER_META_LLM_BASE_URL`
 - `SKILL_SCANNER_META_LLM_API_VERSION`
+- `SKILL_SCANNER_META_LLM_REASONING_EFFORT`
 
 </details>
 

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -101,7 +101,7 @@ def _render_cli_reference() -> str:
         "| `--use-virustotal` | off | Enable VirusTotal hash lookups |",
         "| `--use-aidefense` | off | Enable Cisco AI Defense analyzer |",
         "| `--use-osv` | off | Enable OSV.dev dependency vulnerability scanning (no API key; requires network) |",
-        "| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |",
+        "| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them. |",
         "| `--enable-meta` | off | Enable the meta (cross-correlation) analyzer |",
         "| `--fail-on-findings` | off | Exit non-zero if critical or high findings are reported; equivalent to `--fail-on-severity high` (CI gate) |",
         "| `--fail-on-severity LEVEL` | off | Exit non-zero if findings at or above LEVEL exist (critical, high, medium, low, info) |",
@@ -343,7 +343,7 @@ def _render_api_reference() -> str:
             "- API behavior is policy-aware and mirrors CLI analyzer selection flags.",
             "- API keys for VirusTotal and AI Defense are passed via request headers (`X-VirusTotal-Key`, `X-AIDefense-Key`), not in the JSON body.",
             "- Set `SKILL_SCANNER_ALLOWED_ROOTS` to restrict which directories the API can scan.",
-            "- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default.",
+            "- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default. Direct Google GenAI SDK requests reject configured controls, while LiteLLM-backed Gemini requests support them.",
             "- All `POST` endpoints accept JSON bodies. File upload uses `multipart/form-data`.",
         ]
     )
@@ -389,9 +389,19 @@ def _collect_env_variables() -> dict[str, set[str]]:
         for var in _extract_python_env_variables(text):
             add(var, rel)
 
-    token_options_source = "skill_scanner/llm_token_options.py"
-    for var in ("SKILL_SCANNER_LLM_MAX_TOKENS", "SKILL_SCANNER_META_LLM_MAX_TOKENS"):
-        add(var, token_options_source)
+    runtime_env_sources = {
+        "skill_scanner/llm_token_options.py": (
+            "SKILL_SCANNER_LLM_MAX_TOKENS",
+            "SKILL_SCANNER_META_LLM_MAX_TOKENS",
+        ),
+        "skill_scanner/llm_reasoning.py": (
+            "SKILL_SCANNER_LLM_REASONING_EFFORT",
+            "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
+        ),
+    }
+    for source, variables in runtime_env_sources.items():
+        for var in variables:
+            add(var, source)
 
     return dict(sorted(env_map.items()))
 
@@ -472,7 +482,8 @@ def _describe_env_var(var: str) -> str:
         ),
         "SKILL_SCANNER_LLM_REASONING_EFFORT": (
             "Optional reasoning-depth control: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or "
-            "`max`. Unset preserves the provider default."
+            "`max`. Unset preserves the provider default. Direct Google GenAI SDK requests reject configured "
+            "controls; LiteLLM-backed Gemini requests support them."
         ),
         "SKILL_SCANNER_LLM_FORCE_JSON_OBJECT": "Skip json_schema and start in plain JSON mode for incompatible proxies.",
         "SKILL_SCANNER_META_LLM_API_KEY": "Meta-analyzer API key override.",
@@ -483,7 +494,8 @@ def _describe_env_var(var: str) -> str:
             "Positive integer meta-analysis output budget; falls back to `SKILL_SCANNER_LLM_MAX_TOKENS`."
         ),
         "SKILL_SCANNER_META_LLM_REASONING_EFFORT": (
-            "Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`."
+            "Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`. "
+            "Direct Google GenAI SDK requests reject configured controls; LiteLLM-backed Gemini requests support them."
         ),
         "VIRUSTOTAL_API_KEY": "VirusTotal analyzer API key.",
         "VIRUSTOTAL_UPLOAD_FILES": "Enable upload mode for unknown binaries.",

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -380,24 +380,77 @@ def _collect_env_variables() -> dict[str, set[str]]:
         ROOT / "skill_scanner" / "threats" / "threats.py",
     ]
 
-    env_get_re = re.compile(r'os\.(?:getenv|environ\.get)\(\s*"([A-Z][A-Z0-9_]+)"')
-    env_const_re = re.compile(r'^(_?[A-Z][A-Z0-9_]+)\s*(?::\s*str\s*)?=\s*"([A-Z][A-Z0-9_]+)"', re.MULTILINE)
     for path in candidates:
         if not path.exists():
             continue
         text = path.read_text(encoding="utf-8")
         rel = str(path.relative_to(ROOT))
-        for var in env_get_re.findall(text):
+        for var in _extract_python_env_variables(text):
             add(var, rel)
-        for const_name, var_value in env_const_re.findall(text):
-            if re.search(rf"os\.(?:getenv|environ\.get)\(\s*{const_name}", text):
-                add(var_value, rel)
 
     token_options_source = "skill_scanner/llm_token_options.py"
     for var in ("SKILL_SCANNER_LLM_MAX_TOKENS", "SKILL_SCANNER_META_LLM_MAX_TOKENS"):
         add(var, token_options_source)
 
     return dict(sorted(env_map.items()))
+
+
+def _extract_python_env_variables(source: str) -> set[str]:
+    """Return environment names used by executable ``os`` lookup calls.
+
+    Parsing the syntax tree avoids treating examples in comments or docstrings
+    as supported configuration. Module constants passed to the lookup are
+    resolved so helpers such as ``os.getenv(LLM_REASONING_EFFORT_ENV_VAR)``
+    remain discoverable.
+    """
+    tree = ast.parse(source)
+    constants: dict[str, str] = {}
+    env_name_re = re.compile(r"[A-Z][A-Z0-9_]+")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    constants[target.id] = node.value.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            constants[node.target.id] = node.value.value
+
+    variables: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+
+        function = node.func
+        is_getenv = (
+            isinstance(function, ast.Attribute)
+            and function.attr == "getenv"
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "os"
+        )
+        is_environ_get = (
+            isinstance(function, ast.Attribute)
+            and function.attr == "get"
+            and isinstance(function.value, ast.Attribute)
+            and function.value.attr == "environ"
+            and isinstance(function.value.value, ast.Name)
+            and function.value.value.id == "os"
+        )
+        if not (is_getenv or is_environ_get):
+            continue
+
+        argument = node.args[0]
+        value = argument.value if isinstance(argument, ast.Constant) and isinstance(argument.value, str) else None
+        if isinstance(argument, ast.Name):
+            value = constants.get(argument.id)
+        if value and env_name_re.fullmatch(value):
+            variables.add(value)
+
+    return variables
 
 
 def _describe_env_var(var: str) -> str:

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -32,10 +32,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 REFERENCE_DIR = ROOT / "docs" / "reference"
+REFERENCE_PYTHON = (3, 12)
 
 GENERATED_BANNER = (
     "<!-- GENERATED FILE. DO NOT EDIT DIRECTLY.\n"
-    "     Regenerate with: uv run python scripts/generate_reference_docs.py -->\n\n"
+    "     Regenerate with: uv run --python 3.12 python scripts/generate_reference_docs.py -->\n\n"
 )
 
 
@@ -738,6 +739,15 @@ def _write_or_check(outputs: dict[Path, str], check: bool) -> int:
 
 
 def main() -> int:
+    if sys.version_info[:2] != REFERENCE_PYTHON:
+        expected = ".".join(str(part) for part in REFERENCE_PYTHON)
+        actual = f"{sys.version_info.major}.{sys.version_info.minor}"
+        print(
+            f"Reference output depends on argparse formatting; use Python {expected} (running {actual}).",
+            file=sys.stderr,
+        )
+        return 2
+
     parser = argparse.ArgumentParser(description="Generate reference docs from source of truth.")
     parser.add_argument("--check", action="store_true", help="Fail if generated outputs differ from committed files")
     args = parser.parse_args()

--- a/scripts/generate_reference_docs.py
+++ b/scripts/generate_reference_docs.py
@@ -99,6 +99,8 @@ def _render_cli_reference() -> str:
         "| `--use-behavioral` | off | Enable the behavioral analyzer |",
         "| `--use-virustotal` | off | Enable VirusTotal hash lookups |",
         "| `--use-aidefense` | off | Enable Cisco AI Defense analyzer |",
+        "| `--use-osv` | off | Enable OSV.dev dependency vulnerability scanning (no API key; requires network) |",
+        "| `--llm-reasoning-effort LEVEL` | provider default | Optional reasoning depth: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |",
         "| `--enable-meta` | off | Enable the meta (cross-correlation) analyzer |",
         "| `--fail-on-findings` | off | Exit non-zero if critical or high findings are reported; equivalent to `--fail-on-severity high` (CI gate) |",
         "| `--fail-on-severity LEVEL` | off | Exit non-zero if findings at or above LEVEL exist (critical, high, medium, low, info) |",
@@ -340,6 +342,7 @@ def _render_api_reference() -> str:
             "- API behavior is policy-aware and mirrors CLI analyzer selection flags.",
             "- API keys for VirusTotal and AI Defense are passed via request headers (`X-VirusTotal-Key`, `X-AIDefense-Key`), not in the JSON body.",
             "- Set `SKILL_SCANNER_ALLOWED_ROOTS` to restrict which directories the API can scan.",
+            "- `llm_reasoning_effort` accepts `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; omission preserves the provider default.",
             "- All `POST` endpoints accept JSON bodies. File upload uses `multipart/form-data`.",
         ]
     )
@@ -363,6 +366,7 @@ def _collect_env_variables() -> dict[str, set[str]]:
     candidates = [
         ROOT / "skill_scanner" / "config" / "config.py",
         ROOT / "skill_scanner" / "llm_token_options.py",
+        ROOT / "skill_scanner" / "llm_reasoning.py",
         ROOT / "skill_scanner" / "cli" / "cli.py",
         ROOT / "skill_scanner" / "api" / "router.py",
         ROOT / "skill_scanner" / "core" / "analyzers" / "llm_analyzer.py",
@@ -412,6 +416,10 @@ def _describe_env_var(var: str) -> str:
             "Positive integer output-token budget. Overrides the active policy's "
             "`llm_analysis.max_output_tokens` value."
         ),
+        "SKILL_SCANNER_LLM_REASONING_EFFORT": (
+            "Optional reasoning-depth control: `disabled`, `minimal`, `low`, `medium`, `high`, `xhigh`, or "
+            "`max`. Unset preserves the provider default."
+        ),
         "SKILL_SCANNER_LLM_FORCE_JSON_OBJECT": "Skip json_schema and start in plain JSON mode for incompatible proxies.",
         "SKILL_SCANNER_META_LLM_API_KEY": "Meta-analyzer API key override.",
         "SKILL_SCANNER_META_LLM_MODEL": "Meta-analyzer model override.",
@@ -419,6 +427,9 @@ def _describe_env_var(var: str) -> str:
         "SKILL_SCANNER_META_LLM_API_VERSION": "Meta-analyzer API version override.",
         "SKILL_SCANNER_META_LLM_MAX_TOKENS": (
             "Positive integer meta-analysis output budget; falls back to `SKILL_SCANNER_LLM_MAX_TOKENS`."
+        ),
+        "SKILL_SCANNER_META_LLM_REASONING_EFFORT": (
+            "Meta-analyzer reasoning-depth override; falls back to `SKILL_SCANNER_LLM_REASONING_EFFORT`."
         ),
         "VIRUSTOTAL_API_KEY": "VirusTotal analyzer API key.",
         "VIRUSTOTAL_UPLOAD_FILES": "Enable upload mode for unknown binaries.",
@@ -457,6 +468,7 @@ _ENV_VAR_GROUPS: list[tuple[str, str, list[str]]] = [
             "SKILL_SCANNER_LLM_API_VERSION",
             "SKILL_SCANNER_LLM_USER",
             "SKILL_SCANNER_LLM_MAX_TOKENS",
+            "SKILL_SCANNER_LLM_REASONING_EFFORT",
             "SKILL_SCANNER_LLM_FORCE_JSON_OBJECT",
         ],
     ),
@@ -469,6 +481,7 @@ _ENV_VAR_GROUPS: list[tuple[str, str, list[str]]] = [
             "SKILL_SCANNER_META_LLM_BASE_URL",
             "SKILL_SCANNER_META_LLM_API_VERSION",
             "SKILL_SCANNER_META_LLM_MAX_TOKENS",
+            "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
         ],
     ),
     (
@@ -520,12 +533,14 @@ _ENV_VAR_EXAMPLES: dict[str, str] = {
     "SKILL_SCANNER_LLM_API_VERSION": "2024-02-15-preview",
     "SKILL_SCANNER_LLM_USER": '{"appkey":"your-appkey"}',
     "SKILL_SCANNER_LLM_MAX_TOKENS": "16384",
+    "SKILL_SCANNER_LLM_REASONING_EFFORT": "low",
     "SKILL_SCANNER_LLM_FORCE_JSON_OBJECT": "true",
     "SKILL_SCANNER_META_LLM_API_KEY": "(falls back to LLM_API_KEY)",
     "SKILL_SCANNER_META_LLM_MODEL": "(falls back to LLM_MODEL)",
     "SKILL_SCANNER_META_LLM_BASE_URL": "(falls back to LLM_BASE_URL)",
     "SKILL_SCANNER_META_LLM_API_VERSION": "(falls back to LLM_API_VERSION)",
     "SKILL_SCANNER_META_LLM_MAX_TOKENS": "32768",
+    "SKILL_SCANNER_META_LLM_REASONING_EFFORT": "low",
     "AWS_REGION": "us-east-1",
     "AWS_PROFILE": "my-bedrock-profile",
     "AWS_SESSION_TOKEN": "(temporary STS token)",

--- a/skill_scanner/api/router.py
+++ b/skill_scanner/api/router.py
@@ -47,6 +47,7 @@ from ..core.analyzer_factory import build_analyzers
 from ..core.exceptions import SkillLoadError
 from ..core.scan_policy import ScanPolicy
 from ..core.scanner import SkillScanner
+from ..llm_reasoning import LLMReasoningEffort, ReasoningConfigurationError
 from ..llm_token_options import resolve_llm_max_tokens
 from ..utils.logging_context import scan_log_context
 
@@ -216,6 +217,10 @@ class ScanRequest(BaseModel):
         gt=0,
         description="Maximum output tokens for LLM and meta-analysis responses",
     )
+    llm_reasoning_effort: LLMReasoningEffort | None = Field(
+        None,
+        description="Optional LLM reasoning effort; unset preserves the provider default",
+    )
 
 
 class ScanResponse(BaseModel):
@@ -267,6 +272,10 @@ class BatchScanRequest(BaseModel):
         gt=0,
         description="Maximum output tokens for LLM and meta-analysis responses",
     )
+    llm_reasoning_effort: LLMReasoningEffort | None = Field(
+        None,
+        description="Optional LLM reasoning effort; unset preserves the provider default",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +323,7 @@ def _build_analyzers(
     use_osv: bool = False,
     llm_consensus_runs: int = 1,
     llm_max_tokens: int | None = None,
+    llm_reasoning_effort: str | None = None,
 ):
     """Build the analyzer list — delegates to the centralized factory."""
     return build_analyzers(
@@ -332,6 +342,7 @@ def _build_analyzers(
         use_osv=use_osv,
         llm_consensus_runs=llm_consensus_runs,
         llm_max_tokens=llm_max_tokens,
+        llm_reasoning_effort=llm_reasoning_effort,
     )
 
 
@@ -451,6 +462,7 @@ async def scan_skill(
                 use_osv=request.use_osv,
                 llm_consensus_runs=request.llm_consensus_runs,
                 llm_max_tokens=request.llm_max_tokens,
+                llm_reasoning_effort=request.llm_reasoning_effort,
             )
             scanner = SkillScanner(analyzers=analyzers, policy=policy)
             return scanner.scan_skill(skill_dir)
@@ -483,6 +495,8 @@ async def scan_skill(
                             meta=True,
                             default=policy.llm_analysis.max_output_tokens if policy else 8192,
                         ),
+                        provider=request.llm_provider,
+                        reasoning_effort=request.llm_reasoning_effort,
                     )
                     loader = SkillLoader()
                     skill = loader.load_skill(skill_dir)
@@ -502,6 +516,8 @@ async def scan_skill(
                     result.analyzers_used.append("meta_analyzer")
                     if merge_meta_analyzer_usage is not None:
                         merge_meta_analyzer_usage(result, meta_analyzer)
+                except ReasoningConfigurationError:
+                    raise
                 except Exception as meta_error:
                     logger.warning("Meta-analysis failed: %s", meta_error)
 
@@ -548,6 +564,10 @@ async def scan_uploaded_skill(
         None,
         gt=0,
         description="Maximum output tokens for LLM and meta-analysis responses",
+    ),
+    llm_reasoning_effort: LLMReasoningEffort | None = Form(
+        None,
+        description="Optional LLM reasoning effort; unset preserves the provider default",
     ),
 ):
     """Scan an uploaded skill package (ZIP file)."""
@@ -644,6 +664,7 @@ async def scan_uploaded_skill(
             enable_meta=enable_meta,
             llm_consensus_runs=llm_consensus_runs,
             llm_max_tokens=llm_max_tokens,
+            llm_reasoning_effort=llm_reasoning_effort,
         )
 
         return await scan_skill(request, vt_api_key=vt_api_key, aidefense_api_key=aidefense_api_key)
@@ -742,6 +763,7 @@ def _run_batch_scan(
             use_osv=request.use_osv,
             llm_consensus_runs=request.llm_consensus_runs,
             llm_max_tokens=request.llm_max_tokens,
+            llm_reasoning_effort=request.llm_reasoning_effort,
         )
 
         scanner = SkillScanner(analyzers=analyzers, policy=policy)
@@ -768,6 +790,8 @@ def _run_batch_scan(
                         meta=True,
                         default=policy_ref.llm_analysis.max_output_tokens if policy_ref else 8192,
                     ),
+                    provider=request.llm_provider,
+                    reasoning_effort=request.llm_reasoning_effort,
                 )
                 for result in report_ref.scan_results:
                     if result.findings:
@@ -797,6 +821,8 @@ def _run_batch_scan(
 
             try:
                 asyncio.run(_run_batch_meta(scanner, report, policy))
+            except ReasoningConfigurationError:
+                raise
             except Exception:
                 pass
 

--- a/skill_scanner/cli/cli.py
+++ b/skill_scanner/cli/cli.py
@@ -40,6 +40,7 @@ from ..core.reporters.sarif_reporter import SARIFReporter
 from ..core.reporters.table_reporter import TableReporter
 from ..core.scan_policy import ScanPolicy
 from ..core.scanner import SkillScanner
+from ..llm_reasoning import LLM_REASONING_EFFORT_VALUES, ReasoningConfigurationError
 from ..llm_token_options import resolve_llm_max_tokens
 
 # Optional LLM analyzer (needed only for LLM_AVAILABLE check)
@@ -147,6 +148,7 @@ def _build_analyzers(policy: ScanPolicy, args: argparse.Namespace, status: Calla
         llm_provider=getattr(args, "llm_provider", None),
         llm_consensus_runs=getattr(args, "llm_consensus_runs", 1),
         llm_max_tokens=getattr(args, "llm_max_tokens", None),
+        llm_reasoning_effort=getattr(args, "llm_reasoning_effort", None),
     )
 
     # Emit status messages for the optional analyzers that were activated.
@@ -175,6 +177,7 @@ def _build_meta_analyzer(
     status: Callable[[str], None],
     policy=None,
     max_tokens: int | None = None,
+    reasoning_effort: str | None = None,
 ):
     """Optionally build a MetaAnalyzer if ``--enable-meta`` is set."""
     if not getattr(args, "enable_meta", False):
@@ -199,6 +202,8 @@ def _build_meta_analyzer(
             api_key=meta_api_key,
             base_url=meta_base_url,
             api_version=meta_api_version,
+            provider=getattr(args, "llm_provider", None),
+            reasoning_effort=reasoning_effort,
             policy=policy,
         )
         effective_max_tokens = resolve_llm_max_tokens(
@@ -210,6 +215,8 @@ def _build_meta_analyzer(
         meta = MetaAnalyzer(**kwargs)
         status("Using Meta-Analyzer for false positive filtering and finding prioritization")
         return meta
+    except ReasoningConfigurationError:
+        raise
     except Exception as e:
         logger.warning("Could not initialise Meta-Analyzer: %s", e)
         return None
@@ -405,7 +412,15 @@ def scan_command(args: argparse.Namespace) -> int:
         policy.adjudicator.enabled = True
     analyzers = _build_analyzers(policy, args, status)
     llm_max_tokens = getattr(args, "llm_max_tokens", None)
-    meta_analyzer = _build_meta_analyzer(args, len(analyzers), status, policy=policy, max_tokens=llm_max_tokens)
+    llm_reasoning_effort = getattr(args, "llm_reasoning_effort", None)
+    meta_analyzer = _build_meta_analyzer(
+        args,
+        len(analyzers),
+        status,
+        policy=policy,
+        max_tokens=llm_max_tokens,
+        reasoning_effort=llm_reasoning_effort,
+    )
 
     scanner = SkillScanner(analyzers=analyzers, policy=policy)
     lenient = getattr(args, "lenient", False)
@@ -499,7 +514,15 @@ def scan_all_command(args: argparse.Namespace) -> int:
         policy.adjudicator.enabled = True
     analyzers = _build_analyzers(policy, args, status)
     llm_max_tokens = getattr(args, "llm_max_tokens", None)
-    meta_analyzer = _build_meta_analyzer(args, len(analyzers), status, policy=policy, max_tokens=llm_max_tokens)
+    llm_reasoning_effort = getattr(args, "llm_reasoning_effort", None)
+    meta_analyzer = _build_meta_analyzer(
+        args,
+        len(analyzers),
+        status,
+        policy=policy,
+        max_tokens=llm_max_tokens,
+        reasoning_effort=llm_reasoning_effort,
+    )
 
     scanner = SkillScanner(analyzers=analyzers, policy=policy)
 
@@ -628,7 +651,15 @@ def scan_repo_command(args: argparse.Namespace) -> int:
                 policy.adjudicator.enabled = True
             analyzers = _build_analyzers(policy, args, status)
             llm_max_tokens = getattr(args, "llm_max_tokens", None)
-            meta_analyzer = _build_meta_analyzer(args, len(analyzers), status, policy=policy, max_tokens=llm_max_tokens)
+            llm_reasoning_effort = getattr(args, "llm_reasoning_effort", None)
+            meta_analyzer = _build_meta_analyzer(
+                args,
+                len(analyzers),
+                status,
+                policy=policy,
+                max_tokens=llm_max_tokens,
+                reasoning_effort=llm_reasoning_effort,
+            )
 
             scanner = SkillScanner(analyzers=analyzers, policy=policy)
 
@@ -984,6 +1015,16 @@ def _add_common_scan_flags(parser: argparse.ArgumentParser) -> None:
         metavar="N",
         help="Maximum output tokens for LLM responses (default: 8192). Raise if scans produce truncated JSON.",
     )
+    parser.add_argument(
+        "--llm-reasoning-effort",
+        choices=LLM_REASONING_EFFORT_VALUES,
+        default=None,
+        metavar="LEVEL",
+        help=(
+            "Optional LLM reasoning effort: disabled, minimal, low, medium, high, xhigh, or max. "
+            "Unset preserves the provider default."
+        ),
+    )
     parser.add_argument("--use-trigger", action="store_true", help="Enable trigger specificity analysis")
     parser.add_argument("--enable-meta", action="store_true", help="Enable meta-analysis FP filtering (2+ analyzers)")
     parser.add_argument(
@@ -1148,7 +1189,11 @@ def main() -> int:
     }
     handler = dispatch.get(args.command)
     if handler:
-        return handler(args)
+        try:
+            return handler(args)
+        except ReasoningConfigurationError as exc:
+            print(f"LLM reasoning configuration error: {exc}", file=sys.stderr)
+            return 1
 
     parser.print_help()
     return 1

--- a/skill_scanner/config/config.py
+++ b/skill_scanner/config/config.py
@@ -24,6 +24,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..llm_reasoning import resolve_llm_reasoning_effort
 from ..llm_token_options import resolve_llm_max_tokens
 
 
@@ -46,6 +47,7 @@ class Config:
     llm_rate_limit_delay: float = 2.0
     llm_max_retries: int = 3
     llm_timeout: int = 120
+    llm_reasoning_effort: str | None = None
 
     # AWS Bedrock Configuration
     aws_region_name: str = "us-east-1"
@@ -89,6 +91,10 @@ class Config:
         # Malformed/non-positive environment values are rejected instead of
         # silently producing provider errors or zero-length responses.
         self.llm_max_tokens = resolve_llm_max_tokens(self.llm_max_tokens)
+
+        # Explicit constructor value > scanner-wide environment > unset.
+        # Unset deliberately emits no reasoning/thinking request fields.
+        self.llm_reasoning_effort = resolve_llm_reasoning_effort(self.llm_reasoning_effort)
 
         # Optional raw Chat Completions user field for OpenAI-compatible routes
         if self.llm_user is not None and not self.llm_user.strip():

--- a/skill_scanner/core/analyzer_factory.py
+++ b/skill_scanner/core/analyzer_factory.py
@@ -31,6 +31,7 @@ import logging
 import os
 from pathlib import Path
 
+from ..llm_reasoning import ReasoningConfigurationError
 from ..llm_token_options import resolve_llm_max_tokens
 from .analyzers.base import BaseAnalyzer
 from .analyzers.bytecode_analyzer import BytecodeAnalyzer
@@ -104,6 +105,7 @@ def build_analyzers(
     use_osv: bool = False,
     llm_consensus_runs: int = 1,
     llm_max_tokens: int | None = None,
+    llm_reasoning_effort: str | None = None,
 ) -> list[BaseAnalyzer]:
     """Build the full analyzer list (core + optional).
 
@@ -123,6 +125,9 @@ def build_analyzers(
             policy's ``llm_analysis.max_output_tokens`` value.
         llm_user: Optional raw Chat Completions user field for
             OpenAI-compatible LLM routes.
+        llm_reasoning_effort: Optional reasoning-depth control. When *None*,
+            LLM clients resolve ``SKILL_SCANNER_LLM_REASONING_EFFORT`` and
+            otherwise preserve provider defaults.
 
     Returns:
         A list of analyzer instances ready to be passed to
@@ -140,7 +145,12 @@ def build_analyzers(
         try:
             from .analyzers.behavioral_analyzer import BehavioralAnalyzer
 
-            analyzers.append(BehavioralAnalyzer())
+            analyzers.append(
+                BehavioralAnalyzer(
+                    llm_provider=llm_provider,
+                    llm_reasoning_effort=llm_reasoning_effort,
+                )
+            )
         except (ImportError, ValueError, TypeError) as exc:
             logger.warning("Could not load behavioral analyzer: %s", exc)
 
@@ -167,12 +177,17 @@ def build_analyzers(
                 api_version=api_version,
                 provider=provider,
                 llm_user=llm_user,
+                reasoning_effort=llm_reasoning_effort,
                 policy=policy,
                 **extra_kwargs,
             )
             if llm_consensus_runs > 1:
                 llm.consensus_runs = llm_consensus_runs
             analyzers.append(llm)
+        except ReasoningConfigurationError:
+            # A requested LLM control must never turn ``--use-llm`` into a
+            # successful deterministic-only scan.
+            raise
         except (ImportError, ValueError, TypeError) as exc:
             logger.warning("Could not load LLM analyzer: %s", exc)
 

--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
@@ -31,8 +31,14 @@ import logging
 import os
 from typing import Any
 
+from .....llm_reasoning import build_litellm_reasoning_params, resolve_llm_reasoning_effort
+from ...llm_provider_config import ProviderConfig
 from ...llm_request_handler import _TEMPERATURE_UNSET, _resolve_temperature
-from ...llm_request_options import resolve_llm_user, supports_openai_user_param
+from ...llm_request_options import (
+    normalize_litellm_model_for_provider,
+    resolve_llm_user,
+    supports_openai_user_param,
+)
 
 try:
     from litellm import acompletion
@@ -64,7 +70,9 @@ class AlignmentLLMClient:
         api_key: str | None = None,
         base_url: str | None = None,
         api_version: str | None = None,
+        provider: str | None = None,
         llm_user: str | None = None,
+        reasoning_effort: str | None = None,
         temperature: Any = _TEMPERATURE_UNSET,
         max_tokens: int = 4096,
         timeout: int = 120,
@@ -76,7 +84,10 @@ class AlignmentLLMClient:
             api_key: API key (or resolved from environment)
             base_url: Optional base URL for API
             api_version: Optional API version
+            provider: Optional provider override used for request semantics
             llm_user: Optional raw Chat Completions user field for OpenAI-compatible routes
+            reasoning_effort: Optional reasoning-depth control. When omitted,
+                resolves from ``SKILL_SCANNER_LLM_REASONING_EFFORT``.
             temperature: Temperature for responses.  Pass ``None`` to omit
                 ``temperature`` from the request - required for models that
                 reject it (Claude 4.x via Bedrock, OpenAI o1-series).
@@ -92,17 +103,38 @@ class AlignmentLLMClient:
         if not LITELLM_AVAILABLE:
             raise ImportError("litellm is required for alignment verification. Install with: pip install litellm")
 
-        # Resolve API key from environment if not provided
-        self._api_key = api_key or self._resolve_api_key(model)
-        if not self._api_key and not self._is_bedrock_model(model):
-            raise ValueError("LLM provider API key is required for alignment verification")
-
-        # Store configuration for per-request usage
-        self._model = model
-        self._base_url = base_url
-        self._api_version = api_version
-        self._provider = os.getenv("SKILL_SCANNER_LLM_PROVIDER")
+        # Store configuration for per-request usage. OrcaRouter uses the shared
+        # provider configuration so model normalization, key resolution, and
+        # its default OpenAI-compatible endpoint stay consistent with the main
+        # and meta LLM clients.
+        raw_provider = provider or os.getenv("SKILL_SCANNER_LLM_PROVIDER")
+        self._provider = raw_provider.strip().lower().replace("_", "-") if raw_provider else None
+        self._provider_config: ProviderConfig | None = None
         self._llm_user = resolve_llm_user(llm_user)
+        if self._provider == "orcarouter" or model.lower().startswith("orcarouter/"):
+            self._provider_config = ProviderConfig(
+                model=model,
+                api_key=api_key,
+                base_url=base_url,
+                api_version=api_version,
+                provider=self._provider,
+                llm_user=self._llm_user,
+            )
+            self._provider_config.validate()
+            self._api_key = self._provider_config.api_key
+            self._base_url = self._provider_config.base_url
+            self._api_version = self._provider_config.api_version
+            self._provider = self._provider_config.provider
+            self._model = self._provider_config.model
+            self._llm_user = self._provider_config.llm_user
+        else:
+            self._api_key = api_key or self._resolve_api_key(model)
+            if not self._api_key and not self._is_bedrock_model(model):
+                raise ValueError("LLM provider API key is required for alignment verification")
+            self._base_url = base_url
+            self._api_version = api_version
+            self._model = normalize_litellm_model_for_provider(model, self._provider)
+        self._reasoning_effort = resolve_llm_reasoning_effort(reasoning_effort)
         self._temperature = _resolve_temperature(temperature, "SKILL_SCANNER_LLM_TEMPERATURE", default=0.1)
         self._max_tokens = max_tokens
         self._timeout = timeout
@@ -219,9 +251,17 @@ class AlignmentLLMClient:
             }
             if self._temperature is not None:
                 request_params["temperature"] = self._temperature
+            request_params.update(
+                build_litellm_reasoning_params(
+                    self._reasoning_effort,
+                    model=self._model,
+                    provider=self._provider,
+                )
+            )
 
-            # Add API key if available
-            if self._api_key:
+            if self._provider_config is not None:
+                request_params.update(self._provider_config.get_request_params())
+            elif self._api_key:
                 request_params["api_key"] = self._api_key
 
             # Only enable JSON mode for supported models/providers
@@ -230,9 +270,9 @@ class AlignmentLLMClient:
                 request_params["response_format"] = {"type": "json_object"}
 
             # Add optional parameters if configured
-            if self._base_url:
+            if self._provider_config is None and self._base_url:
                 request_params["api_base"] = self._base_url
-            if self._api_version:
+            if self._provider_config is None and self._api_version:
                 request_params["api_version"] = self._api_version
 
             if self._llm_user and supports_openai_user_param(self._model, self._provider):

--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
@@ -70,12 +70,13 @@ class AlignmentLLMClient:
         api_key: str | None = None,
         base_url: str | None = None,
         api_version: str | None = None,
-        provider: str | None = None,
         llm_user: str | None = None,
-        reasoning_effort: str | None = None,
         temperature: Any = _TEMPERATURE_UNSET,
         max_tokens: int = 4096,
         timeout: int = 120,
+        *,
+        provider: str | None = None,
+        reasoning_effort: str | None = None,
     ):
         """Initialize the alignment LLM client.
 
@@ -84,10 +85,7 @@ class AlignmentLLMClient:
             api_key: API key (or resolved from environment)
             base_url: Optional base URL for API
             api_version: Optional API version
-            provider: Optional provider override used for request semantics
             llm_user: Optional raw Chat Completions user field for OpenAI-compatible routes
-            reasoning_effort: Optional reasoning-depth control. When omitted,
-                resolves from ``SKILL_SCANNER_LLM_REASONING_EFFORT``.
             temperature: Temperature for responses.  Pass ``None`` to omit
                 ``temperature`` from the request - required for models that
                 reject it (Claude 4.x via Bedrock, OpenAI o1-series).
@@ -95,6 +93,9 @@ class AlignmentLLMClient:
                 (numeric value or ``"none"``).
             max_tokens: Max tokens for responses
             timeout: Request timeout in seconds
+            provider: Optional provider override used for request semantics
+            reasoning_effort: Optional reasoning-depth control. When omitted,
+                resolves from ``SKILL_SCANNER_LLM_REASONING_EFFORT``.
 
         Raises:
             ImportError: If litellm is not available

--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
@@ -55,11 +55,12 @@ class AlignmentOrchestrator:
         llm_model: str = "gemini/gemini-2.0-flash",
         llm_api_key: str | None = None,
         llm_base_url: str | None = None,
-        llm_provider: str | None = None,
         llm_temperature: Any = _TEMPERATURE_UNSET,
-        llm_reasoning_effort: str | None = None,
         llm_max_tokens: int = 4096,
         llm_timeout: int = 120,
+        *,
+        llm_provider: str | None = None,
+        llm_reasoning_effort: str | None = None,
     ):
         """Initialize alignment orchestrator.
 
@@ -67,11 +68,11 @@ class AlignmentOrchestrator:
             llm_model: LLM model to use (e.g., "gemini/gemini-2.0-flash")
             llm_api_key: API key for the LLM provider
             llm_base_url: Optional base URL for LLM API
-            llm_provider: Optional provider override used for request semantics
             llm_temperature: Temperature for LLM responses
-            llm_reasoning_effort: Optional reasoning-depth control
             llm_max_tokens: Max tokens for LLM responses
             llm_timeout: Timeout for LLM requests in seconds
+            llm_provider: Optional provider override used for request semantics
+            llm_reasoning_effort: Optional reasoning-depth control
 
         Raises:
             ValueError: If LLM API key is not provided

--- a/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
@@ -55,7 +55,9 @@ class AlignmentOrchestrator:
         llm_model: str = "gemini/gemini-2.0-flash",
         llm_api_key: str | None = None,
         llm_base_url: str | None = None,
+        llm_provider: str | None = None,
         llm_temperature: Any = _TEMPERATURE_UNSET,
+        llm_reasoning_effort: str | None = None,
         llm_max_tokens: int = 4096,
         llm_timeout: int = 120,
     ):
@@ -65,7 +67,9 @@ class AlignmentOrchestrator:
             llm_model: LLM model to use (e.g., "gemini/gemini-2.0-flash")
             llm_api_key: API key for the LLM provider
             llm_base_url: Optional base URL for LLM API
+            llm_provider: Optional provider override used for request semantics
             llm_temperature: Temperature for LLM responses
+            llm_reasoning_effort: Optional reasoning-depth control
             llm_max_tokens: Max tokens for LLM responses
             llm_timeout: Timeout for LLM requests in seconds
 
@@ -80,7 +84,9 @@ class AlignmentOrchestrator:
             model=llm_model,
             api_key=llm_api_key,
             base_url=llm_base_url,
+            provider=llm_provider,
             temperature=llm_temperature,
+            reasoning_effort=llm_reasoning_effort,
             max_tokens=llm_max_tokens,
             timeout=llm_timeout,
         )
@@ -89,6 +95,8 @@ class AlignmentOrchestrator:
             model=llm_model,
             api_key=llm_api_key,
             base_url=llm_base_url,
+            provider=llm_provider,
+            reasoning_effort=llm_reasoning_effort,
         )
 
         # Track analysis statistics

--- a/skill_scanner/core/analyzers/behavioral/alignment/threat_vulnerability_classifier.py
+++ b/skill_scanner/core/analyzers/behavioral/alignment/threat_vulnerability_classifier.py
@@ -46,6 +46,8 @@ class ThreatVulnerabilityClassifier:
         model: str = "gemini/gemini-2.0-flash",
         api_key: str | None = None,
         base_url: str | None = None,
+        provider: str | None = None,
+        reasoning_effort: str | None = None,
     ):
         """Initialize the threat/vulnerability classifier.
 
@@ -53,12 +55,16 @@ class ThreatVulnerabilityClassifier:
             model: LLM model to use
             api_key: API key for the LLM provider
             base_url: Optional base URL for LLM API
+            provider: Optional provider override used for request semantics
+            reasoning_effort: Optional reasoning-depth control
         """
         self.logger = logging.getLogger(__name__)
         self.llm_client = AlignmentLLMClient(
             model=model,
             api_key=api_key,
             base_url=base_url,
+            provider=provider,
+            reasoning_effort=reasoning_effort,
         )
         self._classification_prompt_template = self._get_classification_prompt()
 

--- a/skill_scanner/core/analyzers/behavioral_analyzer.py
+++ b/skill_scanner/core/analyzers/behavioral_analyzer.py
@@ -79,6 +79,8 @@ class BehavioralAnalyzer(BaseAnalyzer):
         use_alignment_verification: bool = False,
         llm_model: str | None = None,
         llm_api_key: str | None = None,
+        llm_provider: str | None = None,
+        llm_reasoning_effort: str | None = None,
     ):
         """
         Initialize behavioral analyzer.
@@ -87,6 +89,8 @@ class BehavioralAnalyzer(BaseAnalyzer):
             use_alignment_verification: Enable LLM-powered alignment verification
             llm_model: LLM model for alignment verification (e.g., "gemini/gemini-2.0-flash")
             llm_api_key: API key for the LLM provider (or resolved from environment)
+            llm_provider: Optional provider override used for request semantics
+            llm_reasoning_effort: Optional reasoning-depth control for alignment calls
 
         Note:
             This analyzer processes Python (.py) files with full AST-based dataflow
@@ -113,6 +117,8 @@ class BehavioralAnalyzer(BaseAnalyzer):
                     self.alignment_orchestrator = AlignmentOrchestrator(
                         llm_model=model,
                         llm_api_key=api_key,
+                        llm_provider=llm_provider,
+                        llm_reasoning_effort=llm_reasoning_effort,
                     )
                     logger.info("Alignment verification enabled with %s", model)
                 else:

--- a/skill_scanner/core/analyzers/llm_analyzer.py
+++ b/skill_scanner/core/analyzers/llm_analyzer.py
@@ -160,6 +160,7 @@ class LLMAnalyzer(BaseAnalyzer):
         # Provider selection (can be enum or string)
         provider: str | None = None,
         llm_user: str | None = None,
+        reasoning_effort: str | None = None,
         # Policy (optional – uses generous defaults when omitted)
         policy: ScanPolicy | None = None,
     ):
@@ -189,6 +190,9 @@ class LLMAnalyzer(BaseAnalyzer):
             provider: LLM provider name (e.g., "openai", "anthropic", "aws-bedrock", etc.)
                 Can be enum or string (e.g., "openai", "anthropic", "aws-bedrock")
             llm_user: Optional raw Chat Completions user field for OpenAI-compatible routes.
+            reasoning_effort: Optional reasoning-depth control. When omitted,
+                resolves from ``SKILL_SCANNER_LLM_REASONING_EFFORT``. Use
+                ``disabled`` for explicit provider-aware thinking disablement.
             policy: Scan policy providing LLM context budget thresholds.
                 When ``None``, generous defaults from ``LLMAnalysisPolicy()``
                 are used.
@@ -257,6 +261,7 @@ class LLMAnalyzer(BaseAnalyzer):
             max_retries=max_retries,
             rate_limit_delay=rate_limit_delay,
             timeout=timeout,
+            reasoning_effort=reasoning_effort,
         )
 
         self.prompt_builder = PromptBuilder()
@@ -275,6 +280,7 @@ class LLMAnalyzer(BaseAnalyzer):
         self.max_retries = max_retries
         self.rate_limit_delay = rate_limit_delay
         self.timeout = timeout
+        self.reasoning_effort = self.request_handler.reasoning_effort
 
         # Cumulative token usage across all LLM calls in the most recent analyze() run.
         self._llm_usage: LLMTokenUsage = _empty_token_usage()

--- a/skill_scanner/core/analyzers/llm_provider_config.py
+++ b/skill_scanner/core/analyzers/llm_provider_config.py
@@ -25,7 +25,11 @@ import importlib.util
 import logging
 import os
 
-from .llm_request_options import resolve_llm_user, supports_openai_user_param
+from .llm_request_options import (
+    normalize_litellm_model_for_provider,
+    resolve_llm_user,
+    supports_openai_user_param,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -172,9 +176,7 @@ class ProviderConfig:
 
     def _normalize_openai_compatible_model_name(self, model: str) -> str:
         """Force LiteLLM's OpenAI adapter for arbitrary OpenAI-compatible model names."""
-        if model.lower().startswith("openai/"):
-            return model
-        return f"openai/{model}"
+        return normalize_litellm_model_for_provider(model, "openai-compatible")
 
     def _normalize_orcarouter_model_name(self, model: str) -> str:
         """Force LiteLLM's OpenAI adapter for OrcaRouter models (OpenAI-compatible)."""

--- a/skill_scanner/core/analyzers/llm_request_handler.py
+++ b/skill_scanner/core/analyzers/llm_request_handler.py
@@ -30,6 +30,11 @@ import warnings
 from pathlib import Path
 from typing import Any, TypedDict
 
+from ...llm_reasoning import (
+    build_litellm_reasoning_params,
+    ensure_google_sdk_reasoning_supported,
+    resolve_llm_reasoning_effort,
+)
 from ...llm_token_options import resolve_llm_max_tokens
 from .llm_provider_config import ProviderConfig
 
@@ -243,6 +248,7 @@ class LLMRequestHandler:
         max_retries: int = 3,
         rate_limit_delay: float = 2.0,
         timeout: int = 120,
+        reasoning_effort: str | None = None,
     ):
         """
         Initialize request handler.
@@ -260,6 +266,9 @@ class LLMRequestHandler:
             max_retries: Max retry attempts on rate limits
             rate_limit_delay: Base delay for exponential backoff
             timeout: Request timeout in seconds
+            reasoning_effort: Optional reasoning-depth control. Resolves from
+                ``SKILL_SCANNER_LLM_REASONING_EFFORT`` when omitted. The
+                ``disabled`` value uses provider-aware request semantics.
         """
         self.provider_config = provider_config
         self.max_tokens = resolve_llm_max_tokens(max_tokens)
@@ -267,6 +276,12 @@ class LLMRequestHandler:
         self.max_retries = max_retries
         self.rate_limit_delay = rate_limit_delay
         self.timeout = timeout
+        self.reasoning_effort = resolve_llm_reasoning_effort(reasoning_effort)
+        if self.provider_config.use_google_sdk:
+            ensure_google_sdk_reasoning_supported(
+                self.reasoning_effort,
+                model=self.provider_config.model,
+            )
 
         # Load JSON schema for structured outputs
         self.response_schema = self._load_response_schema()
@@ -445,6 +460,13 @@ class LLMRequestHandler:
                 }
                 if self.temperature is not None:
                     request_params["temperature"] = self.temperature
+                request_params.update(
+                    build_litellm_reasoning_params(
+                        self.reasoning_effort,
+                        model=self.provider_config.model,
+                        provider=getattr(self.provider_config, "provider", None),
+                    )
+                )
 
                 response_format = self._build_response_format()
                 if response_format:

--- a/skill_scanner/core/analyzers/llm_request_options.py
+++ b/skill_scanner/core/analyzers/llm_request_options.py
@@ -22,7 +22,7 @@ import os
 
 LLM_USER_ENV_VAR = "SKILL_SCANNER_LLM_USER"
 
-_OPENAI_USER_PROVIDERS = {"openai", "openai-compatible", "custom-openai"}
+_OPENAI_COMPATIBLE_PROVIDERS = {"openai", "openai-compatible", "custom-openai"}
 _NON_OPENAI_MODEL_PREFIXES = (
     "anthropic/",
     "bedrock/",
@@ -45,6 +45,22 @@ def resolve_llm_user(llm_user: str | None = None) -> str | None:
     return raw_value
 
 
+def normalize_litellm_model_for_provider(model: str, provider: str | None) -> str:
+    """Force OpenAI-compatible routes through LiteLLM's OpenAI adapter.
+
+    A bare downstream model name can otherwise cause LiteLLM to infer a
+    different provider from the name itself. In particular, a gateway model
+    named ``claude-sonnet-5`` would be inferred as native Anthropic, defeating
+    OpenAI-style request semantics such as ``reasoning_effort='none'``.
+    """
+    provider_normalized = (provider or "").strip().lower().replace("_", "-")
+    if provider_normalized not in _OPENAI_COMPATIBLE_PROVIDERS:
+        return model
+    if model.strip().lower().startswith("openai/"):
+        return model
+    return f"openai/{model}"
+
+
 def supports_openai_user_param(model: str | None, provider: str | None = None) -> bool:
     """Return True when the LiteLLM route should receive the OpenAI `user` parameter."""
     model_lower = (model or "").strip().lower()
@@ -52,7 +68,7 @@ def supports_openai_user_param(model: str | None, provider: str | None = None) -
         return False
 
     provider_normalized = (provider or "").strip().lower().replace("_", "-")
-    if provider_normalized in _OPENAI_USER_PROVIDERS:
+    if provider_normalized in _OPENAI_COMPATIBLE_PROVIDERS:
         return True
 
     return model_lower.startswith(("azure/", "openai/", "gpt-"))

--- a/skill_scanner/core/analyzers/meta_analyzer.py
+++ b/skill_scanner/core/analyzers/meta_analyzer.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ...llm_reasoning import build_litellm_reasoning_params, resolve_llm_reasoning_effort
 from ...llm_token_options import resolve_llm_max_tokens
 from ...threats.threats import ThreatMapping
 from ..models import Finding, ScanResult, Severity, Skill, ThreatCategory
@@ -60,7 +61,11 @@ from .llm_request_handler import (
     _resolve_temperature,
     get_truncation_finish_reason,
 )
-from .llm_request_options import resolve_llm_user, supports_openai_user_param
+from .llm_request_options import (
+    normalize_litellm_model_for_provider,
+    resolve_llm_user,
+    supports_openai_user_param,
+)
 
 if TYPE_CHECKING:
     from ...core.scan_policy import LLMAnalysisPolicy, ScanPolicy
@@ -293,6 +298,8 @@ class MetaAnalyzer(BaseAnalyzer):
         aws_profile: str | None = None,
         aws_session_token: str | None = None,
         llm_user: str | None = None,
+        provider: str | None = None,
+        reasoning_effort: str | None = None,
         # Policy (optional – uses generous defaults × meta multiplier)
         policy: ScanPolicy | None = None,
     ):
@@ -319,6 +326,11 @@ class MetaAnalyzer(BaseAnalyzer):
             aws_profile: AWS profile name (for Bedrock)
             aws_session_token: AWS session token (for Bedrock)
             llm_user: Optional raw Chat Completions user field for OpenAI-compatible routes.
+            provider: Optional provider override used for request semantics.
+            reasoning_effort: Optional reasoning-depth control. When omitted,
+                resolves from ``SKILL_SCANNER_META_LLM_REASONING_EFFORT``,
+                then ``SKILL_SCANNER_LLM_REASONING_EFFORT``. Use ``disabled``
+                for explicit provider-aware thinking disablement.
             policy: Scan policy providing LLM context budget thresholds.
                 The meta analyzer applies ``meta_budget_multiplier`` on top of
                 the base limits.  When ``None``, generous defaults are used.
@@ -338,7 +350,7 @@ class MetaAnalyzer(BaseAnalyzer):
 
         # Use SKILL_SCANNER_* env vars only (no provider-specific fallbacks)
         # Priority: meta-specific > scanner-wide
-        raw_provider = os.getenv("SKILL_SCANNER_LLM_PROVIDER")
+        raw_provider = provider or os.getenv("SKILL_SCANNER_LLM_PROVIDER")
         self.provider = raw_provider.strip().lower().replace("_", "-") if raw_provider else None
         self.api_key = (
             api_key
@@ -362,7 +374,9 @@ class MetaAnalyzer(BaseAnalyzer):
             or os.getenv("SKILL_SCANNER_META_LLM_API_VERSION")  # Meta-specific
             or os.getenv("SKILL_SCANNER_LLM_API_VERSION")  # Scanner-wide
         )
+        self.model = normalize_litellm_model_for_provider(self.model, self.provider)
         self.llm_user = resolve_llm_user(llm_user)
+        self.reasoning_effort = resolve_llm_reasoning_effort(reasoning_effort, meta=True)
 
         # AWS Bedrock settings
         self.aws_region = aws_region
@@ -1114,6 +1128,13 @@ Respond with a JSON object following the schema in the system prompt."""
         }
         if self.temperature is not None:
             api_params["temperature"] = self.temperature
+        api_params.update(
+            build_litellm_reasoning_params(
+                self.reasoning_effort,
+                model=self.model,
+                provider=self.provider,
+            )
+        )
 
         if self.provider_config is not None:
             api_params.update(self.provider_config.get_request_params())

--- a/skill_scanner/llm_reasoning.py
+++ b/skill_scanner/llm_reasoning.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validated, provider-aware controls for optional LLM reasoning effort."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, TypeAlias
+
+LLM_REASONING_EFFORT_ENV_VAR = "SKILL_SCANNER_LLM_REASONING_EFFORT"
+META_LLM_REASONING_EFFORT_ENV_VAR = "SKILL_SCANNER_META_LLM_REASONING_EFFORT"
+
+LLMReasoningEffort: TypeAlias = Literal[
+    "disabled",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+]
+LLM_REASONING_EFFORT_VALUES: tuple[str, ...] = (
+    "disabled",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
+
+
+class ReasoningConfigurationError(ValueError):
+    """Raised when a requested reasoning control is invalid or unsafe."""
+
+
+class ReasoningControlUnsupportedError(ReasoningConfigurationError):
+    """Raised when a configured control cannot be represented safely."""
+
+
+def normalize_llm_reasoning_effort(
+    value: str | None,
+    *,
+    source: str = "reasoning_effort",
+) -> LLMReasoningEffort | None:
+    """Validate and normalize one user-facing reasoning-effort value."""
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        raise ReasoningConfigurationError(f"{source} must be one of: {', '.join(LLM_REASONING_EFFORT_VALUES)}")
+    if normalized not in LLM_REASONING_EFFORT_VALUES:
+        raise ReasoningConfigurationError(
+            f"{source} must be one of: {', '.join(LLM_REASONING_EFFORT_VALUES)}; got {value!r}"
+        )
+    return normalized  # type: ignore[return-value]
+
+
+def resolve_llm_reasoning_effort(
+    explicit: str | None = None,
+    *,
+    meta: bool = False,
+) -> LLMReasoningEffort | None:
+    """Resolve explicit, analyzer-specific, then scanner-wide configuration."""
+    if explicit is not None:
+        return normalize_llm_reasoning_effort(explicit)
+
+    env_vars = (
+        (META_LLM_REASONING_EFFORT_ENV_VAR, LLM_REASONING_EFFORT_ENV_VAR) if meta else (LLM_REASONING_EFFORT_ENV_VAR,)
+    )
+    for env_var in env_vars:
+        raw_value = os.getenv(env_var)
+        if raw_value is not None and raw_value.strip():
+            return normalize_llm_reasoning_effort(raw_value, source=env_var)
+    return None
+
+
+def _uses_anthropic_native_api(model: str | None, provider: str | None) -> bool:
+    """Return whether LiteLLM routes directly to an Anthropic-native API."""
+    model_lower = (model or "").strip().lower()
+    provider_normalized = (provider or "").strip().lower().replace("_", "-")
+
+    # Explicit gateway adapters expose OpenAI-compatible semantics even when
+    # their downstream model name contains "claude".
+    if provider_normalized in {
+        "openai",
+        "openai-compatible",
+        "custom-openai",
+        "azure-openai",
+        "azure-ai",
+        "openrouter",
+        "orcarouter",
+    }:
+        return False
+    if model_lower.startswith(("openai/", "azure/", "openrouter/", "orcarouter/")):
+        return False
+
+    if model_lower.startswith("anthropic/"):
+        return True
+    if model_lower.startswith(("bedrock/", "bedrock-converse/", "bedrock_converse/")):
+        return "claude" in model_lower
+    if model_lower.startswith(("vertex_ai/claude", "vertex/claude")):
+        return True
+    if model_lower.startswith("claude-"):
+        return provider_normalized in {"", "anthropic"}
+
+    return (
+        provider_normalized
+        in {
+            "anthropic",
+            "aws-bedrock",
+            "bedrock",
+            "bedrock-converse",
+            "gcp-vertex",
+            "vertex",
+            "vertex-ai",
+        }
+        and "claude" in model_lower
+    )
+
+
+def build_litellm_reasoning_params(
+    reasoning_effort: str | None,
+    *,
+    model: str | None,
+    provider: str | None = None,
+) -> dict[str, object]:
+    """Translate the user-facing setting into safe LiteLLM request fields.
+
+    ``disabled`` is intentionally not passed as ``reasoning_effort='none'``
+    on Anthropic-native routes. LiteLLM currently maps that value to omission,
+    while Claude Sonnet 5 interprets an omitted ``thinking`` field as adaptive
+    thinking. The native explicit disable field is required there.
+    """
+    normalized = normalize_llm_reasoning_effort(reasoning_effort)
+    if normalized is None:
+        return {}
+    if normalized == "disabled":
+        if _uses_anthropic_native_api(model, provider):
+            return {"thinking": {"type": "disabled"}}
+        return {"reasoning_effort": "none"}
+    return {"reasoning_effort": normalized}
+
+
+def ensure_google_sdk_reasoning_supported(reasoning_effort: str | None, *, model: str) -> None:
+    """Reject a control the direct Google SDK path cannot translate safely.
+
+    LiteLLM normalizes ``reasoning_effort`` for provider adapters, but the
+    direct Google SDK uses model-specific thinking levels or numeric budgets.
+    Silently dropping the configured control would violate the user's intent.
+    """
+    normalized = normalize_llm_reasoning_effort(reasoning_effort)
+    if normalized is not None:
+        raise ReasoningControlUnsupportedError(
+            "llm_reasoning_effort is not supported by the direct Google GenAI SDK "
+            f"path for model {model!r}; use a LiteLLM-backed route or leave it unset"
+        )

--- a/tests/test_llm_reasoning_controls.py
+++ b/tests/test_llm_reasoning_controls.py
@@ -1,0 +1,514 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for optional, provider-aware LLM reasoning controls."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from skill_scanner.config.config import Config
+from skill_scanner.core.analyzers.llm_request_handler import LLMRequestHandler
+from skill_scanner.core.scan_policy import ScanPolicy
+from skill_scanner.llm_reasoning import (
+    ReasoningConfigurationError,
+    ReasoningControlUnsupportedError,
+    build_litellm_reasoning_params,
+    ensure_google_sdk_reasoning_supported,
+    resolve_llm_reasoning_effort,
+)
+
+
+def _provider(model: str, provider: str | None = None) -> MagicMock:
+    config = MagicMock()
+    config.model = model
+    config.provider = provider
+    config.use_google_sdk = False
+    config.get_request_params.return_value = {"api_key": "test-key"}
+    return config
+
+
+def _response(content: str = '{"result":"ok"}') -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    choice.provider_specific_fields = {}
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    return response
+
+
+class TestReasoningResolution:
+    def test_unset_preserves_provider_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        monkeypatch.delenv("SKILL_SCANNER_META_LLM_REASONING_EFFORT", raising=False)
+        assert resolve_llm_reasoning_effort() is None
+        assert resolve_llm_reasoning_effort(meta=True) is None
+
+    def test_scanner_wide_environment_is_validated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", " LoW ")
+        assert resolve_llm_reasoning_effort() == "low"
+
+    def test_meta_specific_environment_precedes_scanner_wide(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "medium")
+        monkeypatch.setenv("SKILL_SCANNER_META_LLM_REASONING_EFFORT", "minimal")
+        assert resolve_llm_reasoning_effort(meta=True) == "minimal"
+
+    def test_explicit_value_precedes_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "high")
+        assert resolve_llm_reasoning_effort("disabled") == "disabled"
+
+    @pytest.mark.parametrize("value", ["", "none", "off", "extreme"])
+    def test_invalid_or_ambiguous_values_are_rejected(
+        self,
+        value: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", value)
+        if value == "":
+            assert resolve_llm_reasoning_effort() is None
+        else:
+            with pytest.raises(ValueError, match="SKILL_SCANNER_LLM_REASONING_EFFORT must be one of"):
+                resolve_llm_reasoning_effort()
+
+    def test_config_resolves_environment_without_changing_unset_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        assert Config().llm_reasoning_effort is None
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "medium")
+        assert Config().llm_reasoning_effort == "medium"
+
+
+class TestProviderAwareParams:
+    def test_unset_emits_no_request_fields(self) -> None:
+        assert build_litellm_reasoning_params(None, model="anthropic/claude-sonnet-5") == {}
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh", "max"])
+    def test_configured_effort_uses_litellm_normalized_field(self, effort: str) -> None:
+        assert build_litellm_reasoning_params(
+            effort,
+            model="anthropic/claude-sonnet-5",
+            provider="anthropic",
+        ) == {"reasoning_effort": effort}
+
+    @pytest.mark.parametrize(
+        "model,provider",
+        [
+            ("anthropic/claude-sonnet-5", "anthropic"),
+            ("claude-sonnet-5", None),
+            ("bedrock/anthropic.claude-sonnet-5-v1:0", "aws-bedrock"),
+            ("vertex_ai/claude-sonnet-5@default", "gcp-vertex"),
+        ],
+    )
+    def test_disabled_uses_native_thinking_field_on_anthropic_routes(
+        self,
+        model: str,
+        provider: str | None,
+    ) -> None:
+        params = build_litellm_reasoning_params("disabled", model=model, provider=provider)
+        assert params == {"thinking": {"type": "disabled"}}
+        assert "reasoning_effort" not in params
+
+    @pytest.mark.parametrize(
+        "model,provider",
+        [
+            ("gpt-5", "openai"),
+            ("openai/claude-sonnet-5", "openai-compatible"),
+            ("openrouter/anthropic/claude-sonnet-5", "openrouter"),
+            ("anthropic/claude-sonnet-5", "orcarouter"),
+            ("orcarouter/anthropic/claude-sonnet-5", ""),
+            ("bedrock/amazon.nova-pro-v1:0", "aws-bedrock"),
+        ],
+    )
+    def test_disabled_uses_openai_semantics_on_gateway_routes(
+        self,
+        model: str,
+        provider: str,
+    ) -> None:
+        assert build_litellm_reasoning_params("disabled", model=model, provider=provider) == {
+            "reasoning_effort": "none"
+        }
+
+    def test_direct_google_sdk_rejects_configured_control_instead_of_dropping_it(self) -> None:
+        ensure_google_sdk_reasoning_supported(None, model="models/gemini-3.1-pro")
+        with pytest.raises(ReasoningControlUnsupportedError, match="direct Google GenAI SDK"):
+            ensure_google_sdk_reasoning_supported("low", model="models/gemini-3.1-pro")
+
+
+class TestMainLLMRequestPath:
+    @pytest.mark.asyncio
+    async def test_unset_preserves_outgoing_request_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        handler = LLMRequestHandler(_provider("gpt-5", "openai"), max_retries=0)
+        handler.response_schema = None
+        with patch(
+            "skill_scanner.core.analyzers.llm_request_handler.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await handler.make_request([{"role": "user", "content": "test"}])
+
+        kwargs = completion.await_args.kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "thinking" not in kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model,provider,effort,expected",
+        [
+            ("gpt-5", "openai", "low", {"reasoning_effort": "low"}),
+            (
+                "anthropic/claude-sonnet-5",
+                "anthropic",
+                "disabled",
+                {"thinking": {"type": "disabled"}},
+            ),
+            (
+                "openai/claude-sonnet-5",
+                "openai-compatible",
+                "disabled",
+                {"reasoning_effort": "none"},
+            ),
+        ],
+    )
+    async def test_configured_control_reaches_litellm(
+        self,
+        model: str,
+        provider: str,
+        effort: str,
+        expected: dict[str, object],
+    ) -> None:
+        handler = LLMRequestHandler(
+            _provider(model, provider),
+            reasoning_effort=effort,
+            max_retries=0,
+        )
+        handler.response_schema = None
+        with patch(
+            "skill_scanner.core.analyzers.llm_request_handler.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await handler.make_request([{"role": "user", "content": "test"}])
+
+        kwargs = completion.await_args.kwargs
+        for key, value in expected.items():
+            assert kwargs[key] == value
+        unexpected = "thinking" if "reasoning_effort" in expected else "reasoning_effort"
+        assert unexpected not in kwargs
+
+    def test_direct_google_handler_fails_loudly_when_control_is_set(self) -> None:
+        provider = _provider("models/gemini-3.1-pro")
+        provider.use_google_sdk = True
+        with pytest.raises(ReasoningControlUnsupportedError, match="direct Google GenAI SDK"):
+            LLMRequestHandler(provider, reasoning_effort="low")
+
+
+class TestMetaAndAlignmentPaths:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model,provider,effort,expected",
+        [
+            ("gpt-5", "openai", None, {}),
+            ("gpt-5", "openai", "medium", {"reasoning_effort": "medium"}),
+            (
+                "anthropic/claude-sonnet-5",
+                "anthropic",
+                "disabled",
+                {"thinking": {"type": "disabled"}},
+            ),
+        ],
+    )
+    async def test_meta_request_uses_shared_provider_mapping(
+        self,
+        model: str,
+        provider: str,
+        effort: str | None,
+        expected: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        monkeypatch.delenv("SKILL_SCANNER_META_LLM_REASONING_EFFORT", raising=False)
+        analyzer = MetaAnalyzer(
+            model=model,
+            api_key="test-key",
+            provider=provider,
+            reasoning_effort=effort,
+            max_retries=1,
+        )
+        with patch(
+            "skill_scanner.core.analyzers.meta_analyzer.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await analyzer._make_llm_request("system", "user")
+
+        kwargs = completion.await_args.kwargs
+        if not expected:
+            assert "reasoning_effort" not in kwargs
+            assert "thinking" not in kwargs
+        for key, value in expected.items():
+            assert kwargs[key] == value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model,provider,effort,expected",
+        [
+            ("gpt-5", "openai", None, {}),
+            ("gpt-5", "openai", "low", {"reasoning_effort": "low"}),
+            (
+                "bedrock/anthropic.claude-sonnet-5-v1:0",
+                "aws-bedrock",
+                "disabled",
+                {"thinking": {"type": "disabled"}},
+            ),
+        ],
+    )
+    async def test_alignment_request_uses_shared_provider_mapping(
+        self,
+        model: str,
+        provider: str,
+        effort: str | None,
+        expected: dict[str, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        client = AlignmentLLMClient(
+            model=model,
+            api_key="test-key",
+            provider=provider,
+            reasoning_effort=effort,
+        )
+        with patch(
+            "skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as completion:
+            await client._make_llm_request("prompt")
+
+        kwargs = completion.await_args.kwargs
+        if not expected:
+            assert "reasoning_effort" not in kwargs
+            assert "thinking" not in kwargs
+        for key, value in expected.items():
+            assert kwargs[key] == value
+
+    @pytest.mark.asyncio
+    async def test_openai_compatible_bare_claude_models_are_normalized(self) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+        from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+        bare_model = "claude-sonnet-5"
+        expected_model = "openai/claude-sonnet-5"
+        meta = MetaAnalyzer(
+            model=bare_model,
+            api_key="test-key",
+            provider="openai-compatible",
+            reasoning_effort="disabled",
+            max_retries=1,
+        )
+        alignment = AlignmentLLMClient(
+            model=bare_model,
+            api_key="test-key",
+            provider="openai-compatible",
+            reasoning_effort="disabled",
+        )
+
+        with patch(
+            "skill_scanner.core.analyzers.meta_analyzer.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as meta_completion:
+            await meta._make_llm_request("system", "user")
+        with patch(
+            "skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as alignment_completion:
+            await alignment._make_llm_request("prompt")
+
+        for completion in (meta_completion, alignment_completion):
+            assert completion.await_args.kwargs["model"] == expected_model
+            assert completion.await_args.kwargs["reasoning_effort"] == "none"
+            assert "thinking" not in completion.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_orcarouter_meta_default_and_alignment_share_gateway_semantics(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+        from skill_scanner.core.analyzers.meta_analyzer import MetaAnalyzer
+
+        for variable in (
+            "SKILL_SCANNER_LLM_MODEL",
+            "SKILL_SCANNER_META_LLM_MODEL",
+            "SKILL_SCANNER_LLM_PROVIDER",
+            "SKILL_SCANNER_LLM_REASONING_EFFORT",
+            "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
+        ):
+            monkeypatch.delenv(variable, raising=False)
+
+        meta = MetaAnalyzer(
+            api_key="test-key",
+            provider="orcarouter",
+            reasoning_effort="disabled",
+            max_retries=1,
+        )
+        alignment = AlignmentLLMClient(
+            model="orcarouter/anthropic/claude-sonnet-5",
+            api_key="test-key",
+            provider="orcarouter",
+            reasoning_effort="disabled",
+        )
+
+        with patch(
+            "skill_scanner.core.analyzers.meta_analyzer.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as meta_completion:
+            await meta._make_llm_request("system", "user")
+        with patch(
+            "skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client.acompletion",
+            AsyncMock(return_value=_response()),
+        ) as alignment_completion:
+            await alignment._make_llm_request("prompt")
+
+        for completion in (meta_completion, alignment_completion):
+            kwargs = completion.await_args.kwargs
+            assert kwargs["model"] == "openai/anthropic/claude-sonnet-5"
+            assert kwargs["api_base"] == "https://api.orcarouter.ai/v1"
+            assert kwargs["reasoning_effort"] == "none"
+            assert "thinking" not in kwargs
+
+
+class TestEntryPointPlumbing:
+    def test_cli_parser_accepts_canonical_values_and_rejects_none(self) -> None:
+        from skill_scanner.cli.cli import build_parser
+
+        args = build_parser().parse_args(["scan", "/tmp/skill", "--llm-reasoning-effort", "disabled"])
+        assert args.llm_reasoning_effort == "disabled"
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["scan", "/tmp/skill", "--llm-reasoning-effort", "none"])
+
+    def test_cli_forwards_setting_to_main_and_meta_factories(self) -> None:
+        from skill_scanner.cli.cli import _build_analyzers, _build_meta_analyzer
+
+        policy = ScanPolicy.default()
+        args = argparse.Namespace(
+            enable_meta=True,
+            llm_provider="anthropic",
+            llm_reasoning_effort="disabled",
+        )
+        with patch("skill_scanner.cli.cli.build_analyzers", return_value=[]) as factory:
+            _build_analyzers(policy, args, lambda _message: None)
+        assert factory.call_args.kwargs["llm_reasoning_effort"] == "disabled"
+
+        with patch("skill_scanner.cli.cli.MetaAnalyzer", return_value=MagicMock()) as meta_type:
+            _build_meta_analyzer(
+                args,
+                2,
+                lambda _message: None,
+                policy=policy,
+                reasoning_effort="disabled",
+            )
+        assert meta_type.call_args.kwargs["reasoning_effort"] == "disabled"
+        assert meta_type.call_args.kwargs["provider"] == "anthropic"
+
+    def test_core_factory_forwards_setting_to_main_and_behavioral_analyzers(self) -> None:
+        from skill_scanner.core.analyzer_factory import build_analyzers
+
+        with (
+            patch("skill_scanner.core.analyzers.llm_analyzer.LLMAnalyzer", return_value=MagicMock()) as llm_type,
+            patch(
+                "skill_scanner.core.analyzers.behavioral_analyzer.BehavioralAnalyzer",
+                return_value=MagicMock(),
+            ) as behavioral_type,
+        ):
+            build_analyzers(
+                ScanPolicy.default(),
+                use_llm=True,
+                use_behavioral=True,
+                llm_provider="anthropic",
+                llm_reasoning_effort="low",
+            )
+
+        assert llm_type.call_args.kwargs["reasoning_effort"] == "low"
+        assert behavioral_type.call_args.kwargs["llm_reasoning_effort"] == "low"
+        assert behavioral_type.call_args.kwargs["llm_provider"] == "anthropic"
+
+    def test_core_factory_does_not_swallow_invalid_reasoning_environment(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzer_factory import build_analyzers
+
+        monkeypatch.setenv("SKILL_SCANNER_LLM_REASONING_EFFORT", "turbo")
+        monkeypatch.delenv("SKILL_SCANNER_LLM_PROVIDER", raising=False)
+        with pytest.raises(ReasoningConfigurationError, match="SKILL_SCANNER_LLM_REASONING_EFFORT"):
+            build_analyzers(
+                ScanPolicy.default(),
+                use_llm=True,
+                llm_model="gpt-5",
+                llm_api_key="test-key",
+            )
+
+    def test_cli_main_reports_reasoning_configuration_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from skill_scanner.cli.cli import main
+
+        monkeypatch.setattr("sys.argv", ["skill-scanner", "list-analyzers"])
+        with patch(
+            "skill_scanner.cli.cli.list_analyzers_command",
+            side_effect=ReasoningConfigurationError("unsupported direct Google reasoning control"),
+        ):
+            assert main() == 1
+        assert "LLM reasoning configuration error" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_api_returns_400_for_reasoning_configuration_error(self, tmp_path) -> None:
+        from skill_scanner.api.router import ScanRequest, scan_skill
+
+        (tmp_path / "SKILL.md").write_text("---\nname: test\ndescription: test\n---\n", encoding="utf-8")
+        request = ScanRequest(
+            skill_directory=str(tmp_path),
+            use_llm=True,
+            llm_reasoning_effort="low",
+        )
+        with patch(
+            "skill_scanner.api.router._build_analyzers",
+            side_effect=ReasoningConfigurationError("unsupported direct Google reasoning control"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await scan_skill(request)
+        assert exc_info.value.status_code == 400
+        assert "unsupported direct Google reasoning control" in exc_info.value.detail
+
+    def test_api_models_validate_and_router_forwards_setting(self) -> None:
+        from skill_scanner.api.router import BatchScanRequest, ScanRequest, _build_analyzers
+
+        scan_request = ScanRequest(skill_directory="/tmp/skill", llm_reasoning_effort="minimal")
+        batch_request = BatchScanRequest(skills_directory="/tmp/skills", llm_reasoning_effort="disabled")
+        assert scan_request.llm_reasoning_effort == "minimal"
+        assert batch_request.llm_reasoning_effort == "disabled"
+        assert ScanRequest(skill_directory="/tmp/skill").llm_reasoning_effort is None
+        with pytest.raises(ValidationError):
+            ScanRequest(skill_directory="/tmp/skill", llm_reasoning_effort="none")
+
+        with patch("skill_scanner.api.router.build_analyzers", return_value=[]) as factory:
+            _build_analyzers(ScanPolicy.default(), llm_reasoning_effort="high")
+        assert factory.call_args.kwargs["llm_reasoning_effort"] == "high"

--- a/tests/test_llm_reasoning_controls.py
+++ b/tests/test_llm_reasoning_controls.py
@@ -211,6 +211,60 @@ class TestMainLLMRequestPath:
 
 
 class TestMetaAndAlignmentPaths:
+    def test_alignment_client_preserves_legacy_positional_arguments(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+            AlignmentLLMClient,
+        )
+
+        monkeypatch.delenv("SKILL_SCANNER_LLM_PROVIDER", raising=False)
+        monkeypatch.delenv("SKILL_SCANNER_LLM_REASONING_EFFORT", raising=False)
+        client = AlignmentLLMClient(
+            "gpt-4o",
+            "test-key",
+            "https://llm.example/v1",
+            "2026-01-01",
+            '{"appkey":"legacy"}',
+            0.25,
+            2048,
+            45,
+        )
+
+        assert client._base_url == "https://llm.example/v1"
+        assert client._api_version == "2026-01-01"
+        assert client._llm_user == '{"appkey":"legacy"}'
+        assert client._temperature == 0.25
+        assert client._max_tokens == 2048
+        assert client._timeout == 45
+
+    def test_alignment_orchestrator_preserves_legacy_positional_arguments(self) -> None:
+        from skill_scanner.core.analyzers.behavioral.alignment.alignment_orchestrator import (
+            AlignmentOrchestrator,
+        )
+
+        with (
+            patch(
+                "skill_scanner.core.analyzers.behavioral.alignment.alignment_orchestrator.AlignmentLLMClient"
+            ) as client_type,
+            patch(
+                "skill_scanner.core.analyzers.behavioral.alignment.alignment_orchestrator.ThreatVulnerabilityClassifier"
+            ),
+        ):
+            AlignmentOrchestrator(
+                "gpt-4o",
+                "test-key",
+                "https://llm.example/v1",
+                0.25,
+                2048,
+                45,
+            )
+
+        assert client_type.call_args.kwargs["temperature"] == 0.25
+        assert client_type.call_args.kwargs["max_tokens"] == 2048
+        assert client_type.call_args.kwargs["timeout"] == 45
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "model,provider,effort,expected",

--- a/tests/test_reference_docs_generator.py
+++ b/tests/test_reference_docs_generator.py
@@ -3,7 +3,13 @@
 
 """Tests for reference-document source discovery."""
 
-from scripts.generate_reference_docs import _extract_python_env_variables
+from scripts.generate_reference_docs import (
+    _collect_env_variables,
+    _extract_python_env_variables,
+    _render_api_reference,
+    _render_cli_reference,
+    _render_configuration_reference,
+)
 
 
 def test_environment_discovery_ignores_comments_and_docstrings() -> None:
@@ -18,3 +24,21 @@ constant = os.environ.get(ENV_NAME)
 '''
 
     assert _extract_python_env_variables(source) == {"CONSTANT_ENV", "DIRECT_ENV"}
+
+
+def test_reasoning_environment_variables_map_to_runtime_resolver() -> None:
+    env_map = _collect_env_variables()
+
+    for variable in (
+        "SKILL_SCANNER_LLM_REASONING_EFFORT",
+        "SKILL_SCANNER_META_LLM_REASONING_EFFORT",
+    ):
+        assert "skill_scanner/llm_reasoning.py" in env_map[variable]
+
+
+def test_generated_references_document_google_reasoning_limitation() -> None:
+    expected = "Direct Google GenAI SDK requests reject configured controls"
+
+    assert expected in _render_cli_reference()
+    assert expected in _render_api_reference()
+    assert expected in _render_configuration_reference()

--- a/tests/test_reference_docs_generator.py
+++ b/tests/test_reference_docs_generator.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for reference-document source discovery."""
+
+from scripts.generate_reference_docs import _extract_python_env_variables
+
+
+def test_environment_discovery_ignores_comments_and_docstrings() -> None:
+    source = '''
+import os
+
+ENV_NAME = "CONSTANT_ENV"
+"""Example only: os.getenv("DOCSTRING_ENV")"""
+# Example only: os.environ.get("COMMENT_ENV")
+direct = os.getenv("DIRECT_ENV")
+constant = os.environ.get(ENV_NAME)
+'''
+
+    assert _extract_python_env_variables(source) == {"CONSTANT_ENV", "DIRECT_ENV"}


### PR DESCRIPTION
## Summary

- expose optional reasoning effort through environment, CLI, API, main LLM, meta, and behavioral-alignment paths
- preserve provider defaults when unset and map disabled correctly for native Claude versus OpenAI-compatible routes
- normalize bare Claude gateway models and cover OrcaRouter in main, meta, and alignment flows
- fail loudly for invalid or unsupported reasoning settings instead of silently dropping the requested analyzer
- regenerate deterministic API, CLI, and configuration references under the canonical Python 3.12 runtime

Direct Google GenAI SDK requests reject configured reasoning controls explicitly; LiteLLM-backed Gemini remains supported.

Closes #166.

## Stack

Layer 16 of gh-stack #182, based on #188. Merge the stack from the bottom upward.

## Verification

- combined reasoning/integration suite: 459 passed, 1 skipped
- full CI-equivalent unit suite on Python 3.10: 1712 passed, 12 skipped, 1 xfailed
- benchmark: 12/12, 100% accuracy/precision/recall/F1
- `uv run pip-audit`: no known vulnerabilities
- `uv run pre-commit run --all-files`
- `uv run --python 3.12 python scripts/generate_reference_docs.py --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable LLM reasoning effort for CLI commands and API scans.
  * Supports levels from `disabled` through `max`, with provider-aware behavior.
  * Added separate reasoning-effort configuration for meta-analysis.
  * Invalid or unsupported settings now produce clear configuration errors.

* **Documentation**
  * Updated environment, CLI, API, configuration, and analyzer references with the new options and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->