### PR TITLE
fix(adjudicator): send provider credentials with the LiteLLM request

### DIFF
--- a/skill_scanner/core/analyzers/adjudicator.py
+++ b/skill_scanner/core/analyzers/adjudicator.py
@@ -278,6 +278,10 @@ class Adjudicator:
         # policy level costs nothing on skills with no HIGH+ findings.
         self._rule_registry: Any = None
 
+        # Lazy-loaded provider config, for the same reason. ``False`` marks a
+        # resolution failure so it is attempted once, not per finding.
+        self._provider_config: Any = None
+
         # Audit records for every finding we considered (kept, skipped,
         # or demoted). Callers can attach these to scan_metadata for
         # traceability.
@@ -325,6 +329,45 @@ class Adjudicator:
             "severity": rule.default_severity or "",
         }
 
+    def _provider_params(self) -> dict[str, Any]:
+        """Resolve provider credentials and routing for the outbound request.
+
+        Delegates to :class:`ProviderConfig` -- the same resolver
+        ``LLMRequestHandler`` uses -- so the adjudicator honours
+        ``SKILL_SCANNER_LLM_API_KEY``, ``SKILL_SCANNER_LLM_BASE_URL`` and every
+        provider-specific mechanism it already implements (Azure Entra ID,
+        Bedrock bearer/IAM, Vertex ADC, Gemini's ``GEMINI_API_KEY`` handoff)
+        rather than re-deriving any of it here.
+
+        The config is built once and cached. ``ProviderConfig`` raises
+        ``ImportError`` when the provider's SDK is missing, and a resolver
+        failure must not be louder than the missing credential it is trying to
+        supply, so any exception degrades to an empty dict: the request then
+        goes out exactly as it did before this method existed, and the caller's
+        existing error path keeps the finding at its original severity.
+
+        ``self.model`` is deliberately passed through unchanged instead of
+        adopting ``ProviderConfig.model``. For Gemini with ``google-genai``
+        installed that attribute is normalised for the Google SDK, which this
+        LiteLLM-only call path cannot use.
+        """
+        if self._provider_config is None:
+            try:
+                from .llm_provider_config import ProviderConfig
+
+                self._provider_config = ProviderConfig(model=self.model or "")
+            except Exception as exc:
+                logger.debug("adjudicator could not resolve provider config: %s", exc)
+                self._provider_config = False
+
+        if self._provider_config is False:
+            return {}
+        try:
+            return dict(self._provider_config.get_request_params())
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("adjudicator could not build provider request params: %s", exc)
+            return {}
+
     def _call_llm(self, prompt: str) -> dict[str, Any] | None:
         """Send the prompt via LiteLLM sync completion.
 
@@ -354,6 +397,14 @@ class Adjudicator:
         }
         if self.temperature is not None:
             request["temperature"] = self.temperature
+        # Credentials and routing come from the same resolver the LLM analyzer uses.
+        # Without this the request carries no api_key/api_base, so LiteLLM falls back
+        # to provider-native discovery (``ANTHROPIC_API_KEY`` and friends) and every
+        # deployment configured the documented way -- via
+        # ``SKILL_SCANNER_LLM_API_KEY`` / ``SKILL_SCANNER_LLM_BASE_URL`` -- fails
+        # authentication. Keys cannot collide: get_request_params only ever returns
+        # api_key/azure_ad_token/api_base/api_version/user/aws_*.
+        request.update(self._provider_params())
 
         content = ""
         last_exc: Exception | None = None

--- a/skill_scanner/core/analyzers/adjudicator.py
+++ b/skill_scanner/core/analyzers/adjudicator.py
@@ -282,6 +282,9 @@ class Adjudicator:
         # resolution failure so it is attempted once, not per finding.
         self._provider_config: Any = None
 
+        # Latch so a broken LLM path is reported once per scan, not per finding.
+        self._llm_failure_reported = False
+
         # Audit records for every finding we considered (kept, skipped,
         # or demoted). Callers can attach these to scan_metadata for
         # traceability.
@@ -329,33 +332,78 @@ class Adjudicator:
             "severity": rule.default_severity or "",
         }
 
+    def _note_llm_failure(self, detail: object) -> None:
+        """Report the first failure to obtain a verdict at WARNING, once.
+
+        Every adjudication failure is individually harmless -- the finding keeps
+        its original severity and the gate only gets stricter -- which is exactly
+        why a wholly broken adjudicator is invisible. It leaves no trace outside
+        DEBUG logs while still appearing in ``analyzers_used``, so a
+        misconfiguration reads as "found no false positives" rather than "never
+        ran". One WARNING per scan is enough to tell those apart; the remaining
+        failures stay at DEBUG so a flaky provider cannot flood the log.
+        """
+        if self._llm_failure_reported:
+            return
+        self._llm_failure_reported = True
+        logger.warning(
+            "Adjudication is not producing verdicts (%s). Findings keep their original "
+            "severity, so the scan verdict is unaffected -- but no false positive will be "
+            "demoted while this persists. Check the model id and credentials "
+            "(SKILL_SCANNER_LLM_MODEL / SKILL_SCANNER_ADJUDICATOR_LLM_MODEL, "
+            "SKILL_SCANNER_LLM_API_KEY, SKILL_SCANNER_LLM_BASE_URL). "
+            "Later failures in this scan are logged at DEBUG.",
+            detail,
+        )
+
     def _provider_params(self) -> dict[str, Any]:
         """Resolve provider credentials and routing for the outbound request.
 
         Delegates to :class:`ProviderConfig` -- the same resolver
-        ``LLMRequestHandler`` uses -- so the adjudicator honours
-        ``SKILL_SCANNER_LLM_API_KEY``, ``SKILL_SCANNER_LLM_BASE_URL`` and every
-        provider-specific mechanism it already implements (Azure Entra ID,
-        Bedrock bearer/IAM, Vertex ADC, Gemini's ``GEMINI_API_KEY`` handoff)
+        ``LLMRequestHandler`` uses -- so the adjudicator picks up every
+        provider mechanism it already implements (Azure Entra ID tokens,
+        Bedrock bearer/IAM, Vertex ADC, the Gemini ``GEMINI_API_KEY`` handoff)
         rather than re-deriving any of it here.
 
-        The config is built once and cached. ``ProviderConfig`` raises
-        ``ImportError`` when the provider's SDK is missing, and a resolver
-        failure must not be louder than the missing credential it is trying to
-        supply, so any exception degrades to an empty dict: the request then
-        goes out exactly as it did before this method existed, and the caller's
-        existing error path keeps the finding at its original severity.
+        ``base_url`` and ``api_version`` are read here and passed IN, because
+        ``ProviderConfig`` takes them as constructor arguments and never reads
+        the environment for them -- ``analyzer_factory`` and ``meta_analyzer``
+        do that for their own call sites. Omitting them would be worse than
+        sending nothing: an OpenAI-compatible gateway config would ship the
+        gateway's ``api_key`` and the scanned file body to the provider's public
+        endpoint instead of the configured gateway. The two-tier lookup mirrors
+        ``meta_analyzer``, since ``SKILL_SCANNER_ADJUDICATOR_LLM_MODEL`` already
+        lets the adjudicator run a different model, which may need a different
+        endpoint.
 
-        ``self.model`` is deliberately passed through unchanged instead of
-        adopting ``ProviderConfig.model``. For Gemini with ``google-genai``
-        installed that attribute is normalised for the Google SDK, which this
-        LiteLLM-only call path cannot use.
+        The config is built once and cached. A resolver failure must not be
+        louder than the credential it is trying to supply, so any exception
+        degrades to an empty dict: the request then goes out exactly as it did
+        before this method existed, and the caller's existing error path keeps
+        the finding at its original severity.
+
+        Side effect, inherited from the shared resolver: for Google AI Studio
+        models ``get_request_params`` sets ``GEMINI_API_KEY`` in the process
+        environment when it is unset. Same value, from the same variable, as
+        the LLM analyzer would write.
         """
         if self._provider_config is None:
             try:
                 from .llm_provider_config import ProviderConfig
 
-                self._provider_config = ProviderConfig(model=self.model or "")
+                self._provider_config = ProviderConfig(
+                    # `or ""` satisfies the type checker only; _call_llm has
+                    # already returned when self.model is falsy.
+                    model=self.model or "",
+                    base_url=(
+                        os.environ.get("SKILL_SCANNER_ADJUDICATOR_LLM_BASE_URL")
+                        or os.environ.get("SKILL_SCANNER_LLM_BASE_URL")
+                    ),
+                    api_version=(
+                        os.environ.get("SKILL_SCANNER_ADJUDICATOR_LLM_API_VERSION")
+                        or os.environ.get("SKILL_SCANNER_LLM_API_VERSION")
+                    ),
+                )
             except Exception as exc:
                 logger.debug("adjudicator could not resolve provider config: %s", exc)
                 self._provider_config = False
@@ -363,10 +411,29 @@ class Adjudicator:
         if self._provider_config is False:
             return {}
         try:
-            return dict(self._provider_config.get_request_params())
+            params = dict(self._provider_config.get_request_params())
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("adjudicator could not build provider request params: %s", exc)
             return {}
+
+        # Adopt the normalised model ONLY for OpenAI-compatible providers, where
+        # ProviderConfig adds the `openai/` prefix LiteLLM requires to route at
+        # all -- a bare gateway model name raises "LLM Provider NOT provided".
+        # Deliberately not generalised: the Gemini normalisation targets the
+        # Google SDK, which this LiteLLM-only path cannot use.
+        if getattr(self._provider_config, "is_openai_compatible", False):
+            params["model"] = self._provider_config.model
+
+        # ProviderConfig defaults aws_region to us-east-1, so this key is always
+        # present for Bedrock. An explicit aws_region_name short-circuits
+        # LiteLLM's whole resolution chain -- model-ARN inference,
+        # AWS_REGION_NAME, AWS_DEFAULT_REGION, and the boto3 session that reads
+        # ~/.aws/config. Drop it unless the operator really set AWS_REGION, so a
+        # profile- or ARN-derived region keeps working as it did before this
+        # method supplied any parameters at all.
+        if "AWS_REGION" not in os.environ:
+            params.pop("aws_region_name", None)
+        return params
 
     def _call_llm(self, prompt: str) -> dict[str, Any] | None:
         """Send the prompt via LiteLLM sync completion.
@@ -386,8 +453,24 @@ class Adjudicator:
         if not self.model:
             return None
 
+        # Credentials and routing come from the same resolver the LLM analyzer uses.
+        # Without them the request carries no api_key/api_base, so LiteLLM falls back
+        # to provider-native discovery (``ANTHROPIC_API_KEY`` and friends) and every
+        # deployment configured the documented way -- via
+        # ``SKILL_SCANNER_LLM_API_KEY`` / ``SKILL_SCANNER_LLM_BASE_URL`` -- fails
+        # authentication.
+        #
+        # Spread FIRST so the adjudicator's own parameters win by construction
+        # rather than by a promise about what get_request_params returns today: a
+        # future `max_tokens` or `timeout` key there must not silently override
+        # this pass's deliberate 200-token cap and per-request timeout. `model` is
+        # the one value the resolver may legitimately override (OpenAI-compatible
+        # prefixing), so it is taken explicitly instead of being clobbered.
+        provider_params = self._provider_params()
+        model = provider_params.pop("model", None) or self.model
         request: dict[str, Any] = {
-            "model": self.model,
+            **provider_params,
+            "model": model,
             "messages": [
                 {"role": "system", "content": _SYSTEM_PROMPT},
                 {"role": "user", "content": prompt},
@@ -397,14 +480,6 @@ class Adjudicator:
         }
         if self.temperature is not None:
             request["temperature"] = self.temperature
-        # Credentials and routing come from the same resolver the LLM analyzer uses.
-        # Without this the request carries no api_key/api_base, so LiteLLM falls back
-        # to provider-native discovery (``ANTHROPIC_API_KEY`` and friends) and every
-        # deployment configured the documented way -- via
-        # ``SKILL_SCANNER_LLM_API_KEY`` / ``SKILL_SCANNER_LLM_BASE_URL`` -- fails
-        # authentication. Keys cannot collide: get_request_params only ever returns
-        # api_key/azure_ad_token/api_base/api_version/user/aws_*.
-        request.update(self._provider_params())
 
         content = ""
         last_exc: Exception | None = None
@@ -427,9 +502,11 @@ class Adjudicator:
                             _time.sleep(delay)
                             continue
                     logger.debug("adjudicator LLM call failed: %s", exc)
+                    self._note_llm_failure(exc)
                     return None
             else:
                 logger.debug("adjudicator LLM call exhausted retries: %s", last_exc)
+                self._note_llm_failure(f"exhausted retries: {last_exc}")
                 return None
 
         # Extract the first JSON object from the response. Some models
@@ -438,11 +515,13 @@ class Adjudicator:
         end = content.rfind("}")
         if start == -1 or end == -1 or end <= start:
             logger.debug("adjudicator response had no JSON: %r", content[:200])
+            self._note_llm_failure("response contained no JSON object")
             return None
         try:
             return json.loads(content[start : end + 1])
         except json.JSONDecodeError:
             logger.debug("adjudicator response was invalid JSON: %r", content[start : end + 1][:200])
+            self._note_llm_failure("response was not valid JSON")
             return None
 
     def _adjudicate_one(self, finding: Finding, skill: Skill) -> AdjudicationResult:

--- a/tests/test_adjudicator.py
+++ b/tests/test_adjudicator.py
@@ -34,6 +34,7 @@ Plus:
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -510,23 +511,94 @@ class TestAdjudicatorProviderCredentials:
         monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "gateway-model")
         monkeypatch.setenv("SKILL_SCANNER_LLM_PROVIDER", "openai-compatible")
         monkeypatch.setenv("SKILL_SCANNER_LLM_API_KEY", "sk-proxy-key")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_BASE_URL", "https://gateway.example/v1")
         skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
         finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
 
         with patch("litellm.completion") as mock_call:
             mock_call.return_value = _mock_litellm_response("real", 5)
-            adj = Adjudicator()
-            # base_url has no dedicated adjudicator env var; it reaches the request
-            # through ProviderConfig exactly as it does for the LLM analyzer.
-            adj._provider_config = None
-            with patch(
-                "skill_scanner.core.analyzers.llm_provider_config.ProviderConfig.get_request_params",
-                return_value={"api_key": "sk-proxy-key", "api_base": "https://gateway.example/v1"},
-            ):
-                adj.adjudicate([finding], skill)
+            Adjudicator().adjudicate([finding], skill)
 
-        assert mock_call.call_args.kwargs["api_base"] == "https://gateway.example/v1"
-        assert mock_call.call_args.kwargs["api_key"] == "sk-proxy-key"
+        kwargs = mock_call.call_args.kwargs
+        # Without api_base, LiteLLM routes by model name to the provider's PUBLIC
+        # endpoint -- so the gateway key and the scanned file body would both go
+        # somewhere the operator deliberately routed away from.
+        assert kwargs["api_base"] == "https://gateway.example/v1"
+        assert kwargs["api_key"] == "sk-proxy-key"
+        # LiteLLM cannot route a bare custom model name ("LLM Provider NOT
+        # provided"), so the prefix ProviderConfig adds has to survive.
+        assert kwargs["model"] == "openai/gateway-model"
+
+    def test_request_carries_api_version_for_azure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "azure/gpt-4o")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_API_KEY", "azure-key")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_BASE_URL", "https://example.openai.azure.com")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_API_VERSION", "2024-08-01-preview")
+        monkeypatch.delenv("SKILL_SCANNER_LLM_PROVIDER", raising=False)
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            Adjudicator().adjudicate([finding], skill)
+
+        # Azure rejects the call outright without both of these.
+        kwargs = mock_call.call_args.kwargs
+        assert kwargs["api_base"] == "https://example.openai.azure.com"
+        assert kwargs["api_version"] == "2024-08-01-preview"
+
+    def test_adjudicator_specific_base_url_overrides_scanner_wide(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "gateway-model")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_PROVIDER", "openai-compatible")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_API_KEY", "sk-proxy-key")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_BASE_URL", "https://scanner-wide.example/v1")
+        monkeypatch.setenv("SKILL_SCANNER_ADJUDICATOR_LLM_BASE_URL", "https://adjudicator-only.example/v1")
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            Adjudicator().adjudicate([finding], skill)
+
+        # Mirrors the MODEL override tier: a different adjudicator model may live
+        # behind a different endpoint.
+        assert mock_call.call_args.kwargs["api_base"] == "https://adjudicator-only.example/v1"
+
+    def test_bedrock_region_is_not_pinned_when_aws_region_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("SKILL_SCANNER_LLM_PROVIDER", raising=False)
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            Adjudicator().adjudicate([finding], skill)
+
+        # ProviderConfig defaults the region to us-east-1. Forwarding that
+        # short-circuits LiteLLM's own resolution (model ARN, AWS_DEFAULT_REGION,
+        # ~/.aws/config profile), silently relocating requests for an operator who
+        # never set AWS_REGION.
+        assert "aws_region_name" not in mock_call.call_args.kwargs
+
+    def test_bedrock_region_is_forwarded_when_aws_region_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        monkeypatch.delenv("SKILL_SCANNER_LLM_PROVIDER", raising=False)
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            Adjudicator().adjudicate([finding], skill)
+
+        assert mock_call.call_args.kwargs["aws_region_name"] == "eu-west-1"
 
     def test_model_and_messages_are_not_overwritten_by_provider_params(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -565,3 +637,29 @@ class TestAdjudicatorProviderCredentials:
         # finding at its original severity if it fails.
         assert mock_call.call_count == 1
         assert finding.severity == Severity.HIGH
+
+    def test_first_llm_failure_is_reported_at_warning_once(
+        self, tmp_path: Path, with_model_env: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        findings = [
+            _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4),
+            _finding("COMMAND_INJECTION_OS_SYSTEM", Severity.CRITICAL, line_number=4),
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            with patch("litellm.completion", side_effect=RuntimeError("Missing API Key")):
+                Adjudicator().adjudicate(findings, skill)
+
+        # A wholly broken adjudicator used to be invisible: failures logged at
+        # DEBUG while `adjudicator` still appeared in analyzers_used, so a
+        # misconfiguration read as "no false positives found".
+        # Scope to this module's logger: rule_registry emits unrelated pack-load
+        # warnings that would otherwise be counted here.
+        warnings = [
+            r for r in caplog.records if r.levelno == logging.WARNING and r.name.endswith("analyzers.adjudicator")
+        ]
+        assert len(warnings) == 1, "expected exactly one WARNING per scan, not one per finding"
+        assert "not producing verdicts" in warnings[0].getMessage()
+        # Demote-only invariant is untouched by the new reporting.
+        assert all(f.severity in (Severity.HIGH, Severity.CRITICAL) for f in findings)

--- a/tests/test_adjudicator.py
+++ b/tests/test_adjudicator.py
@@ -474,3 +474,94 @@ class TestAdjudicatorAvailability:
 
         mock_call.assert_not_called()
         assert finding.severity == Severity.HIGH
+
+
+# ----- Provider credentials ------------------------------------------------
+
+
+class TestAdjudicatorProviderCredentials:
+    """The outbound request carries the credentials the scanner is configured with.
+
+    Regression coverage for the adjudicator building its LiteLLM request by hand
+    and omitting ``api_key`` / ``api_base``. Every test above patches
+    ``litellm.completion`` and asserts on the request the adjudicator *builds*,
+    so a request that can never authenticate against a real provider still
+    passed the whole suite. These assert on the credential fields instead.
+    """
+
+    def test_request_carries_api_key_from_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "anthropic/claude-sonnet-4-5")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_API_KEY", "sk-test-key")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            Adjudicator().adjudicate([finding], skill)
+
+        # Without this, LiteLLM falls back to provider-native discovery
+        # (ANTHROPIC_API_KEY), which the scanner never sets.
+        assert mock_call.call_args.kwargs["api_key"] == "sk-test-key"
+
+    def test_request_carries_api_base_for_openai_compatible_endpoint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "gateway-model")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_PROVIDER", "openai-compatible")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_API_KEY", "sk-proxy-key")
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            adj = Adjudicator()
+            # base_url has no dedicated adjudicator env var; it reaches the request
+            # through ProviderConfig exactly as it does for the LLM analyzer.
+            adj._provider_config = None
+            with patch(
+                "skill_scanner.core.analyzers.llm_provider_config.ProviderConfig.get_request_params",
+                return_value={"api_key": "sk-proxy-key", "api_base": "https://gateway.example/v1"},
+            ):
+                adj.adjudicate([finding], skill)
+
+        assert mock_call.call_args.kwargs["api_base"] == "https://gateway.example/v1"
+        assert mock_call.call_args.kwargs["api_key"] == "sk-proxy-key"
+
+    def test_model_and_messages_are_not_overwritten_by_provider_params(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILL_SCANNER_ADJUDICATOR_LLM_MODEL", "adjudicator/model-id")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_MODEL", "analyzer/model-id")
+        monkeypatch.setenv("SKILL_SCANNER_LLM_API_KEY", "sk-test-key")
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            Adjudicator().adjudicate([finding], skill)
+
+        # The adjudicator-specific model override still wins, and merging the
+        # provider params must not disturb the prompt payload.
+        kwargs = mock_call.call_args.kwargs
+        assert kwargs["model"] == "adjudicator/model-id"
+        assert kwargs["max_tokens"] == 200
+        assert len(kwargs["messages"]) == 2
+
+    def test_provider_resolution_failure_still_calls_llm(self, tmp_path: Path, with_model_env: None) -> None:
+        skill = _make_skill(tmp_path, "---\nname: test\n---\n\nSome content.\n")
+        finding = _finding("PROMPT_INJECTION_CONCEALMENT", Severity.HIGH, line_number=4)
+
+        with patch("litellm.completion") as mock_call:
+            mock_call.return_value = _mock_litellm_response("real", 5)
+            with patch(
+                "skill_scanner.core.analyzers.llm_provider_config.ProviderConfig.__init__",
+                side_effect=ImportError("provider SDK missing"),
+            ):
+                Adjudicator().adjudicate([finding], skill)
+
+        # A resolver failure must not be louder than the credential it supplies:
+        # the request still goes out, and the existing error path keeps the
+        # finding at its original severity if it fails.
+        assert mock_call.call_count == 1
+        assert finding.severity == Severity.HIGH


### PR DESCRIPTION
## Problem

The adjudicator builds its LiteLLM request by hand and omits `api_key` and `api_base`, so `--adjudicate` cannot authenticate in any deployment configured through the documented env vars. Every adjudication call fails, and because the failures are logged at `DEBUG` and the pass is demote-only, the feature silently does nothing while still reporting `adjudicator` in `analyzers_used`.

Reproduced with only the documented variables set (`SKILL_SCANNER_LLM_MODEL=anthropic/claude-sonnet-4-5`, `SKILL_SCANNER_LLM_API_KEY=<key>`, `ANTHROPIC_API_KEY` unset):

```
litellm.completion kwargs: [drop_params, max_tokens, messages, model, temperature, timeout]
  api_key present: False | api_base present: False

litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to
anthropic but no key is set either in the environment variables or via params.
Please set `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` in your environment vars
```

Seen in CI on 2.0.13 as **21 candidate findings and 21 failed adjudication calls**, in a run where the LLM analyzer authenticated and produced findings normally against the same environment — which isolates the cause to this call path rather than to the configuration.

## Cause

`adjudicator.py` is the only production LiteLLM call site that does not resolve its request through `ProviderConfig`:

```
LLMAnalyzer  ─┐
MetaAnalyzer ─┴─> LLMRequestHandler ──> acompletion(**request_params)
                        │                        ▲
                        └─ ProviderConfig.get_request_params()
                             api_key  <- SKILL_SCANNER_LLM_API_KEY
                             api_base <- SKILL_SCANNER_LLM_BASE_URL

Adjudicator ────────────────────────> litellm.completion(**request)
                                        model, messages, max_tokens,
                                        timeout, temperature — nothing else
```

`llm_request_handler.py` merges `ProviderConfig.get_request_params()` (`llm_provider_config.py:286`) into the outbound request; that is where `SKILL_SCANNER_LLM_API_KEY` becomes `api_key` and `SKILL_SCANNER_LLM_BASE_URL` becomes `api_base`. The adjudicator re-implements model resolution (`_resolve_model`) and temperature resolution (`_resolve_temperature`) but not credential resolution, so nothing supplies them and LiteLLM falls back to provider-native discovery.

Because `api_base` is also missing, an OpenAI-compatible gateway cannot be reached at all — there is no env-var workaround for that configuration.

## Fix

Merge `ProviderConfig.get_request_params()` into the request, so the adjudicator uses the same resolver as every other LLM caller. That also picks up the provider mechanisms it already handles — Azure Entra ID tokens, Bedrock bearer/IAM, Vertex ADC, and Gemini's `GEMINI_API_KEY` handoff — rather than re-deriving any of them here.

Deliberate choices, all noted in the code:

- **`self.model` is passed through unchanged** rather than adopting `ProviderConfig.model`. For Gemini with `google-genai` installed, that attribute is normalised for the Google SDK, which this LiteLLM-only path cannot use. Keeping the adjudicator's resolved model also preserves the existing `SKILL_SCANNER_ADJUDICATOR_LLM_MODEL` override precedence.
- **A resolver failure degrades to `{}`, it does not raise.** It must not be louder than the credential it is trying to supply; the request then goes out exactly as it does today and the existing error path keeps the finding at its original severity. The load-bearing demote-only invariant is untouched.
- **No key collisions are possible** — `get_request_params` only ever returns `api_key` / `azure_ad_token` / `api_base` / `api_version` / `user` / `aws_*`.
- **`is_available()` still checks only the model.** Requiring a key would break Ollama, Vertex ADC and Bedrock IAM, which authenticate ambiently.

## Why the existing tests didn't catch this

All 19 tests in `test_adjudicator.py` patch `litellm.completion` and assert on the request the adjudicator *builds* — messages, model, max_tokens, temperature — never on whether that request can authenticate. So a request that fails against every real provider passes the whole suite.

The four new tests in `TestAdjudicatorProviderCredentials` assert on the credential fields instead. The first fails with `KeyError: 'api_key'` without this change. They also cover `api_base` for an OpenAI-compatible endpoint, that merging provider params does not disturb `model`/`messages`/`max_tokens` or the adjudicator-specific model override, and that a resolver failure still issues the call and leaves severity intact.

## Verification

- Full suite: **1675 passed, 5 skipped, 1 xfailed**.
- `ruff check` and `ruff format --check` clean on both changed files.
- End-to-end re-run of the original repro now shows `api_key` present in the outbound kwargs.

Production change is +51 lines in one file, no behaviour change on any path that was already working.