### PR TITLE
fix(scanner): block untrusted pickle files

### DIFF
--- a/skill_scanner/core/analyzers/static.py
+++ b/skill_scanner/core/analyzers/static.py
@@ -22,6 +22,7 @@ import ast
 import configparser
 import hashlib
 import logging
+import pickletools
 import re
 from pathlib import Path
 from typing import Any
@@ -1377,6 +1378,10 @@ class StaticAnalyzer(BaseAnalyzer):
             if skill_file.file_type != "binary":
                 continue
 
+            if ext in {".pkl", ".pickle"}:
+                findings.append(self._pickle_finding(skill_file))
+                continue
+
             if ext in INERT_EXTENSIONS:
                 continue
 
@@ -1423,6 +1428,144 @@ class StaticAnalyzer(BaseAnalyzer):
             )
 
         return findings
+
+    def _pickle_finding(self, skill_file) -> Finding:
+        """Report serialized Python objects as executable, untrusted content.
+
+        Pickle is not a data-only format: loading a pickle can invoke arbitrary
+        callables encoded by the producer.  Inspect opcodes with ``pickletools``
+        (which never unpickles the object) to distinguish an ordinary serialized
+        object from one that visibly references a code-execution primitive.
+        Even a syntactically valid pickle remains HIGH because static analysis
+        cannot make loading attacker-controlled pickle data safe.
+        """
+        dangerous_globals: list[str] = []
+        executable_opcodes: list[str] = []
+        parse_error: str | None = None
+        inspection_skipped_reason: str | None = None
+        inspection_limit = max(0, self.policy.file_limits.max_loader_file_size_bytes)
+
+        def _record_global(module: str, name: str) -> None:
+            reference = f"{module} {name}"
+            if module in {"builtins", "os", "posix", "nt", "subprocess", "commands"} or name in {
+                "eval",
+                "exec",
+                "system",
+                "popen",
+                "spawn",
+                "Popen",
+            }:
+                dangerous_globals.append(reference)
+
+        if skill_file.size_bytes > inspection_limit:
+            inspection_skipped_reason = "size-limit"
+        else:
+            try:
+                # Bound the actual read as well as checking the loader's size
+                # metadata, so a file replacement race cannot exhaust memory.
+                with skill_file.path.open("rb") as handle:
+                    payload = handle.read(inspection_limit + 1)
+                if len(payload) > inspection_limit:
+                    inspection_skipped_reason = "size-limit"
+                else:
+                    stack: list[object] = []
+                    memo: dict[int, object] = {}
+                    next_memo_index = 0
+                    mark = object()
+                    string_opcodes = {
+                        "STRING",
+                        "BINSTRING",
+                        "SHORT_BINSTRING",
+                        "UNICODE",
+                        "BINUNICODE",
+                        "SHORT_BINUNICODE",
+                        "BINUNICODE8",
+                    }
+
+                    for opcode, argument, _ in pickletools.genops(payload):
+                        opcode_name = opcode.name
+                        if opcode_name in string_opcodes:
+                            if isinstance(argument, bytes):
+                                stack.append(argument.decode("utf-8", errors="replace"))
+                            else:
+                                stack.append(argument if isinstance(argument, str) else None)
+                        elif opcode_name == "MEMOIZE":
+                            memo[next_memo_index] = stack[-1] if stack else None
+                            next_memo_index += 1
+                        elif opcode_name in {"PUT", "BINPUT", "LONG_BINPUT"}:
+                            memo[int(argument)] = stack[-1] if stack else None
+                        elif opcode_name in {"GET", "BINGET", "LONG_BINGET"}:
+                            stack.append(memo.get(int(argument)))
+                        elif opcode_name == "GLOBAL" and isinstance(argument, str):
+                            module, _, name = argument.partition(" ")
+                            _record_global(module, name)
+                            stack.append(None)
+                        elif opcode_name == "STACK_GLOBAL":
+                            executable_opcodes.append(opcode_name)
+                            name = stack.pop() if stack else None
+                            module = stack.pop() if stack else None
+                            if isinstance(module, str) and isinstance(name, str):
+                                _record_global(module, name)
+                            stack.append(None)
+                        elif opcode_name == "REDUCE":
+                            executable_opcodes.append(opcode_name)
+                            if stack:
+                                stack.pop()
+                            if stack:
+                                stack.pop()
+                            stack.append(None)
+                        elif opcode_name == "MARK":
+                            stack.append(mark)
+                        elif opcode_name == "POP":
+                            if stack:
+                                stack.pop()
+                        elif opcode_name == "POP_MARK":
+                            while stack and stack.pop() is not mark:
+                                pass
+                        elif opcode_name == "DUP" and stack:
+                            stack.append(stack[-1])
+            except Exception as exc:  # noqa: BLE001 - malformed untrusted bytes must not abort a scan
+                parse_error = type(exc).__name__
+
+        suspicious = bool(dangerous_globals)
+        details = ""
+        if dangerous_globals:
+            details = f" Detected executable pickle opcode references: {', '.join(sorted(set(dangerous_globals)))}."
+        elif inspection_skipped_reason:
+            details = (
+                f" Opcode inspection was skipped because the file exceeds the {inspection_limit}-byte "
+                "inspection limit; the file must still be treated as untrusted."
+            )
+        elif parse_error:
+            details = f" Opcode inspection failed ({parse_error}); the file must still be treated as untrusted."
+
+        metadata: dict[str, object] = {
+            "opcode_inspection": "pickletools.genops",
+            "dangerous_opcodes": dangerous_globals,
+            "observed_executable_opcodes": sorted(set(executable_opcodes)),
+            "inspection_limit_bytes": inspection_limit,
+        }
+        if inspection_skipped_reason:
+            metadata["inspection_skipped_reason"] = inspection_skipped_reason
+        if parse_error:
+            metadata["parse_error"] = parse_error
+
+        return Finding(
+            id=self._generate_finding_id("PICKLE_FILE_DETECTED", skill_file.relative_path),
+            rule_id="PICKLE_FILE_DETECTED",
+            category=ThreatCategory.COMMAND_INJECTION,
+            severity=Severity.CRITICAL if suspicious else Severity.HIGH,
+            title="Executable Python pickle detected",
+            description=(
+                f"Pickle file found: {skill_file.relative_path}. Python pickle loading can execute "
+                f"arbitrary code supplied by the file producer; do not load it from an untrusted skill."
+                f"{details}"
+            ),
+            file_path=skill_file.relative_path,
+            remediation="Remove pickle files from skills. Use a non-executable data format such as JSON instead.",
+            analyzer="static",
+            metadata=metadata,
+        )
 
     def _check_hidden_files(self, skill: Skill) -> list[Finding]:
         """Check for hidden files (dotfiles) and __pycache__ in skill package."""

--- a/skill_scanner/data/packs/core/pack.yaml
+++ b/skill_scanner/data/packs/core/pack.yaml
@@ -608,6 +608,13 @@ rules:
       enabled: true
     description: "Binary file detected in skill package"
 
+  PICKLE_FILE_DETECTED:
+    source: python
+    analyzer: static
+    knobs:
+      enabled: true
+    description: "Executable Python pickle detected"
+
   PYCACHE_FILES_DETECTED:
     source: python
     analyzer: static

--- a/skill_scanner/utils/file_utils.py
+++ b/skill_scanner/utils/file_utils.py
@@ -102,6 +102,8 @@ def get_file_type(file_path: Path) -> str:
         ".dylib": "binary",
         ".dll": "binary",
         ".bin": "binary",
+        ".pkl": "binary",
+        ".pickle": "binary",
     }
 
     return type_mapping.get(suffix, "other")

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -484,3 +484,10 @@ class TestGetFileType:
         from skill_scanner.utils.file_utils import get_file_type
 
         assert get_file_type(Path("data.xyz")) == "other"
+
+    @pytest.mark.parametrize("filename", ["config.pkl", "config.pickle"])
+    def test_get_file_type_detects_pickle_as_binary(self, filename):
+        """Pickle files must be classified as binary before content loading."""
+        from skill_scanner.utils.file_utils import get_file_type
+
+        assert get_file_type(Path(filename)) == "binary"

--- a/tests/test_pickle_detection.py
+++ b/tests/test_pickle_detection.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for untrusted pickle detection."""
+
+import os
+import pickle
+from datetime import datetime
+
+from skill_scanner.core.analyzers.static import StaticAnalyzer
+from skill_scanner.core.loader import SkillLoader
+from skill_scanner.core.models import Severity
+from skill_scanner.core.scan_policy import ScanPolicy
+
+
+def _write_skill(skill_dir, payload: bytes):
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: pickle-skill\ndescription: Test serialized configuration\n---\n\n# Skill\n"
+    )
+    (skill_dir / "config.pkl").write_bytes(payload)
+
+
+def test_pickle_file_is_never_considered_safe(tmp_path):
+    """Even an ordinary pickle must produce a blocking finding."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps({"enabled": True}))
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_findings = [f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED"]
+    assert len(pickle_findings) == 1
+    assert pickle_findings[0].severity == Severity.HIGH
+
+
+def test_pickle_code_execution_opcode_is_critical(tmp_path):
+    """A pickle referring to an execution primitive receives CRITICAL severity."""
+
+    class Execute:
+        def __reduce__(self):
+            return os.system, ("echo should-not-run",)
+
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps(Execute()))
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.CRITICAL
+    assert any(reference.endswith(" system") for reference in pickle_finding.metadata["dangerous_opcodes"])
+    assert "STACK_GLOBAL" in pickle_finding.metadata["observed_executable_opcodes"]
+
+
+def test_benign_reduce_opcode_is_not_automatically_critical(tmp_path):
+    """STACK_GLOBAL and REDUCE alone do not prove a dangerous callable."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps(datetime(2026, 1, 1)))
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.HIGH
+    assert pickle_finding.metadata["dangerous_opcodes"] == []
+    assert {"STACK_GLOBAL", "REDUCE"}.issubset(pickle_finding.metadata["observed_executable_opcodes"])
+
+
+def test_pickle_inspection_respects_policy_size_limit(tmp_path):
+    """Oversized pickle files remain blocking without being read in full."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps({"payload": "x" * 200}))
+    policy = ScanPolicy.default()
+    policy.file_limits.max_loader_file_size_bytes = 16
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(policy=policy, use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.HIGH
+    assert pickle_finding.metadata["inspection_skipped_reason"] == "size-limit"
+    assert pickle_finding.metadata["inspection_limit_bytes"] == 16
+
+
+def test_pickle_parser_failure_does_not_abort_scan(tmp_path, monkeypatch):
+    """Unexpected parser exceptions are converted into a blocking finding."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps({"enabled": True}))
+
+    def fail_parser(_payload):
+        raise RuntimeError("unexpected parser failure")
+
+    monkeypatch.setattr("skill_scanner.core.analyzers.static.pickletools.genops", fail_parser)
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.HIGH
+    assert pickle_finding.metadata["parse_error"] == "RuntimeError"


### PR DESCRIPTION
## Summary

- Classify `.pkl` and `.pickle` files explicitly as binary content.
- Inspect pickle opcodes with the standard library `pickletools` module without deserializing untrusted data.
- Report all bundled pickles at HIGH severity and resolved dangerous globals at CRITICAL severity.
- Bound reads using the policy loader limit and convert malformed-parser failures into blocking findings.
- Add regression coverage for ordinary, malicious, oversized, malformed, and benign custom-object pickles.

## Attribution

This vulnerability was discovered by **Ofri Ouzan of the JFrog Vulnerability Research team**. Thank you for the detailed report and reproduction.

## CodeRabbit follow-up

Resolved the posted review comment by bounding pickle inspection. Also resolved the full-stack review issues concerning parser exception safety and false CRITICAL severity from bare `STACK_GLOBAL`/`REDUCE` opcodes.

## Testing

- `uv run pytest tests/test_pickle_detection.py tests/test_bug_fixes.py -q`
- Final rebased stack: `1874 passed, 5 skipped, 1 xfailed`
- Pre-commit hooks pass for the full stacked diff.

Stack 1 of 4.