### PR TITLE
fix(scanner): verify pyc with standard library code objects

### DIFF
--- a/skill_scanner/core/analyzers/bytecode_analyzer.py
+++ b/skill_scanner/core/analyzers/bytecode_analyzer.py
@@ -25,16 +25,14 @@ Dependencies: Python stdlib only (ast, marshal, struct).
 Optional: decompyle3 or uncompyle6 for decompiling bytecode without source.
 """
 
-import ast
 import hashlib
 import importlib.util
-import io
 import logging
 import marshal
+import re
 import struct
-import sys
 from pathlib import Path
-from typing import Any
+from types import CodeType
 
 from ..models import Finding, Severity, Skill, SkillFile, ThreatCategory
 from ..scan_policy import ScanPolicy
@@ -167,33 +165,33 @@ class BytecodeAnalyzer(BaseAnalyzer):
         return None
 
     def _compare_bytecode_to_source(self, pyc_file: SkillFile, py_file: SkillFile) -> list[Finding]:
-        """Compare a .pyc file against its .py source using ast.dump()."""
+        """Compare a .pyc file against equivalently compiled Python source."""
         findings: list[Finding] = []
 
-        # Parse the .py source into AST
+        # Compile the .py source with the running interpreter.  Comparing code
+        # objects avoids optional decompiler dependencies and works for the
+        # Python versions supported by this scanner.
         source_content = py_file.read_content()
-        if not source_content:
-            return findings
-
+        optimization = self._pyc_optimization_level(pyc_file)
+        if optimization is None:
+            return [self._unverifiable_finding(pyc_file, py_file, "unsupported-optimization-level")]
         try:
-            source_ast = ast.parse(source_content, filename=py_file.relative_path)
-            source_dump = ast.dump(source_ast, annotate_fields=True, include_attributes=False)
-        except SyntaxError as e:
+            source_code = compile(
+                source_content,
+                py_file.relative_path,
+                "exec",
+                dont_inherit=True,
+                optimize=optimization,
+            )
+        except (SyntaxError, ValueError, TypeError) as e:
             logger.debug("Cannot parse %s: %s", py_file.relative_path, e)
-            return findings
+            return [self._unverifiable_finding(pyc_file, py_file, type(e).__name__)]
 
-        # Try to load and decompile the .pyc file
-        pyc_ast = self._load_pyc_ast(pyc_file.path)
-        if pyc_ast is None:
-            # Can't decompile - without decompyle3/uncompyle6 this always fires.
-            # Don't emit a finding here; the PYCACHE_FILES_DETECTED and
-            # BYTECODE_NO_SOURCE rules already cover the important cases.
-            # Only BYTECODE_SOURCE_MISMATCH (actual tampering) is worth flagging.
-            return findings
+        pyc_code = self._load_pyc_code(pyc_file.path)
+        if pyc_code is None:
+            return [self._unverifiable_finding(pyc_file, py_file, "invalid-or-unsupported-pyc")]
 
-        pyc_dump = ast.dump(pyc_ast, annotate_fields=True, include_attributes=False)
-
-        if source_dump != pyc_dump:
+        if self._code_fingerprint(source_code) != self._code_fingerprint(pyc_code):
             findings.append(
                 Finding(
                     id=self._generate_finding_id("BYTECODE_SOURCE_MISMATCH", pyc_file.relative_path),
@@ -218,22 +216,76 @@ class BytecodeAnalyzer(BaseAnalyzer):
 
         return findings
 
-    def _load_pyc_ast(self, pyc_path: Path) -> ast.AST | None:
+    @staticmethod
+    def _pyc_optimization_level(pyc_file: SkillFile) -> int | None:
+        """Return the optimization level encoded in a PEP 3147 cache name."""
+        match = re.search(r"\.opt-([^.]+)\.pyc$", pyc_file.path.name)
+        if match is None:
+            return 0
+        marker = match.group(1)
+        if marker not in {"0", "1", "2"}:
+            return None
+        return int(marker)
+
+    @staticmethod
+    def _code_fingerprint(code: CodeType) -> tuple:
+        """Return a semantic fingerprint for *code*, ignoring source locations."""
+        constants = tuple(
+            BytecodeAnalyzer._code_fingerprint(value) if isinstance(value, CodeType) else value
+            for value in code.co_consts
+        )
+        return (
+            code.co_argcount,
+            code.co_posonlyargcount,
+            code.co_kwonlyargcount,
+            code.co_nlocals,
+            code.co_stacksize,
+            code.co_flags,
+            code.co_code,
+            constants,
+            code.co_names,
+            code.co_varnames,
+            code.co_freevars,
+            code.co_cellvars,
+            getattr(code, "co_exceptiontable", b""),
+        )
+
+    def _unverifiable_finding(self, pyc_file: SkillFile, py_file: SkillFile, reason: str) -> Finding:
+        """Create a blocking finding when bytecode cannot be compared safely."""
+        return Finding(
+            id=self._generate_finding_id("BYTECODE_UNVERIFIABLE", pyc_file.relative_path),
+            rule_id="BYTECODE_UNVERIFIABLE",
+            category=ThreatCategory.OBFUSCATION,
+            severity=Severity.HIGH,
+            title="Python bytecode cannot be verified against source",
+            description=(
+                f"Bytecode file {pyc_file.relative_path} could not be compared with "
+                f"{py_file.relative_path} ({reason}). Unverifiable bytecode may contain "
+                "code that is absent from the visible source."
+            ),
+            file_path=pyc_file.relative_path,
+            remediation="Remove pre-compiled bytecode or provide bytecode built by the scanner's Python version.",
+            analyzer=self.name,
+            metadata={"reason": reason, "source_file": py_file.relative_path},
+        )
+
+    def _load_pyc_code(self, pyc_path: Path) -> CodeType | None:
         """
-        Try to reconstruct an AST from a .pyc file.
+        Load a code object from a .pyc file without executing it.
 
         Strategy:
-        1. Use marshal to load the code object
-        2. Use dis to get bytecode instructions
-        3. Try decompyle3/uncompyle6 if available
-        4. Fall back to recompiling source and comparing code objects
+        1. Validate the magic number for this Python interpreter
+        2. Parse the PEP 552 header
+        3. Use marshal to load the code object
 
-        Returns AST if successful, None otherwise.
+        Returns a code object if it can be safely compared, otherwise None.
         """
         try:
             with open(pyc_path, "rb") as f:
                 # Read .pyc header
                 magic = f.read(4)
+                if magic != importlib.util.MAGIC_NUMBER:
+                    return None
                 flags = struct.unpack("<I", f.read(4))[0]
 
                 # Check for PEP 552 hash-based validation
@@ -247,34 +299,7 @@ class BytecodeAnalyzer(BaseAnalyzer):
 
                 # Load the code object
                 code = marshal.load(f)
-
-            # Try to decompile using decompyle3
-            try:
-                import decompyle3
-
-                output = io.StringIO()
-                decompyle3.deparse_code2str(code, out=output)
-                decompiled_source = output.getvalue()
-                return ast.parse(decompiled_source)
-            except ImportError:
-                pass
-            except Exception:
-                pass
-
-            # Try uncompyle6
-            try:
-                import uncompyle6
-
-                output = io.StringIO()
-                uncompyle6.deparse_code2str(code, out=output)
-                decompiled_source = output.getvalue()
-                return ast.parse(decompiled_source)
-            except ImportError:
-                pass
-            except Exception:
-                pass
-
-            return None
+            return code if isinstance(code, CodeType) else None
 
         except Exception as e:
             logger.debug("Failed to load .pyc %s: %s", pyc_path, e)

--- a/skill_scanner/core/analyzers/static.py
+++ b/skill_scanner/core/analyzers/static.py
@@ -22,6 +22,7 @@ import ast
 import configparser
 import hashlib
 import logging
+import pickletools
 import re
 from pathlib import Path
 from typing import Any
@@ -1201,6 +1202,10 @@ class StaticAnalyzer(BaseAnalyzer):
             if skill_file.file_type != "binary":
                 continue
 
+            if ext in {".pkl", ".pickle"}:
+                findings.append(self._pickle_finding(skill_file))
+                continue
+
             if ext in INERT_EXTENSIONS:
                 continue
 
@@ -1247,6 +1252,144 @@ class StaticAnalyzer(BaseAnalyzer):
             )
 
         return findings
+
+    def _pickle_finding(self, skill_file) -> Finding:
+        """Report serialized Python objects as executable, untrusted content.
+
+        Pickle is not a data-only format: loading a pickle can invoke arbitrary
+        callables encoded by the producer.  Inspect opcodes with ``pickletools``
+        (which never unpickles the object) to distinguish an ordinary serialized
+        object from one that visibly references a code-execution primitive.
+        Even a syntactically valid pickle remains HIGH because static analysis
+        cannot make loading attacker-controlled pickle data safe.
+        """
+        dangerous_globals: list[str] = []
+        executable_opcodes: list[str] = []
+        parse_error: str | None = None
+        inspection_skipped_reason: str | None = None
+        inspection_limit = max(0, self.policy.file_limits.max_loader_file_size_bytes)
+
+        def _record_global(module: str, name: str) -> None:
+            reference = f"{module} {name}"
+            if module in {"builtins", "os", "posix", "nt", "subprocess", "commands"} or name in {
+                "eval",
+                "exec",
+                "system",
+                "popen",
+                "spawn",
+                "Popen",
+            }:
+                dangerous_globals.append(reference)
+
+        if skill_file.size_bytes > inspection_limit:
+            inspection_skipped_reason = "size-limit"
+        else:
+            try:
+                # Bound the actual read as well as checking the loader's size
+                # metadata, so a file replacement race cannot exhaust memory.
+                with skill_file.path.open("rb") as handle:
+                    payload = handle.read(inspection_limit + 1)
+                if len(payload) > inspection_limit:
+                    inspection_skipped_reason = "size-limit"
+                else:
+                    stack: list[object] = []
+                    memo: dict[int, object] = {}
+                    next_memo_index = 0
+                    mark = object()
+                    string_opcodes = {
+                        "STRING",
+                        "BINSTRING",
+                        "SHORT_BINSTRING",
+                        "UNICODE",
+                        "BINUNICODE",
+                        "SHORT_BINUNICODE",
+                        "BINUNICODE8",
+                    }
+
+                    for opcode, argument, _ in pickletools.genops(payload):
+                        opcode_name = opcode.name
+                        if opcode_name in string_opcodes:
+                            if isinstance(argument, bytes):
+                                stack.append(argument.decode("utf-8", errors="replace"))
+                            else:
+                                stack.append(argument if isinstance(argument, str) else None)
+                        elif opcode_name == "MEMOIZE":
+                            memo[next_memo_index] = stack[-1] if stack else None
+                            next_memo_index += 1
+                        elif opcode_name in {"PUT", "BINPUT", "LONG_BINPUT"}:
+                            memo[int(argument)] = stack[-1] if stack else None
+                        elif opcode_name in {"GET", "BINGET", "LONG_BINGET"}:
+                            stack.append(memo.get(int(argument)))
+                        elif opcode_name == "GLOBAL" and isinstance(argument, str):
+                            module, _, name = argument.partition(" ")
+                            _record_global(module, name)
+                            stack.append(None)
+                        elif opcode_name == "STACK_GLOBAL":
+                            executable_opcodes.append(opcode_name)
+                            name = stack.pop() if stack else None
+                            module = stack.pop() if stack else None
+                            if isinstance(module, str) and isinstance(name, str):
+                                _record_global(module, name)
+                            stack.append(None)
+                        elif opcode_name == "REDUCE":
+                            executable_opcodes.append(opcode_name)
+                            if stack:
+                                stack.pop()
+                            if stack:
+                                stack.pop()
+                            stack.append(None)
+                        elif opcode_name == "MARK":
+                            stack.append(mark)
+                        elif opcode_name == "POP":
+                            if stack:
+                                stack.pop()
+                        elif opcode_name == "POP_MARK":
+                            while stack and stack.pop() is not mark:
+                                pass
+                        elif opcode_name == "DUP" and stack:
+                            stack.append(stack[-1])
+            except Exception as exc:  # noqa: BLE001 - malformed untrusted bytes must not abort a scan
+                parse_error = type(exc).__name__
+
+        suspicious = bool(dangerous_globals)
+        details = ""
+        if dangerous_globals:
+            details = f" Detected executable pickle opcode references: {', '.join(sorted(set(dangerous_globals)))}."
+        elif inspection_skipped_reason:
+            details = (
+                f" Opcode inspection was skipped because the file exceeds the {inspection_limit}-byte "
+                "inspection limit; the file must still be treated as untrusted."
+            )
+        elif parse_error:
+            details = f" Opcode inspection failed ({parse_error}); the file must still be treated as untrusted."
+
+        metadata: dict[str, object] = {
+            "opcode_inspection": "pickletools.genops",
+            "dangerous_opcodes": dangerous_globals,
+            "observed_executable_opcodes": sorted(set(executable_opcodes)),
+            "inspection_limit_bytes": inspection_limit,
+        }
+        if inspection_skipped_reason:
+            metadata["inspection_skipped_reason"] = inspection_skipped_reason
+        if parse_error:
+            metadata["parse_error"] = parse_error
+
+        return Finding(
+            id=self._generate_finding_id("PICKLE_FILE_DETECTED", skill_file.relative_path),
+            rule_id="PICKLE_FILE_DETECTED",
+            category=ThreatCategory.COMMAND_INJECTION,
+            severity=Severity.CRITICAL if suspicious else Severity.HIGH,
+            title="Executable Python pickle detected",
+            description=(
+                f"Pickle file found: {skill_file.relative_path}. Python pickle loading can execute "
+                f"arbitrary code supplied by the file producer; do not load it from an untrusted skill."
+                f"{details}"
+            ),
+            file_path=skill_file.relative_path,
+            remediation="Remove pickle files from skills. Use a non-executable data format such as JSON instead.",
+            analyzer="static",
+            metadata=metadata,
+        )
 
     def _check_hidden_files(self, skill: Skill) -> list[Finding]:
         """Check for hidden files (dotfiles) and __pycache__ in skill package."""

--- a/skill_scanner/data/packs/core/pack.yaml
+++ b/skill_scanner/data/packs/core/pack.yaml
@@ -608,6 +608,13 @@ rules:
       enabled: true
     description: "Binary file detected in skill package"
 
+  PICKLE_FILE_DETECTED:
+    source: python
+    analyzer: static
+    knobs:
+      enabled: true
+    description: "Executable Python pickle detected"
+
   PYCACHE_FILES_DETECTED:
     source: python
     analyzer: static

--- a/skill_scanner/data/packs/core/pack.yaml
+++ b/skill_scanner/data/packs/core/pack.yaml
@@ -1015,3 +1015,10 @@ rules:
     knobs:
       enabled: true
     description: "Bytecode does not match source code"
+
+  BYTECODE_UNVERIFIABLE:
+    source: python
+    analyzer: bytecode
+    knobs:
+      enabled: true
+    description: "Python bytecode cannot be verified against source"

--- a/skill_scanner/utils/file_utils.py
+++ b/skill_scanner/utils/file_utils.py
@@ -102,6 +102,8 @@ def get_file_type(file_path: Path) -> str:
         ".dylib": "binary",
         ".dll": "binary",
         ".bin": "binary",
+        ".pkl": "binary",
+        ".pickle": "binary",
     }
 
     return type_mapping.get(suffix, "other")

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -484,3 +484,10 @@ class TestGetFileType:
         from skill_scanner.utils.file_utils import get_file_type
 
         assert get_file_type(Path("data.xyz")) == "other"
+
+    @pytest.mark.parametrize("filename", ["config.pkl", "config.pickle"])
+    def test_get_file_type_detects_pickle_as_binary(self, filename):
+        """Pickle files must be classified as binary before content loading."""
+        from skill_scanner.utils.file_utils import get_file_type
+
+        assert get_file_type(Path(filename)) == "binary"

--- a/tests/test_bytecode_analyzer.py
+++ b/tests/test_bytecode_analyzer.py
@@ -151,14 +151,8 @@ class TestBytecodeIntegrity:
         findings = analyzer.analyze(skill)
         assert len(findings) == 0
 
-    def test_tampered_bytecode_no_decompiler(self, tmp_path):
-        """Without decompyle3/uncompyle6, tampered bytecode silently passes.
-
-        This is expected - BYTECODE_SOURCE_MISMATCH only fires when we can
-        actually decompile and compare. The PYCACHE_FILES_DETECTED and
-        BYTECODE_NO_SOURCE rules handle the common cases.
-        When decompilers ARE available, this would produce BYTECODE_SOURCE_MISMATCH.
-        """
+    def test_tampered_bytecode_detected_without_decompiler(self, tmp_path):
+        """Tampered bytecode is detected using only the standard library."""
         skill_dir = tmp_path / "skill"
         skill_dir.mkdir()
 
@@ -187,11 +181,54 @@ class TestBytecodeIntegrity:
         analyzer = BytecodeAnalyzer()
         findings = analyzer.analyze(skill)
 
-        # Without decompilers, no MISMATCH can be detected
-        # This is a known limitation - the analyzer gracefully degrades
         mismatch = [f for f in findings if f.rule_id == "BYTECODE_SOURCE_MISMATCH"]
-        # May or may not be detected depending on installed packages
-        # We don't assert count here - just verify no crash
+        assert len(mismatch) == 1
+        assert mismatch[0].severity == Severity.CRITICAL
+
+    def test_unsupported_bytecode_is_blocked(self, tmp_path):
+        """Bytecode from another Python version cannot silently pass."""
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        py_file = skill_dir / "module.py"
+        py_file.write_text("value = 1\n")
+        pyc_file = skill_dir / "module.cpython-999.pyc"
+        pyc_file.write_bytes(b"\x00\x00\x00\x00" + b"\x00" * 20)
+
+        skill = _make_skill(
+            skill_dir,
+            [
+                _make_skill_file(py_file, "module.py", "python"),
+                _make_skill_file(pyc_file, "module.cpython-999.pyc", "binary"),
+            ],
+        )
+
+        findings = BytecodeAnalyzer().analyze(skill)
+        unverifiable = [f for f in findings if f.rule_id == "BYTECODE_UNVERIFIABLE"]
+        assert len(unverifiable) == 1
+        assert unverifiable[0].severity == Severity.HIGH
+
+    @pytest.mark.parametrize("optimization", [1, 2])
+    def test_optimized_bytecode_is_compared_at_matching_level(self, tmp_path, optimization):
+        """PEP 3147 opt-N bytecode is not mistaken for source tampering."""
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        py_file = skill_dir / "module.py"
+        py_file.write_text('"""Removed by optimize=2."""\nassert True\nvalue = 1\n')
+        pyc_file = skill_dir / f"module.cpython-311.opt-{optimization}.pyc"
+        py_compile.compile(str(py_file), cfile=str(pyc_file), doraise=True, optimize=optimization)
+
+        skill = _make_skill(
+            skill_dir,
+            [
+                _make_skill_file(py_file, "module.py", "python"),
+                _make_skill_file(pyc_file, pyc_file.name, "binary"),
+            ],
+        )
+
+        findings = BytecodeAnalyzer().analyze(skill)
+        assert not [
+            finding for finding in findings if finding.rule_id in {"BYTECODE_SOURCE_MISMATCH", "BYTECODE_UNVERIFIABLE"}
+        ]
 
 
 class TestStemCollisionResolution:

--- a/tests/test_pickle_detection.py
+++ b/tests/test_pickle_detection.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for untrusted pickle detection."""
+
+import os
+import pickle
+from datetime import datetime
+
+from skill_scanner.core.analyzers.static import StaticAnalyzer
+from skill_scanner.core.loader import SkillLoader
+from skill_scanner.core.models import Severity
+from skill_scanner.core.scan_policy import ScanPolicy
+
+
+def _write_skill(skill_dir, payload: bytes):
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: pickle-skill\ndescription: Test serialized configuration\n---\n\n# Skill\n"
+    )
+    (skill_dir / "config.pkl").write_bytes(payload)
+
+
+def test_pickle_file_is_never_considered_safe(tmp_path):
+    """Even an ordinary pickle must produce a blocking finding."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps({"enabled": True}))
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_findings = [f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED"]
+    assert len(pickle_findings) == 1
+    assert pickle_findings[0].severity == Severity.HIGH
+
+
+def test_pickle_code_execution_opcode_is_critical(tmp_path):
+    """A pickle referring to an execution primitive receives CRITICAL severity."""
+
+    class Execute:
+        def __reduce__(self):
+            return os.system, ("echo should-not-run",)
+
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps(Execute()))
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.CRITICAL
+    assert any(reference.endswith(" system") for reference in pickle_finding.metadata["dangerous_opcodes"])
+    assert "STACK_GLOBAL" in pickle_finding.metadata["observed_executable_opcodes"]
+
+
+def test_benign_reduce_opcode_is_not_automatically_critical(tmp_path):
+    """STACK_GLOBAL and REDUCE alone do not prove a dangerous callable."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps(datetime(2026, 1, 1)))
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.HIGH
+    assert pickle_finding.metadata["dangerous_opcodes"] == []
+    assert {"STACK_GLOBAL", "REDUCE"}.issubset(pickle_finding.metadata["observed_executable_opcodes"])
+
+
+def test_pickle_inspection_respects_policy_size_limit(tmp_path):
+    """Oversized pickle files remain blocking without being read in full."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps({"payload": "x" * 200}))
+    policy = ScanPolicy.default()
+    policy.file_limits.max_loader_file_size_bytes = 16
+
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(policy=policy, use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.HIGH
+    assert pickle_finding.metadata["inspection_skipped_reason"] == "size-limit"
+    assert pickle_finding.metadata["inspection_limit_bytes"] == 16
+
+
+def test_pickle_parser_failure_does_not_abort_scan(tmp_path, monkeypatch):
+    """Unexpected parser exceptions are converted into a blocking finding."""
+    skill_dir = tmp_path / "skill"
+    _write_skill(skill_dir, pickle.dumps({"enabled": True}))
+
+    def fail_parser(_payload):
+        raise RuntimeError("unexpected parser failure")
+
+    monkeypatch.setattr("skill_scanner.core.analyzers.static.pickletools.genops", fail_parser)
+    skill = SkillLoader().load_skill(skill_dir)
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+
+    pickle_finding = next(f for f in findings if f.rule_id == "PICKLE_FILE_DETECTED")
+    assert pickle_finding.severity == Severity.HIGH
+    assert pickle_finding.metadata["parse_error"] == "RuntimeError"


### PR DESCRIPTION
## Superseded

While this stack was under review, `main` incorporated #162, which independently implements the same bytecode-integrity remediation with standard-library code-object comparison, optimization-level coverage, and fail-closed handling for malformed or foreign-version bytecode.

The duplicate commit was removed during the final rebase so the stack does not override or duplicate the upstream implementation.

## Attribution

The underlying vulnerability was discovered by **Ofri Ouzan of the JFrog Vulnerability Research team**. Thank you for the detailed report and reproduction.

## Verification

The upstream implementation and its regression coverage pass in the rebased stack, including `tests/test_bytecode_analyzer.py`.