### PR TITLE
fix(scanner): preserve multiline shell injection severity

### DIFF
--- a/skill_scanner/data/packs/core/signatures/command_injection.yaml
+++ b/skill_scanner/data/packs/core/signatures/command_injection.yaml
@@ -25,6 +25,7 @@
   patterns:
     - "os\\.system\\s*\\([^)]*[f\"'].*\\{.*\\}"
     - "subprocess\\.(?:call|run|Popen)\\s*\\([^)]*[f\"'].*\\{.*\\}"
+    - "subprocess\\.(?:call|run|Popen)\\s*\\((?=[^)]*\\n)[^)]*[f\"'].*\\{.*\\}"
     - "os\\.popen\\s*\\([^)]*[f\"'].*\\{.*\\}"
   file_types: [python]
   description: "Shell command execution with string formatting (potential injection)"
@@ -35,6 +36,7 @@
   severity: HIGH
   patterns:
     - "subprocess\\.(?:call|run|Popen)\\s*\\([^)]*shell\\s*=\\s*True"
+    - "subprocess\\.(?:call|run|Popen)\\s*\\((?=[^)]*\\n)[^)]*shell\\s*=\\s*True"
     - "os\\.system\\s*\\("
   file_types: [python]
   description: "Shell command execution with shell=True enabled"

--- a/tests/test_issue_190_multiline_shell.py
+++ b/tests/test_issue_190_multiline_shell.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for issue #190 multiline command matching."""
+
+from skill_scanner.core.analyzers.static import StaticAnalyzer
+from skill_scanner.core.models import Severity
+
+
+def test_multiline_dynamic_subprocess_call_remains_critical(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import subprocess
+
+def run(download_path):
+    subprocess.call(
+        f'chmod +x {download_path}',
+        shell=True,
+    )
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_OS_SYSTEM"]
+    assert matches
+    assert matches[0].severity == Severity.CRITICAL
+
+
+def test_multiline_literal_subprocess_call_retains_shell_true_finding(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import subprocess
+
+subprocess.call(
+    ['chmod', '+x', 'tool'],
+    shell=True,
+)
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert matches
+    assert matches[0].severity == Severity.HIGH
+
+
+def test_single_line_dynamic_subprocess_call_still_matches(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import subprocess
+
+subprocess.run(f'chmod +x {download_path}', shell=True)
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_OS_SYSTEM"]
+    assert matches
+    assert matches[0].severity == Severity.CRITICAL


### PR DESCRIPTION
## Summary

- Make dynamic subprocess and `shell=True` signatures newline-safe.
- Preserve CRITICAL severity for formatted multiline subprocess commands.
- Use deterministic single-line and multiline patterns without the ambiguous newline alternation.
- Add regression coverage for multiline dynamic, multiline literal, and single-line shell invocations.

## Attribution

Fixes #190, originally discovered and reported by **[@2002lcy0401](https://github.com/2002lcy0401)** (lcy). Thank you for the clear reproduction and suggested fix.

## CodeRabbit follow-up

Removed the ambiguous repeated alternation that could cause excessive regex backtracking while retaining the issue #190 multiline match.

## Testing

- `uv run pytest tests/test_issue_190_multiline_shell.py tests/test_markdown_code_blocks.py tests/test_rule_registry.py -q`
- Final rebased stack: `1874 passed, 5 skipped, 1 xfailed`
- Pre-commit hooks pass for the full stacked diff.

Stack 4 of 4. Depends on #195.