### PR TITLE
fix(static): detect os.system() calls through import aliases (#205)

### DIFF
--- a/skill_scanner/core/analyzers/static.py
+++ b/skill_scanner/core/analyzers/static.py
@@ -495,6 +495,7 @@ class StaticAnalyzer(BaseAnalyzer):
         findings.extend(self._check_manifest(skill))
         findings.extend(self._scan_instruction_body(skill))
         findings.extend(self._scan_scripts(skill))
+        findings.extend(self._check_aliased_dangerous_calls(skill))
         findings.extend(self._check_dynamic_sensitive_file_access(skill))
         findings.extend(self._check_consistency(skill))
         findings.extend(self._check_dependency_pinning(skill))
@@ -800,6 +801,93 @@ class StaticAnalyzer(BaseAnalyzer):
             parts.append(current.id)
             return ".".join(reversed(parts))
         return None
+
+    @staticmethod
+    def _find_os_import_aliases(tree: ast.Module) -> set[str]:
+        """Return local names bound to the ``os`` module via ``import os as X``.
+
+        The unaliased case (``asname`` unset, or explicitly ``import os as
+        os``) is excluded so COMMAND_INJECTION_SHELL_TRUE's regex signature
+        remains the sole detector for that path -- this check only covers the
+        alias gap, never duplicating a literal ``os.system(`` match.
+        """
+        aliases: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Import):
+                continue
+            for alias in node.names:
+                if alias.name == "os" and alias.asname and alias.asname != "os":
+                    aliases.add(alias.asname)
+        return aliases
+
+    def _check_aliased_dangerous_calls(self, skill: Skill) -> list[Finding]:
+        """Detect os.system() calls made through an import alias.
+
+        COMMAND_INJECTION_SHELL_TRUE's signature matches ``os.system(``
+        literally, so ``import os as _o; _o.system(...)`` slips through. This
+        AST-based check closes that specific gap. It intentionally does not
+        attempt broader alias/data-flow resolution (e.g. ``from os import
+        system as x``, re-aliasing through assignment, or non-``os``
+        modules) -- those are separate, larger pieces of work.
+        """
+        rule_id = "COMMAND_INJECTION_SHELL_TRUE"
+        if rule_id in self.policy.disabled_rules:
+            return []
+
+        findings: list[Finding] = []
+
+        for sf in skill.files:
+            if sf.file_type != "python":
+                continue
+
+            content = sf.read_content()
+            if not content:
+                continue
+
+            try:
+                tree = ast.parse(content)
+            except SyntaxError as e:
+                logger.debug("Syntax error parsing %s for alias check: %s", sf.relative_path, e)
+                continue
+
+            os_aliases = self._find_os_import_aliases(tree)
+            if not os_aliases:
+                continue
+
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "system"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id in os_aliases
+                ):
+                    findings.append(
+                        Finding(
+                            id=self._generate_finding_id(rule_id, f"{sf.relative_path}:{node.lineno}"),
+                            rule_id=rule_id,
+                            category=ThreatCategory.COMMAND_INJECTION,
+                            severity=Severity.HIGH,
+                            title="Shell command execution with shell=True enabled",
+                            description=(
+                                f"'{sf.relative_path}' calls os.system() through the import alias "
+                                f"'{func.value.id}' (line {node.lineno}). This is equivalent to a "
+                                "direct os.system() call but bypasses literal pattern matching."
+                            ),
+                            file_path=sf.relative_path,
+                            line_number=node.lineno,
+                            remediation="Use subprocess with argument lists (shell=False) instead of os.system().",
+                            analyzer="static",
+                            metadata={
+                                "analysis_method": "import_alias_resolution",
+                                "resolved_alias": func.value.id,
+                            },
+                        )
+                    )
+
+        return findings
 
     def _check_dynamic_sensitive_file_access(self, skill: Skill) -> list[Finding]:
         """Detect glob/open flows that enumerate credential files indirectly.

--- a/skill_scanner/core/analyzers/static.py
+++ b/skill_scanner/core/analyzers/static.py
@@ -356,6 +356,113 @@ def _redact_secret(text: str) -> str:
     return text[:4] + "****"
 
 
+class _OsAliasCallVisitor(ast.NodeVisitor):
+    """Scope-aware walk that finds os.system() calls made through an import alias.
+
+    Tracks, per lexical scope, which local names are currently bound to the
+    ``os`` module. A function parameter, local (re)assignment, ``for``/``with``
+    target, etc. that shares an inherited alias's name shadows it -- so a
+    same-named but unrelated local variable is never mistaken for the ``os``
+    alias, and a function-local ``import os as X`` only applies inside that
+    function. Traversal follows AST source order, so a call textually before
+    its defining ``import`` is (correctly) not matched.
+
+    Deliberately narrow: does not model comprehension-local scoping or class
+    bodies as their own scope (both are rare enough for this pattern that any
+    resulting imprecision only causes a missed detection, never a false
+    positive -- the safe direction for a new check).
+    """
+
+    def __init__(self) -> None:
+        self.matches: list[tuple[int, str]] = []
+        self._scope_stack: list[set[str]] = [set()]
+
+    @property
+    def _active(self) -> set[str]:
+        return self._scope_stack[-1]
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            bound_name = alias.asname or alias.name.split(".")[0]
+            if alias.name == "os" and alias.asname and alias.asname != "os":
+                self._active.add(alias.asname)
+            else:
+                self._active.discard(bound_name)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            self._active.discard(alias.asname or alias.name)
+
+    def _shadow(self, target: ast.expr) -> None:
+        if isinstance(target, ast.Name):
+            self._active.discard(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                self._shadow(elt)
+        elif isinstance(target, ast.Starred):
+            self._shadow(target.value)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            self._shadow(target)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._shadow(node.target)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._shadow(node.target)
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        self._shadow(node.target)
+        self.generic_visit(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._shadow(node.target)
+        self.generic_visit(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        for item in node.items:
+            if item.optional_vars is not None:
+                self._shadow(item.optional_vars)
+        self.generic_visit(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        for item in node.items:
+            if item.optional_vars is not None:
+                self._shadow(item.optional_vars)
+        self.generic_visit(node)
+
+    def _enter_function_scope(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        params = {a.arg for a in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)}
+        if node.args.vararg:
+            params.add(node.args.vararg.arg)
+        if node.args.kwarg:
+            params.add(node.args.kwarg.arg)
+        self._scope_stack.append(self._active - params)
+        self.generic_visit(node)
+        self._scope_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._enter_function_scope(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._enter_function_scope(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "system"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in self._active
+        ):
+            self.matches.append((node.lineno, func.value.id))
+        self.generic_visit(node)
+
+
 class StaticAnalyzer(BaseAnalyzer):
     """Static pattern-based security analyzer."""
 
@@ -802,32 +909,16 @@ class StaticAnalyzer(BaseAnalyzer):
             return ".".join(reversed(parts))
         return None
 
-    @staticmethod
-    def _find_os_import_aliases(tree: ast.Module) -> set[str]:
-        """Return local names bound to the ``os`` module via ``import os as X``.
-
-        The unaliased case (``asname`` unset, or explicitly ``import os as
-        os``) is excluded so COMMAND_INJECTION_SHELL_TRUE's regex signature
-        remains the sole detector for that path -- this check only covers the
-        alias gap, never duplicating a literal ``os.system(`` match.
-        """
-        aliases: set[str] = set()
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Import):
-                continue
-            for alias in node.names:
-                if alias.name == "os" and alias.asname and alias.asname != "os":
-                    aliases.add(alias.asname)
-        return aliases
-
     def _check_aliased_dangerous_calls(self, skill: Skill) -> list[Finding]:
         """Detect os.system() calls made through an import alias.
 
         COMMAND_INJECTION_SHELL_TRUE's signature matches ``os.system(``
         literally, so ``import os as _o; _o.system(...)`` slips through. This
-        AST-based check closes that specific gap. It intentionally does not
-        attempt broader alias/data-flow resolution (e.g. ``from os import
-        system as x``, re-aliasing through assignment, or non-``os``
+        AST-based check closes that specific gap using scope-aware alias
+        tracking (``_OsAliasCallVisitor``) so a parameter or local variable
+        that shadows the alias name is never mistaken for it. It
+        intentionally does not attempt broader resolution (e.g. ``from os
+        import system as x``, comprehension-scoped shadowing, or non-``os``
         modules) -- those are separate, larger pieces of work.
         """
         rule_id = "COMMAND_INJECTION_SHELL_TRUE"
@@ -850,42 +941,29 @@ class StaticAnalyzer(BaseAnalyzer):
                 logger.debug("Syntax error parsing %s for alias check: %s", sf.relative_path, e)
                 continue
 
-            os_aliases = self._find_os_import_aliases(tree)
-            if not os_aliases:
-                continue
+            visitor = _OsAliasCallVisitor()
+            visitor.visit(tree)
 
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                func = node.func
-                if (
-                    isinstance(func, ast.Attribute)
-                    and func.attr == "system"
-                    and isinstance(func.value, ast.Name)
-                    and func.value.id in os_aliases
-                ):
-                    findings.append(
-                        Finding(
-                            id=self._generate_finding_id(rule_id, f"{sf.relative_path}:{node.lineno}"),
-                            rule_id=rule_id,
-                            category=ThreatCategory.COMMAND_INJECTION,
-                            severity=Severity.HIGH,
-                            title="Shell command execution with shell=True enabled",
-                            description=(
-                                f"'{sf.relative_path}' calls os.system() through the import alias "
-                                f"'{func.value.id}' (line {node.lineno}). This is equivalent to a "
-                                "direct os.system() call but bypasses literal pattern matching."
-                            ),
-                            file_path=sf.relative_path,
-                            line_number=node.lineno,
-                            remediation="Use subprocess with argument lists (shell=False) instead of os.system().",
-                            analyzer="static",
-                            metadata={
-                                "analysis_method": "import_alias_resolution",
-                                "resolved_alias": func.value.id,
-                            },
-                        )
+            for line_number, alias in visitor.matches:
+                findings.append(
+                    Finding(
+                        id=self._generate_finding_id(rule_id, f"{sf.relative_path}:{line_number}"),
+                        rule_id=rule_id,
+                        category=ThreatCategory.COMMAND_INJECTION,
+                        severity=Severity.HIGH,
+                        title="Shell command execution with shell=True enabled",
+                        description=(
+                            f"'{sf.relative_path}' calls os.system() through the import alias "
+                            f"'{alias}' (line {line_number}). This is equivalent to a direct "
+                            "os.system() call but bypasses literal pattern matching."
+                        ),
+                        file_path=sf.relative_path,
+                        line_number=line_number,
+                        remediation="Use subprocess with argument lists (shell=False) instead of os.system().",
+                        analyzer="static",
+                        metadata={"analysis_method": "import_alias_resolution", "resolved_alias": alias},
                     )
+                )
 
         return findings
 

--- a/tests/test_issue_205_import_alias.py
+++ b/tests/test_issue_205_import_alias.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for issue #205: os.system() detection bypassed via import alias."""
+
+from skill_scanner.core.analyzers.static import StaticAnalyzer
+from skill_scanner.core.models import Severity
+from skill_scanner.core.scan_policy import ScanPolicy
+
+
+def test_aliased_os_system_call_is_detected(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os as _o
+
+_o.system('pip install -r requirements.txt')
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert matches
+    assert matches[0].severity == Severity.HIGH
+    assert matches[0].file_path == "scripts/main.py"
+    assert matches[0].line_number == 4
+
+
+def test_unaliased_os_system_call_still_detected_by_signature(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os
+
+os.system('pip install -r requirements.txt')
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert matches
+
+
+def test_unaliased_os_system_call_not_double_reported(make_skill):
+    """The AST check must not fire for the literal case -- only the regex signature should."""
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os
+
+os.system('pip install -r requirements.txt')
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert len(matches) == 1
+    assert matches[0].metadata.get("analysis_method") != "import_alias_resolution"
+
+
+def test_self_aliased_import_treated_as_unaliased(make_skill):
+    """``import os as os`` should behave like the unaliased case, not double-fire."""
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os as os
+
+os.system('pip install -r requirements.txt')
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert len(matches) == 1
+    assert matches[0].metadata.get("analysis_method") != "import_alias_resolution"
+
+
+def test_unrelated_module_alias_does_not_false_positive(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import sys as _o
+
+_o.exit(1)
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert not matches
+
+
+def test_syntax_error_file_does_not_crash_scan(make_skill):
+    skill = make_skill(
+        {
+            "scripts/broken.py": """
+def f(:
+    pass
+"""
+        }
+    )
+
+    # Should not raise.
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    assert isinstance(findings, list)
+
+
+def test_disabled_rule_suppresses_aliased_detection(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os as _o
+
+_o.system('pip install -r requirements.txt')
+"""
+        }
+    )
+
+    policy = ScanPolicy()
+    policy.disabled_rules = {"COMMAND_INJECTION_SHELL_TRUE"}
+
+    findings = StaticAnalyzer(use_yara=False, policy=policy).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert not matches

--- a/tests/test_issue_205_import_alias.py
+++ b/tests/test_issue_205_import_alias.py
@@ -95,6 +95,84 @@ _o.exit(1)
     assert not matches
 
 
+def test_function_parameter_shadowing_the_alias_is_not_flagged(make_skill):
+    """CodeRabbit-flagged case: a parameter reusing the alias name shadows it."""
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os as _o
+
+def safe(_o):
+    _o.system()
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert not matches
+
+
+def test_local_reassignment_shadowing_the_alias_is_not_flagged(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os as _o
+
+def handler():
+    _o = SomeUnrelatedThing()
+    _o.system()
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert not matches
+
+
+def test_function_local_os_import_is_scoped_to_that_function(make_skill):
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+def run():
+    import os as _o
+    _o.system('pip install -r requirements.txt')
+
+def unrelated(_o):
+    return _o.upper()
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert len(matches) == 1
+    assert matches[0].line_number == 4
+
+
+def test_sibling_function_still_detected_after_shadowing_function(make_skill):
+    """A parameter shadow in one function must not leak into a sibling function."""
+    skill = make_skill(
+        {
+            "scripts/main.py": """
+import os as _o
+
+def safe(_o):
+    _o.system()
+
+def unsafe():
+    _o.system('pip install -r requirements.txt')
+"""
+        }
+    )
+
+    findings = StaticAnalyzer(use_yara=False).analyze(skill)
+    matches = [f for f in findings if f.rule_id == "COMMAND_INJECTION_SHELL_TRUE"]
+    assert len(matches) == 1
+    assert matches[0].line_number == 8
+
+
 def test_syntax_error_file_does_not_crash_scan(make_skill):
     skill = make_skill(
         {


### PR DESCRIPTION
## Description

The COMMAND_INJECTION_SHELL_TRUE signature matches `os.system(` literally via regex,
so `import os as _o; _o.system(...)` bypassed detection entirely (HIGH -> no finding).
This adds a narrow AST-based check that resolves single-hop `os` import aliases and
flags aliased `os.system()` calls under the existing rule_id, so
severity_overrides/disabled_rules/dedup all keep working unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #205

## Changes Made

- Change 1: Added `_check_aliased_dangerous_calls()` and a `_find_os_import_aliases()`
  static helper to `StaticAnalyzer` (`skill_scanner/core/analyzers/static.py`), wired
  into `analyze()` right after `_scan_scripts()`.
- Change 2: The check parses each Python file's AST, tracks `import os as X` aliases
  (excluding the unaliased/self-aliased case so it never duplicates the existing regex
  match), and flags `X.system(...)` calls under the existing `COMMAND_INJECTION_SHELL_TRU
  rule_id/severity/category.
- Change 3: Added `tests/test_issue_205_import_alias.py` (7 cases covering the bug,
  the non-regression path, double-report avoidance, self-aliasing, unrelated-module
  aliasing, syntax-error resilience, and disabled-rule suppression).

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated — N/A, static-analysis unit-level fix, no external
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing

```bash
skill-scanner scan /tmp/alias-demo --format summary
# alias-demo/scripts/main.py contains:
#   import os as _o
#   _o.system('pip install -r requirements.txt')

Results:
- Expected: COMMAND_INJECTION_SHELL_TRUE (HIGH), same as the unaliased os.system(...) cas
- Actual: Confirmed via --format json: rule_id=COMMAND_INJECTION_SHELL_TRUE,
  severity=HIGH, title="Shell command execution with shell=True enabled". (A second
  INFO/MANIFEST_MISSING_LICENSE finding is unrelated noise from the minimal demo
  skill's manifest, not related to this change.)

Checklist

Code Quality

- [x] Code follows project style guidelines
- [x] Type hints added where applicable
- [x] Docstrings added/updated for public APIs
- [x] No hardcoded credentials or secrets
- [x] Error handling is comprehensive (SyntaxError caught per-file; scan never crashes on
- [x] Logging is appropriate (debug-level on parse failure, matching existing precedent)

Documentation

- [ ] README updated (if needed) — not needed, internal detection-only change
- [ ] API documentation updated (if needed) — not needed, no API/CLI surface change
- [ ] CHANGELOG updated — repo has no manual CHANGELOG.md; changelog is generated from Gi
- [x] Code comments added for complex logic (docstring explains why the unaliased case is

Security

- [x] No new security vulnerabilities introduced
- [x] Input validation added where needed
- [x] Follows security best practices from workspace rules
- [x] No eval/exec on user input without sanitization (N/A — no eval/exec used)

Testing

- [x] Tests pass: uv run pre-commit run --all-files
- [x] Benchmark passes: uv run python evals/runners/benchmark_runner.py (100% accuracy/prion)
- [x] No regressions in existing functionality (full suite: 1802 passed, 5 skipped, 1 xfailed, 0 failed)
- [x] Edge cases covered (self-aliasing, unrelated-module aliasing, syntax errors, disabl

Performance Impact

- [x] No significant performance regression (one extra ast.parse() per Python file, only import)
- [ ] Performance benchmarks run (if applicable) — covered by the general benchmark above; no dedicated perf benchmark exists for this narrow addition
- [x] Resource usage is acceptable

Screenshots (if applicable)

N/A — no UI change.

Additional Notes

Scope is deliberately narrow: only import os as X; X.system(...). Not covered
(intentionally, to keep this first PR small): from os import system as x,
re-aliasing via assignment, or aliasing of other dangerous modules/functions.
Those are natural, separate follow-up issues if this lands well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static analysis to detect command-injection risks when `os.system()` is imported under an alias.
  * Prevented duplicate findings for standard imports and avoided false positives from unrelated aliases.
  * Correctly handles alias shadowing, function-local imports, and source-order imports.
  * Scans now handle malformed Python files without crashing.
  * Disabled command-injection rules continue to suppress these findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->